### PR TITLE
fix(quality): faithful synthesis aggregation and half-point scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **LaTeX garbling in review quotes** — Added `verify_quotes` call after critique agent (which re-garbles LaTeX via JSON round-trip). Added LaTeX preservation instructions to all section prompts.
+- **Quality scorer synthesizer overriding judges** — Synthesis prompt now faithfully aggregates panel scores instead of re-evaluating independently. Scoring changed from integer 1-5 to half-point increments (1.0-5.0) for finer granularity.
 
 ### Changed
 

--- a/src/coarse/quality.py
+++ b/src/coarse/quality.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class DimensionScore(BaseModel):
     dimension: str
-    score: int  # 1-5
+    score: float  # 1.0-5.0, half-point increments (1, 1.5, 2, ..., 5)
     reasoning: str
 
 
@@ -36,7 +36,10 @@ original paper, a reference review written by another reviewer, and a \
 generated review. Your task is to assess the generated review's quality \
 primarily against the paper itself, using the reference for calibration.
 
-Score each dimension from 1 (very poor) to 5 (excellent):
+Score each dimension from 1.0 (very poor) to 5.0 (excellent) in half-point \
+increments (1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5). Use half-points to \
+distinguish minor issues from major ones — e.g., one truncated quote out of \
+19 is a 4.5, not a 4:
 
 1. **coverage**: Does the generated review identify the paper's most important \
 issues? Evaluate this against the paper itself — what are the real strengths, \
@@ -91,7 +94,8 @@ source of truth and the reference review for calibration (not as an answer key).
 {generated}
 </generated>
 
-Score the generated review on: coverage, specificity, depth, and format (each 1-5).
+Score the generated review on: coverage, specificity, depth, and format \
+(each 1.0-5.0 in half-point increments).
 Verify quotes against the paper text. Assess coverage and depth against the \
 paper itself — does the generated review find the paper's real issues and \
 engage with its actual methodology and assumptions? Credit valid issues the \
@@ -181,8 +185,12 @@ communication).
 
 Your task:
 1. For each dimension (coverage, specificity, depth, format), determine a final \
-consensus score (1-5) that reflects the panel's assessments. Weight disagreements \
-toward the more critical judge — overrating quality is worse than underrating it.
+consensus score (1.0-5.0 in half-point increments) that FAITHFULLY reflects \
+the panel's actual scores. Your score must stay within the range of the \
+judges' scores — if all judges gave 5, the consensus is 5; if judges gave \
+4.5, 4.5, 5, the consensus is 4.5 or 5. Do NOT introduce your own \
+independent assessment or dock points for issues the judges did not penalize. \
+When judges disagree, weight toward the more critical judge.
 2. Synthesize 3-5 key strengths from across all judges' reports (deduplicate).
 3. Synthesize 3-5 key weaknesses (deduplicate and prioritize the most actionable).
 4. Provide 3-5 concrete improvement_suggestions for the review pipeline — \
@@ -298,7 +306,7 @@ def evaluate_review_panel(
 
 def _average_reports(reports: list[QualityReport]) -> QualityReport:
     """Simple average fallback when synthesis isn't possible."""
-    dim_scores: dict[str, list[int]] = {}
+    dim_scores: dict[str, list[float]] = {}
     for r in reports:
         for d in r.dimensions:
             dim_scores.setdefault(d.dimension, []).append(d.score)
@@ -306,7 +314,7 @@ def _average_reports(reports: list[QualityReport]) -> QualityReport:
     dims = [
         DimensionScore(
             dimension=name,
-            score=round(sum(scores) / len(scores)),
+            score=round(sum(scores) / len(scores) * 2) / 2,  # nearest 0.5
             reasoning=f"Average of {len(scores)} judge(s)",
         )
         for name, scores in dim_scores.items()

--- a/tests/test_quality-eval.py
+++ b/tests/test_quality-eval.py
@@ -11,11 +11,11 @@ from coarse.synthesis import render_review
 from coarse.types import DetailedComment, OverviewFeedback, OverviewIssue, Review
 
 
-def _make_dimension(dimension: str, score: int) -> DimensionScore:
+def _make_dimension(dimension: str, score: float) -> DimensionScore:
     return DimensionScore(dimension=dimension, score=score, reasoning=f"Reasoning for {dimension}.")
 
 
-def _make_judge_output(scores: list[int]) -> _JudgeOutput:
+def _make_judge_output(scores: list[float]) -> _JudgeOutput:
     dimensions = [
         _make_dimension(dim, score)
         for dim, score in zip(["coverage", "specificity", "depth", "format"], scores)
@@ -27,7 +27,7 @@ def _make_judge_output(scores: list[int]) -> _JudgeOutput:
     )
 
 
-def _make_mock_client(scores: list[int]) -> LLMClient:
+def _make_mock_client(scores: list[float]) -> LLMClient:
     client = MagicMock(spec=LLMClient)
     client.complete.return_value = _make_judge_output(scores)
     return client


### PR DESCRIPTION
## Summary
- Synthesis prompt now faithfully aggregates panel scores instead of re-evaluating independently (was docking points when all 3 judges gave 5/5)
- Scoring changed from integer 1-5 to half-point increments (1.0-5.0) so a single truncated quote costs 0.5 not 1.0
- User prompt updated to match system prompt scale; test type hints fixed int→float

## Test plan
- [x] All 271 tests pass
- [x] Ruff lint clean
- [x] Verified with live quality run: 3 judges all 5.0 → synthesized 4.9/5.0 (previously 4.5/5.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)