### PR TITLE
fix(quotes): prevent LaTeX garbling in review output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **LaTeX garbling in review quotes** — Added `verify_quotes` call after critique agent (which re-garbles LaTeX via JSON round-trip). Added LaTeX preservation instructions to all section prompts.
+
 ### Changed
 
 - **Structured assumption cross-check** — Rewrote `ASSUMPTION_CHECK_SYSTEM` with a 4-step procedure (extract assumptions → characterize data → cross-check with common mismatch patterns → evaluate defenses). Added INTRODUCTION sections to assumption-relevant types so data descriptions are visible. Adds `_TONE_BLOCK` to assumption prompt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ paper.pdf
     → [overview agent]   LLM → 4-6 macro issues (parallel with section agents)
     → [section agents]   LLM → 15-25 detailed comments (1 per section, parallel)
     → [crossref agent]   LLM → deduplicate, validate quotes, consistency
+    → [quote_verify.py]  Programmatic → fuzzy-match quotes against paper text
     → [critique agent]   LLM → self-critique quality gate, revise weak comments
+    → [quote_verify.py]  Programmatic → re-verify quotes (critique re-garbles via JSON)
     → [synthesis.py]     Deterministic → paper_review.md (refine.ink format)
 
 With `--agentic`: proof/methodology/results sections use CodingSectionAgent (OpenHands SDK),

--- a/src/coarse/pipeline.py
+++ b/src/coarse/pipeline.py
@@ -148,7 +148,7 @@ def review_paper(
     3. Analyze structure via markdown parsing + cheap LLM metadata → PaperStructure
     4. Phase 1: Overview agent + assumption checker (parallel, blocking)
     5. Phase 2: Section agents (parallel, text-only with overview context)
-    6. Cross-reference + critique
+    6. Cross-reference + quote verification + critique + quote re-verification
     7. Synthesis → markdown
 
     Returns:
@@ -310,6 +310,11 @@ def review_paper(
         final_comments = critique_agent.run(
             overview, verified_comments, comment_target=comment_target
         )
+
+    # Re-verify quotes after critique (critique re-emits through JSON, re-garbling LaTeX)
+    final_comments = verify_quotes(
+        final_comments, paper_text.full_markdown, drop_unverified=True,
+    )
 
     # Ensure sequential numbering 1..N
     final_comments = _renumber_comments(final_comments)

--- a/src/coarse/prompts.py
+++ b/src/coarse/prompts.py
@@ -240,6 +240,8 @@ For each issue you identify, produce a structured comment with:
 - quote: Copy-paste the EXACT characters from the section text. The quote MUST be a \
 verbatim substring of the section text provided below — do not paraphrase, reword, \
 summarize, or reconstruct any part of it. Copy it character-for-character. \
+If the text contains LaTeX commands (e.g., \\rho, \\frac, \\boldsymbol), copy them \
+exactly with their backslashes — do not render or interpret LaTeX as symbols. \
 The quote MUST include the COMPLETE passage — NEVER truncate mid-sentence or \
 mid-equation. If a passage spans multiple lines or contains multi-line equations, \
 include ALL of it. A truncated quote is a critical error.
@@ -364,7 +366,10 @@ For each issue, produce a structured comment with:
 - title: A concise, specific title (5-10 words)
 - quote: Copy-paste the EXACT characters from the section text. The quote MUST be a \
 verbatim substring of the section text provided below — do not paraphrase, reword, \
-or summarize any part of it. The quote MUST include the COMPLETE passage — NEVER \
+or summarize any part of it. \
+If the text contains LaTeX commands (e.g., \\rho, \\frac, \\boldsymbol), copy them \
+exactly with their backslashes — do not render or interpret LaTeX as symbols. \
+The quote MUST include the COMPLETE passage — NEVER \
 truncate mid-sentence or mid-equation. If a passage spans multiple lines or \
 contains multi-line equations, include ALL of it. A truncated quote is a critical error.
 - feedback: Show your re-derivation or calculation that reveals the error (3-8 \
@@ -394,7 +399,10 @@ For each issue you identify, produce a structured comment with:
 - title: A concise, specific title (5-10 words)
 - quote: Copy-paste the EXACT characters from the section text. The quote MUST be a \
 verbatim substring of the section text provided below — do not paraphrase, reword, \
-or summarize any part of it. The quote MUST include the COMPLETE passage — NEVER \
+or summarize any part of it. \
+If the text contains LaTeX commands (e.g., \\rho, \\frac, \\boldsymbol), copy them \
+exactly with their backslashes — do not render or interpret LaTeX as symbols. \
+The quote MUST include the COMPLETE passage — NEVER \
 truncate mid-sentence or mid-equation. If a passage spans multiple lines or \
 contains multi-line equations, include ALL of it. A truncated quote is a critical error.
 - feedback: Explain the methodological concern with specifics (3-8 sentences). If an \
@@ -422,8 +430,10 @@ For each issue you identify, produce a structured comment with:
 - title: A concise, specific title (5-10 words)
 - quote: Copy-paste the EXACT characters from the section text. The quote MUST be a \
 verbatim substring of the section text provided below — do not paraphrase, reword, \
-or summarize any part of it. The quote should be at least 2 full sentences; longer \
-is better.
+or summarize any part of it. \
+If the text contains LaTeX commands (e.g., \\rho, \\frac, \\boldsymbol), copy them \
+exactly with their backslashes — do not render or interpret LaTeX as symbols. \
+The quote should be at least 2 full sentences; longer is better.
 - feedback: Explain the concern with specifics (3-8 sentences). If a claim about prior \
 work is wrong, state what the prior work actually shows.
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,6 +5,9 @@ from coarse.prompts import (
     CROSSREF_SYSTEM,
     METADATA_SYSTEM,
     OVERVIEW_SYSTEM,
+    SECTION_LITERATURE_SYSTEM,
+    SECTION_METHODOLOGY_SYSTEM,
+    SECTION_PROOF_SYSTEM,
     SECTION_SYSTEM,
     assumption_check_user,
     critique_user,
@@ -179,6 +182,16 @@ def test_assumption_check_system_lists_common_mismatches():
 def test_assumption_check_user_references_procedure():
     result = assumption_check_user("Test Paper", "some text")
     assert "4-step" in result
+
+
+def test_section_prompts_include_latex_preservation_instruction():
+    latex_phrase = "do not render or interpret LaTeX"
+    prompts = (
+        SECTION_SYSTEM, SECTION_PROOF_SYSTEM,
+        SECTION_METHODOLOGY_SYSTEM, SECTION_LITERATURE_SYSTEM,
+    )
+    for prompt in prompts:
+        assert latex_phrase in prompt
 
 
 def test_assumption_relevant_types_includes_introduction():


### PR DESCRIPTION
## Summary
- Add `verify_quotes()` call after critique agent — critique re-emits quotes through JSON, re-garbling LaTeX backslash commands (`\rho` → `ho`, `\frac` → `rac`)
- Add LaTeX preservation instructions to all 4 section prompts (SECTION_SYSTEM, PROOF, METHODOLOGY, LITERATURE)
- Update pipeline docs in CLAUDE.md and docstring to reflect both verification steps

## Test plan
- [x] New test `test_section_prompts_include_latex_preservation_instruction` verifies instruction in all 4 prompts
- [x] All 271 tests pass
- [x] Ruff lint clean (only pre-existing E402/E501)
- [x] Version consistency verified (0.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)