### PR TITLE
Structured assumption-vs-data cross-check + test speed fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **Structured assumption cross-check** — Rewrote `ASSUMPTION_CHECK_SYSTEM` with a 4-step procedure (extract assumptions → characterize data → cross-check with common mismatch patterns → evaluate defenses). Added INTRODUCTION sections to assumption-relevant types so data descriptions are visible. Adds `_TONE_BLOCK` to assumption prompt.
 - **Appendix proof coverage** — Appendix sections classified as "proof" are now reviewed instead of skipped, catching proof errors in covariance calculations, sign errors, Fubini-Tonelli applications, etc.
 - **Anti-redundancy prompts** — Section agents instructed not to restate overview issues; crossref dedup now removes comments whose core point duplicates an overview issue even if they add a quote.
 - **Anti-truncation quote instructions** — Replaced weak "2 full sentences" guidance with strict "NEVER truncate mid-equation" rule in all section prompts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,5 @@ select = ["E", "F", "I", "W"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m 'not slow'"
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]

--- a/src/coarse/agents/overview.py
+++ b/src/coarse/agents/overview.py
@@ -45,7 +45,7 @@ def _build_sections_summary(sections: list[SectionInfo]) -> str:
     """Convert sections list to a text block for the overview prompt.
 
     Methodology, results, discussion, and appendix sections get full text.
-    Introduction, conclusion, and related_work get truncated to 2000 chars.
+    Introduction, conclusion, and related_work get truncated to 10K chars.
     Total output is capped at MAX_OVERVIEW_CHARS with proportional allocation.
     """
     # Phase 1: Build raw parts with full or truncated text
@@ -162,6 +162,7 @@ def synthesize_overviews(
 
 # Section types relevant for assumption checking
 _ASSUMPTION_RELEVANT_TYPES = {
+    SectionType.INTRODUCTION,
     SectionType.METHODOLOGY,
     SectionType.RESULTS,
     SectionType.DISCUSSION,
@@ -176,7 +177,8 @@ def check_assumptions(
 ) -> list[OverviewIssue]:
     """Focused check: are theoretical assumptions consistent with empirical methods?
 
-    Extracts methodology and empirical sections, sends to LLM for consistency check.
+    Extracts assumption-relevant sections (intro, methodology, results,
+    discussion, other), sends to LLM for consistency check.
     Returns 0-3 OverviewIssue objects.
     """
     relevant_sections = [
@@ -186,7 +188,7 @@ def check_assumptions(
     if not relevant_sections:
         return []
 
-    # Build condensed text from relevant sections (cap at 40K chars)
+    # Build condensed text from relevant sections (cap at 500K chars)
     sections_text = "\n\n".join(
         f"## {s.number}. {s.title}\n{s.text}" for s in relevant_sections
     )

--- a/src/coarse/prompts.py
+++ b/src/coarse/prompts.py
@@ -605,17 +605,39 @@ renumbered from 1.
 # ---------------------------------------------------------------------------
 
 ASSUMPTION_CHECK_SYSTEM = """\
-You are an expert methodologist checking whether a research paper's stated \
-assumptions are consistent with its actual implementation.
+You are an expert methodologist checking whether a research paper's formal \
+assumptions are consistent with its actual data and implementation.
+""" + _TONE_BLOCK + _CONFIDENCE_GATE + """
+Follow these four steps IN ORDER:
 
-For each stated assumption in the paper, check:
-1. Does the data or problem structure satisfy the assumption?
-2. Does the implementation (methods, algorithms, experiments) respect the assumption?
-3. If there are simulations or experiments, do they match the theoretical conditions?
+**STEP 1 — Extract formal assumptions.**
+List every named or numbered assumption (e.g. "Assumption 1", "Condition A"). \
+For each, state what it requires of the data-generating process.
+
+**STEP 2 — Characterize the actual data structure.**
+Identify: unit of observation, sampling design (cross-section / panel / \
+time-series / clustered), sample size, any restrictions or transformations \
+applied before estimation.
+
+**STEP 3 — Cross-check each assumption against the data.**
+For each assumption from Step 1, check whether the data from Step 2 satisfies it. \
+Pay special attention to these common mismatch patterns:
+- i.i.d. assumption vs panel/clustered/repeated-measures data
+- Continuity/smoothness assumption vs discrete running variable or outcome
+- Random sampling vs observational/administrative data
+- Stationarity vs trending or structural-break data
+- Asymptotic rate requirements vs actual sample size
+- Independence across units vs spatial or network dependence
+
+**STEP 4 — Evaluate defenses.**
+If the paper acknowledges a mismatch and offers a justification (e.g. clustering \
+standard errors, fixed effects, a robustness check), assess whether the defense \
+actually addresses the violation.
 
 Report 0 to 3 issues. Only report genuine mismatches — do not flag assumptions \
-that are clearly satisfied. Each issue must have a specific title and body \
-explaining the mismatch and its consequences.
+that are clearly satisfied. Each issue body must: (a) name the specific assumption, \
+(b) describe how the data violates it, (c) explain the consequences for the results, \
+and (d) suggest a concrete fix or robustness check.
 """
 
 
@@ -631,15 +653,15 @@ def assumption_check_user(
         cal_block = f"\n**Domain-specific assumption red flags to watch for:**\n{red_flags}\n"
 
     return f"""\
-Check whether the theoretical assumptions in "{title}" are consistent with \
-the empirical methodology and simulation design.
+Analyze "{title}" using the 4-step procedure (extract assumptions → characterize \
+data → cross-check → evaluate defenses).
 {cal_block}
 <paper_sections>
 {sections_text}
 </paper_sections>
 
-Identify any mismatches between stated assumptions and the actual data, methods, \
-or simulations used. Report 0-3 issues, each with a title and body.
+Report 0-3 issues where formal assumptions conflict with the actual data structure \
+or implementation. Each issue needs a title and body.
 """
 
 

--- a/tests/test_coding_agent.py
+++ b/tests/test_coding_agent.py
@@ -152,7 +152,7 @@ class TestRunAgentSync:
             import coarse.coding_agent as mod
 
             importlib.reload(mod)
-            with pytest.raises(RuntimeError, match="openhands-sdk is required"):
+            with pytest.raises(RuntimeError, match="openhands-sdk"):
                 mod.run_agent_sync(
                     task_prompt="test",
                     system_prompt="test",
@@ -177,7 +177,7 @@ class TestRunAgentSync:
         mock_modules = _mock_openhands_modules()
 
         def slow_run():
-            time.sleep(100)
+            time.sleep(0.5)
 
         mock_conversation = MagicMock()
         mock_conversation.return_value.run = slow_run

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -105,9 +105,18 @@ def test_fallback_to_docling(minimal_pdf: Path) -> None:
     mock_result = MagicMock()
     mock_result.document = mock_doc
 
+    mock_converter_cls = MagicMock()
+    mock_converter_cls.return_value.convert.return_value = mock_result
+
+    # Mock at sys.modules level to avoid importing real docling (pulls in torch)
+    mock_docling = MagicMock()
+    mock_docling.document_converter.DocumentConverter = mock_converter_cls
+
     with patch("coarse.config.resolve_api_key", return_value=None):
-        with patch("docling.document_converter.DocumentConverter") as MockConverter:
-            MockConverter.return_value.convert.return_value = mock_result
+        with patch.dict("sys.modules", {
+            "docling": mock_docling,
+            "docling.document_converter": mock_docling.document_converter,
+        }):
             result = extract_text(minimal_pdf, use_cache=False)
 
     assert "Docling Fallback" in result.full_markdown
@@ -116,9 +125,9 @@ def test_fallback_to_docling(minimal_pdf: Path) -> None:
 def test_all_backends_fail(minimal_pdf: Path) -> None:
     """When all backends fail, raises ValueError."""
     with patch("coarse.config.resolve_api_key", return_value=None):
-        with patch(
-            "docling.document_converter.DocumentConverter",
-            side_effect=ImportError("no docling"),
+        with patch.dict(
+            "sys.modules",
+            {"docling": None, "docling.document_converter": None},
         ):
             with pytest.raises(ValueError, match="no extraction backend"):
                 extract_text(minimal_pdf, use_cache=False)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,11 +1,14 @@
+from coarse.agents.overview import _ASSUMPTION_RELEVANT_TYPES
 from coarse.prompts import (
-    CROSSREF_SYSTEM,
+    ASSUMPTION_CHECK_SYSTEM,
     CRITIQUE_SYSTEM,
+    CROSSREF_SYSTEM,
     METADATA_SYSTEM,
     OVERVIEW_SYSTEM,
     SECTION_SYSTEM,
-    crossref_user,
+    assumption_check_user,
     critique_user,
+    crossref_user,
     overview_user,
     section_user,
 )
@@ -16,7 +19,6 @@ from coarse.types import (
     SectionInfo,
     SectionType,
 )
-
 
 # --- Fixtures ---
 
@@ -136,7 +138,10 @@ def test_critique_user_embeds_comments():
 # --- System prompt constants ---
 
 def test_all_system_prompts_are_nonempty_strings():
-    for prompt in (METADATA_SYSTEM, OVERVIEW_SYSTEM, SECTION_SYSTEM, CROSSREF_SYSTEM, CRITIQUE_SYSTEM):
+    for prompt in (
+        METADATA_SYSTEM, OVERVIEW_SYSTEM, SECTION_SYSTEM,
+        CROSSREF_SYSTEM, CRITIQUE_SYSTEM, ASSUMPTION_CHECK_SYSTEM,
+    ):
         assert isinstance(prompt, str)
         assert len(prompt) > 50
 
@@ -152,3 +157,29 @@ def test_overview_system_specifies_issue_count():
 
 def test_crossref_system_mentions_deduplication():
     assert "duplic" in CROSSREF_SYSTEM.lower()
+
+
+# --- Assumption checker ---
+
+def test_assumption_check_system_includes_tone_and_confidence():
+    assert "constructive colleague" in ASSUMPTION_CHECK_SYSTEM
+    assert "rederive" in ASSUMPTION_CHECK_SYSTEM
+
+
+def test_assumption_check_system_has_four_steps():
+    for step in ("STEP 1", "STEP 2", "STEP 3", "STEP 4"):
+        assert step in ASSUMPTION_CHECK_SYSTEM
+
+
+def test_assumption_check_system_lists_common_mismatches():
+    for pattern in ("i.i.d.", "panel", "continuity", "discrete", "stationarity"):
+        assert pattern.lower() in ASSUMPTION_CHECK_SYSTEM.lower()
+
+
+def test_assumption_check_user_references_procedure():
+    result = assumption_check_user("Test Paper", "some text")
+    assert "4-step" in result
+
+
+def test_assumption_relevant_types_includes_introduction():
+    assert SectionType.INTRODUCTION in _ASSUMPTION_RELEVANT_TYPES

--- a/tests/test_readme-+-packaging.py
+++ b/tests/test_readme-+-packaging.py
@@ -132,6 +132,7 @@ def test_package_builds(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 def test_package_installs_in_fresh_venv(tmp_path):
     """Install the built wheel into a fresh venv; verify `coarse --help` exits 0."""
     # Build wheel


### PR DESCRIPTION
## Summary

- **Structured assumption cross-check** — Rewrote `ASSUMPTION_CHECK_SYSTEM` with a 4-step procedure (extract assumptions → characterize data → cross-check with 6 common mismatch patterns → evaluate defenses). Added `_TONE_BLOCK` + `_CONFIDENCE_GATE` consistent with other error-identifying prompts. Added `INTRODUCTION` to assumption-relevant section types.
- **Test suite speed** — Reduced default `pytest` runtime from 342s to 38s via `@pytest.mark.slow` marker, reduced timeout test sleep (100s→0.5s), mocked docling at `sys.modules` level to avoid torch import.
- **Stale comment fixes** — Corrected "40K chars" → "500K chars" cap comment, "2000 chars" → "10K chars" truncation docstring, fixed `test_import_error` regex mismatch.

## Test plan

- [x] `uv run ruff check src/ tests/` — lint clean (pre-existing E501/I001 only)
- [x] `uv run pytest tests/ -v` — 270 passed, 0 failed, 38s
- [x] Version consistency verified (pyproject.toml = __init__.py = 0.1.0)
- [ ] Re-run R3D review to verify assumption checker catches panel/i.i.d. mismatch
- [ ] Re-score with panel eval, target Coverage 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)