### PR TITLE
hotfix: OpenRouter OCR robustness + Modal libGL + capacity 20

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,17 @@
 # Copy this file to .env and fill in the keys you have.
 # Only OPENROUTER_API_KEY is required; all others are optional.
 
-# Required: routes all LLM calls through OpenRouter (https://openrouter.ai/keys)
+# Required: routes all LLM calls (including Mistral OCR for PDF extraction)
+# through OpenRouter. Get one at https://openrouter.ai/keys.
 OPENROUTER_API_KEY=
 
-# Optional: enables vision-based extraction QA (improves PDF extraction quality)
-GEMINI_API_KEY=
-
-# Optional: direct Mistral OCR (skips OpenRouter for PDF extraction)
-MISTRAL_API_KEY=
-
 # Optional: use these providers directly instead of through OpenRouter
+# (lower latency, separate billing).
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
+# GEMINI_API_KEY=
 # GOOGLE_API_KEY=
+# MISTRAL_API_KEY=
 # GROQ_API_KEY=
 # TOGETHER_API_KEY=
 # COHERE_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Changed
+
+- **Mistral OCR is now OpenRouter-only** — removed the `_extract_mistral_direct` backend that tried to hit Mistral's API directly with a `MISTRAL_API_KEY`. All PDF OCR now routes through OpenRouter's `file-parser` plugin, so users only ever need an `OPENROUTER_API_KEY`. The OCR → Docling fallback chain is unchanged for offline use.
+- **Raised Modal concurrency from 10 → 20 containers**, removed the web-side hard rejection gate so bursts beyond the container limit are queued by Modal instead of erroring out.
+
+### Fixed
+
+- **Docling fallback works in production** — added `libgl1` + `libglib2.0-0` to the Modal image. Without them, Docling crashed on first import with `libGL.so.1: cannot open shared object file`, meaning the "offline fallback" wasn't actually a fallback when the OpenRouter OCR path failed.
+- **OpenRouter OCR error handling** — when OpenRouter returns HTTP 200 with an error body (rate limit, plugin unavailable, content policy), extraction no longer crashes with `KeyError: 'choices'`. Instead it raises a clean `ExtractionError` with the provider's error message, which the orchestrator can then classify into a user-facing message. Also handles missing `choices`, malformed annotations, empty content, and non-dict JSON responses.
+- **OpenRouter OCR retry logic** — added bounded retries (3 attempts, exponential backoff 1s/2s/4s) on connection errors, read timeouts, and transient HTTP statuses (408, 429, 500, 502, 503, 504). Non-transient 4xx errors (401 bad key, 402 spend limit) fail fast without wasting retries. Diagnostic logging on every retry and every unexpected response shape.
+
 ## v1.1.0 — 2026-04-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ uv run python -m coarse paper.pdf
 
 ```
 paper (PDF, TXT, MD, TeX, DOCX, HTML, EPUB)
-    → [extraction.py]    Mistral OCR / Docling fallback → PaperText (markdown)
+    → [extraction.py]    Mistral OCR via OpenRouter / Docling fallback → PaperText (markdown)
     → [extraction_qa.py] Vision LLM spot-check (auto-triggers on garbled text)
     → [structure.py]     Parse headings + LLM → PaperStructure (sections, math detection, domain)
     → [calibrate_domain] Domain-specific review criteria (parallel with literature)
@@ -194,8 +194,8 @@ Runs on every push to main and every PR:
 Current models (verified 2026-03-04):
 - **Default**: `qwen/qwen3.5-plus-02-15` (via OpenRouter, 1M ctx, $0.26/1.56 per 1M tok)
 - **Vision**: `gemini/gemini-3-flash-preview` (1M ctx, $0.50/3.00 per 1M tok) — post-extraction QA (litellm uses `gemini/` prefix)
-- **OCR**: `mistral/mistral-ocr-latest` — PDF text extraction (Mistral OCR via litellm)
-- **OpenRouter Extraction**: `google/gemini-3-flash-preview` — fallback extraction via OpenRouter file-parser plugin
+- **OCR**: Mistral OCR, always routed through OpenRouter's `file-parser` plugin (never direct). Required: only `OPENROUTER_API_KEY`.
+- **OpenRouter Extraction**: `google/gemini-3-flash-preview` — the host model that carries the file-parser plugin request
 - **Literature Search**: `perplexity/sonar-pro-search` — web-grounded literature search via OpenRouter (~$0.03)
 - **Quality Eval**: `gemini/gemini-3-flash-preview` — dev-only quality evaluation (single-judge or panel)
 - **Cheap (OpenAI)**: `openai/gpt-5.1-codex-mini` ($0.25/2.00)

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -9,15 +9,18 @@ The web app runs on four free services:
 | **Modal** | Serverless Python worker | $30/month compute credits |
 | **Gmail** | Email notifications | 500 emails/day (app password) |
 
-Users provide their own OpenRouter API key, so **you only pay** for Mistral OCR + Gemini Flash extraction (~$0.02–0.07 per review). Everything else is free.
+Users provide their own OpenRouter API key, which covers **everything**: review agents, literature search, and Mistral OCR for PDF extraction (all routed through OpenRouter's file-parser plugin). The operator pays only for Modal compute (~$0.08–0.10 per review) and Gmail SMTP.
 
 ---
 
 ## Prerequisites
 
 - GitHub repo (public, for free GitHub Actions)
-- API keys: `OPENROUTER_API_KEY`, `MISTRAL_API_KEY`, `GEMINI_API_KEY`
 - Accounts on: [Supabase](https://supabase.com), [Modal](https://modal.com), [Vercel](https://vercel.com)
+- A Gmail account with an App Password for notification emails
+- A shared secret for the Modal webhook (`python -c "import secrets; print(secrets.token_urlsafe(32))"`)
+
+No LLM provider API keys are needed on the deployment side — users supply their own.
 
 ---
 
@@ -49,12 +52,11 @@ The `reviews` table stores review metadata and results. PDFs are uploaded to the
 
    | Secret name | Environment variables |
    |-------------|----------------------|
-   | `coarse-openrouter` | `OPENROUTER_API_KEY` (fallback if user doesn't provide one) |
-   | `coarse-mistral` | `MISTRAL_API_KEY` |
-   | `coarse-gemini` | `GEMINI_API_KEY` |
    | `coarse-supabase` | `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` |
    | `coarse-webhook` | `MODAL_WEBHOOK_SECRET` (generate: `python -c "import secrets; print(secrets.token_urlsafe(32))"`) |
    | `coarse-gmail` | `GMAIL_USER`, `GMAIL_APP_PASSWORD`, `SITE_URL` (e.g. `https://coarse.vercel.app`) |
+
+   **No LLM provider secrets are mounted.** The user's OpenRouter key arrives with each review request and is set into the container's env for the duration of the run, then unset. See `modal_worker.py` for the pattern.
 
 3. Deploy:
    ```bash

--- a/deploy/modal_worker.py
+++ b/deploy/modal_worker.py
@@ -25,6 +25,12 @@ _repo_root = Path(__file__).resolve().parent.parent
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
+    # Docling's OCR stack (and a few other PDF/image libs) link against
+    # libGL and glib at runtime. debian_slim doesn't ship these, so without
+    # them Docling crashes on first import with `libGL.so.1: cannot open
+    # shared object file`. That's the offline fallback when the OpenRouter
+    # OCR path fails, so it must actually work.
+    .apt_install("libgl1", "libglib2.0-0")
     .pip_install(
         # Install deps only (coarse source is baked into image below)
         "litellm>=1.60",
@@ -199,8 +205,7 @@ def do_review(req_dict: dict):
         from coarse import review_paper
         from coarse.config import CoarseConfig
         has_or_key = bool(os.environ.get("OPENROUTER_API_KEY"))
-        has_mi_key = bool(os.environ.get("MISTRAL_API_KEY"))
-        print(f"[{job_id}] Import OK — OPENROUTER_API_KEY={'set' if has_or_key else 'MISSING'}, MISTRAL_API_KEY={'set' if has_mi_key else 'MISSING'}")
+        print(f"[{job_id}] Import OK — OPENROUTER_API_KEY={'set' if has_or_key else 'MISSING'}")
         print(f"[{job_id}] Starting pipeline")
 
         config = CoarseConfig(use_coding_agents=False, extraction_qa=True)

--- a/deploy/modal_worker.py
+++ b/deploy/modal_worker.py
@@ -142,7 +142,7 @@ class ReviewRequest(BaseModel):
     image=image,
     timeout=7200,
     memory=2048,
-    max_containers=10,
+    max_containers=20,
     secrets=[
         modal.Secret.from_name("coarse-supabase"),
         modal.Secret.from_name("coarse-webhook"),

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -2,7 +2,7 @@
 
 Supports PDF, TXT, MD, DOCX, TEX/LATEX, HTML, and EPUB.
 
-PDF priority: Mistral OCR (direct) → OpenRouter → Docling.
+PDF priority: Mistral OCR via OpenRouter file-parser plugin → Docling (offline).
 DOCX/HTML/TEX: Docling (if installed) → lightweight fallback (mammoth/markdownify/regex).
 TXT/MD: Direct read. EPUB: ebooklib + markdownify.
 """
@@ -109,40 +109,154 @@ def _save_cache(pdf_path: Path, paper_text: PaperText) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _extract_mistral_direct(path: Path) -> str:
-    """Extract via Mistral OCR API (requires MISTRAL_API_KEY)."""
-    import os
-
-    from litellm import ocr
-
-    from coarse.models import OCR_MODEL
-
-    # Only use a real Mistral key here — the OpenRouter fallback in
-    # resolve_api_key() would send an OpenRouter key to Mistral's API,
-    # which fails and blocks the OpenRouter extraction backend.
-    key = os.environ.get("MISTRAL_API_KEY")
-    if not key:
-        raise ValueError("No MISTRAL_API_KEY")
-
-    response = ocr(
-        model=OCR_MODEL,
-        document={"type": "document_url", "document_url": f"file://{path.resolve()}"},
-        api_key=key,
-    )
-    pages = response.pages
-    if not pages:
-        raise ValueError("Mistral OCR returned no pages")
-    return PAGE_BREAK.join(page.markdown for page in pages)
-
-
 _MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB
+
+# Retry config for transient OpenRouter failures. Only applied to idempotent
+# POSTs; network errors and these specific HTTP statuses are retried.
+_OCR_RETRY_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+_OCR_MAX_RETRIES = 3  # total attempts = 1 + _OCR_MAX_RETRIES
+_OCR_BACKOFF_BASE = 2.0  # seconds; actual wait = base ** attempt
+
+# Truncate diagnostic log output so a runaway response body doesn't flood logs.
+_OCR_LOG_TRUNCATE = 500
+
+
+def _post_openrouter_ocr(
+    *,
+    url: str,
+    headers: dict,
+    payload: dict,
+    timeout: int,
+) -> "requests.Response":  # noqa: F821
+    """POST to OpenRouter with bounded retries on transient failures.
+
+    Retries on connection errors, read timeouts, and specific 5xx/429/408
+    statuses. Does NOT retry on 4xx (except 408, 429) since those are
+    user-actionable (bad key, content policy, etc.).
+
+    Raises ExtractionError with context if all attempts fail with network
+    errors. Otherwise returns the last Response (caller must still check
+    `raise_for_status()` and body).
+    """
+    import time
+
+    import requests
+
+    last_network_exc: Exception | None = None
+    for attempt in range(_OCR_MAX_RETRIES + 1):
+        try:
+            resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            last_network_exc = exc
+            if attempt < _OCR_MAX_RETRIES:
+                wait = _OCR_BACKOFF_BASE ** attempt
+                logger.warning(
+                    "OpenRouter OCR network error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1, _OCR_MAX_RETRIES + 1, wait, exc,
+                )
+                time.sleep(wait)
+                continue
+            raise ExtractionError(
+                f"OpenRouter OCR network error after {_OCR_MAX_RETRIES + 1} attempts: {exc}"
+            ) from exc
+
+        if resp.status_code in _OCR_RETRY_STATUSES and attempt < _OCR_MAX_RETRIES:
+            wait = _OCR_BACKOFF_BASE ** attempt
+            logger.warning(
+                "OpenRouter OCR returned %d (attempt %d/%d), retrying in %.1fs",
+                resp.status_code, attempt + 1, _OCR_MAX_RETRIES + 1, wait,
+            )
+            time.sleep(wait)
+            continue
+
+        return resp
+
+    # Unreachable: the loop either returns on success or raises on final network error
+    raise ExtractionError(  # pragma: no cover
+        f"OpenRouter OCR retry loop exited unexpectedly (last exc: {last_network_exc})"
+    )
+
+
+def _parse_openrouter_ocr_response(resp: "requests.Response") -> str:  # noqa: F821
+    """Parse an OpenRouter OCR response into a single markdown string.
+
+    Handles several failure modes OpenRouter exposes:
+    - HTTP 200 with `{"error": {...}}` (plugin failed mid-request)
+    - HTTP 200 with empty `choices`
+    - Malformed annotation structure
+    - Empty content fallback
+    """
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise ExtractionError(
+            f"OpenRouter returned invalid JSON (HTTP {resp.status_code}): {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise ExtractionError(
+            f"OpenRouter OCR response was not a JSON object: {type(data).__name__}"
+        )
+
+    # OpenRouter can return HTTP 200 with an error body (rate limit, plugin
+    # failure, content policy, etc.). Surface a clean error instead of
+    # crashing on KeyError: 'choices'.
+    if "error" in data and not data.get("choices"):
+        err = data["error"]
+        msg = err.get("message") if isinstance(err, dict) else None
+        logger.warning("OpenRouter OCR returned error body: %s", str(err)[:_OCR_LOG_TRUNCATE])
+        raise ExtractionError(f"OpenRouter OCR error: {msg or err}")
+
+    choices = data.get("choices")
+    if not choices:
+        logger.warning(
+            "OpenRouter OCR unexpected response (no choices): keys=%s body=%s",
+            sorted(data.keys()), str(data)[:_OCR_LOG_TRUNCATE],
+        )
+        raise ExtractionError(
+            f"OpenRouter OCR returned no choices (response keys: {sorted(data.keys())})"
+        )
+
+    first_choice = choices[0] if isinstance(choices, list) else {}
+    message = (first_choice or {}).get("message") or {}
+
+    # Try annotations first (raw OCR output, no model paraphrasing).
+    # File-parser's documented response shape (message.annotations):
+    #   [{"type": "file", "file": {"content":
+    #       [{"type": "text", "text": ...}, ...]}}]
+    annotations = message.get("annotations") or []
+    for ann in annotations:
+        if not isinstance(ann, dict) or ann.get("type") != "file":
+            continue
+        file_obj = ann.get("file") or {}
+        content_items = file_obj.get("content") or []
+        texts = [
+            item.get("text", "")
+            for item in content_items
+            if isinstance(item, dict) and item.get("type") == "text" and item.get("text")
+        ]
+        if texts:
+            return PAGE_BREAK.join(texts)
+
+    # Fallback: model response (the prompt asks for verbatim text when the
+    # plugin output is unavailable or the model paraphrased anyway).
+    content = message.get("content")
+    if not content or not isinstance(content, str) or not content.strip():
+        logger.warning(
+            "OpenRouter OCR returned no usable content; message keys=%s",
+            sorted(message.keys()),
+        )
+        raise ExtractionError("OpenRouter OCR returned empty content")
+    return content
 
 
 def _extract_mistral_openrouter(path: Path) -> str:
-    """Extract via OpenRouter's Mistral OCR file-parser plugin."""
-    import base64
+    """Extract via OpenRouter's Mistral OCR file-parser plugin.
 
-    import requests
+    This is the only Mistral OCR path — all Mistral OCR calls route through
+    OpenRouter so users only ever need an OPENROUTER_API_KEY.
+    """
+    import base64
 
     from coarse.config import resolve_api_key
     from coarse.models import OPENROUTER_EXTRACTION_MODEL
@@ -162,13 +276,13 @@ def _extract_mistral_openrouter(path: Path) -> str:
     with open(path, "rb") as f:
         pdf_b64 = base64.b64encode(f.read()).decode()
 
-    resp = requests.post(
-        "https://openrouter.ai/api/v1/chat/completions",
+    resp = _post_openrouter_ocr(
+        url="https://openrouter.ai/api/v1/chat/completions",
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         },
-        json={
+        payload={
             "model": OPENROUTER_EXTRACTION_MODEL,
             "messages": [{"role": "user", "content": [
                 {"type": "text", "text": OPENROUTER_EXTRACTION_PROMPT},
@@ -182,32 +296,7 @@ def _extract_mistral_openrouter(path: Path) -> str:
         timeout=300,
     )
     resp.raise_for_status()
-    try:
-        data = resp.json()
-    except ValueError as e:
-        raise ExtractionError(
-            f"OpenRouter returned invalid JSON (HTTP {resp.status_code}): {e}"
-        ) from e
-
-    # Try annotations first (raw OCR output, no model modification)
-    annotations = (
-        data.get("choices", [{}])[0].get("message", {}).get("annotations", [])
-    )
-    for ann in annotations:
-        if ann.get("type") == "file":
-            texts = [
-                p["text"]
-                for p in ann["file"].get("content", [])
-                if p.get("type") == "text"
-            ]
-            if texts:
-                return PAGE_BREAK.join(texts)
-
-    # Fallback: model response (asked to return text verbatim)
-    content = data["choices"][0]["message"]["content"]
-    if not content:
-        raise ValueError("No content from OpenRouter OCR")
-    return content
+    return _parse_openrouter_ocr_response(resp)
 
 
 def _extract_docling(path: Path) -> str:
@@ -350,7 +439,7 @@ from coarse.garble import garble_ratio as compute_garble_ratio, normalize_ocr_ga
 def extract_text(pdf_path: str | Path, use_cache: bool = True) -> PaperText:
     """Extract text from a PDF file.
 
-    Tries Mistral OCR (direct API, then OpenRouter plugin) for high-quality
+    Tries Mistral OCR via OpenRouter's file-parser plugin for high-quality
     LaTeX extraction, falling back to Docling for offline use.
 
     Args:
@@ -386,9 +475,8 @@ def extract_text(pdf_path: str | Path, use_cache: bool = True) -> PaperText:
         if cached is not None:
             return cached
 
-    # Priority: Mistral direct → OpenRouter → Docling
+    # Priority: Mistral OCR via OpenRouter → Docling (offline fallback)
     extractors = [
-        ("Mistral OCR (direct)", _extract_mistral_direct),
         ("Mistral OCR (OpenRouter)", _extract_mistral_openrouter),
         ("Docling", _extract_docling),
     ]

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,9 +21,33 @@ from coarse.types import ExtractionError, PaperText
 
 
 def _mock_ocr_response(pages_markdown: list[str]):
-    """Create a mock litellm.ocr() response with pages."""
-    pages = [SimpleNamespace(markdown=md) for md in pages_markdown]
-    return SimpleNamespace(pages=pages)
+    """Create a mock OpenRouter file-parser response.
+
+    The real response shape is:
+    {"choices": [{"message": {"annotations": [{"type": "file",
+      "file": {"content": [{"type": "text", "text": "..."}, ...]}}]}}]}
+
+    Each "text" item represents one page. Returned as a MagicMock with
+    status_code=200 and .json() returning the dict, so it can be used as
+    the return value for patch("requests.post", ...).
+    """
+    content_items = [{"type": "text", "text": md} for md in pages_markdown]
+    data = {
+        "choices": [{
+            "message": {
+                "annotations": [{
+                    "type": "file",
+                    "file": {"content": content_items},
+                }],
+                "content": None,
+            }
+        }]
+    }
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data
+    resp.raise_for_status = MagicMock()
+    return resp
 
 
 @pytest.fixture
@@ -45,8 +68,8 @@ def minimal_pdf(tmp_path: Path) -> Path:
 
 
 def test_extract_text_returns_paper_text(minimal_pdf: Path, mock_ocr_pages) -> None:
-    with patch("litellm.ocr", return_value=_mock_ocr_response(mock_ocr_pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(mock_ocr_pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
     assert isinstance(result, PaperText)
     assert isinstance(result.full_markdown, str)
@@ -55,8 +78,8 @@ def test_extract_text_returns_paper_text(minimal_pdf: Path, mock_ocr_pages) -> N
 
 
 def test_extract_text_contains_page_breaks(minimal_pdf: Path, mock_ocr_pages) -> None:
-    with patch("litellm.ocr", return_value=_mock_ocr_response(mock_ocr_pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(mock_ocr_pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
     assert "<!-- PAGE BREAK -->" in result.full_markdown
     assert "# Test Paper" in result.full_markdown
@@ -65,8 +88,8 @@ def test_extract_text_contains_page_breaks(minimal_pdf: Path, mock_ocr_pages) ->
 
 def test_extract_text_joins_pages_with_page_break(minimal_pdf: Path) -> None:
     pages = ["Page 1 content", "Page 2 content", "Page 3 content"]
-    with patch("litellm.ocr", return_value=_mock_ocr_response(pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
     assert result.full_markdown.count("<!-- PAGE BREAK -->") == 2
 
@@ -87,8 +110,8 @@ def test_token_estimate_heuristic() -> None:
 def test_extract_text_caching(minimal_pdf: Path, mock_ocr_pages) -> None:
     """Extraction result should be cached and reloaded on second call."""
     mock_fn = MagicMock(return_value=_mock_ocr_response(mock_ocr_pages))
-    with patch("litellm.ocr", mock_fn):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", mock_fn):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result1 = extract_text(minimal_pdf, use_cache=True)
             # Second call should use cache — ocr not called again
             result2 = extract_text(minimal_pdf, use_cache=True)
@@ -100,8 +123,8 @@ def test_extract_text_caching(minimal_pdf: Path, mock_ocr_pages) -> None:
 def test_extract_text_no_cache(minimal_pdf: Path, mock_ocr_pages) -> None:
     """With use_cache=False, OCR is always called."""
     mock_fn = MagicMock(return_value=_mock_ocr_response(mock_ocr_pages))
-    with patch("litellm.ocr", mock_fn):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", mock_fn):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             extract_text(minimal_pdf, use_cache=False)
             extract_text(minimal_pdf, use_cache=False)
 
@@ -109,7 +132,7 @@ def test_extract_text_no_cache(minimal_pdf: Path, mock_ocr_pages) -> None:
 
 
 def test_fallback_to_docling(minimal_pdf: Path) -> None:
-    """When Mistral OCR is unavailable, should fall back to Docling."""
+    """When OpenRouter OCR is unavailable, should fall back to Docling."""
     mock_doc = MagicMock()
     mock_doc.export_to_markdown.return_value = "# Docling Fallback\n\nContent here."
     mock_result = MagicMock()
@@ -122,9 +145,9 @@ def test_fallback_to_docling(minimal_pdf: Path) -> None:
     mock_docling = MagicMock()
     mock_docling.document_converter.DocumentConverter = mock_converter_cls
 
-    # Ensure no Mistral key (direct check) and no OpenRouter key (resolve_api_key)
+    # Ensure no OpenRouter key (resolve_api_key) so the OpenRouter backend skips
     env_clean = {k: v for k, v in os.environ.items()
-                 if k not in ("MISTRAL_API_KEY", "OPENROUTER_API_KEY")}
+                 if k not in ("OPENROUTER_API_KEY",)}
     with patch.dict(os.environ, env_clean, clear=True):
         with patch.dict("sys.modules", {
             "docling": mock_docling,
@@ -139,9 +162,9 @@ def test_all_backends_fail(minimal_pdf: Path) -> None:
     """When all backends fail, raises ExtractionError with failure details."""
     from coarse.types import ExtractionError
 
-    # Ensure no Mistral key (direct check) and no OpenRouter key (resolve_api_key)
+    # Ensure no OpenRouter key (resolve_api_key) so OpenRouter backend skips
     env_clean = {k: v for k, v in os.environ.items()
-                 if k not in ("MISTRAL_API_KEY", "OPENROUTER_API_KEY")}
+                 if k not in ("OPENROUTER_API_KEY",)}
     with patch.dict(os.environ, env_clean, clear=True):
         with patch.dict(
             "sys.modules",
@@ -149,6 +172,185 @@ def test_all_backends_fail(minimal_pdf: Path) -> None:
         ):
             with pytest.raises(ExtractionError, match="all extraction backends failed"):
                 extract_text(minimal_pdf, use_cache=False)
+
+
+# --- OpenRouter OCR error handling and retry ---
+
+
+def _mock_error_response(status: int, body: dict | str):
+    """Build a mock requests.Response with a given status and JSON body."""
+    resp = MagicMock()
+    resp.status_code = status
+    if isinstance(body, dict):
+        resp.json.return_value = body
+    else:
+        resp.json.side_effect = ValueError(f"invalid json: {body}")
+    if status >= 400:
+        import requests as _r
+        http_err = _r.HTTPError(f"{status} Error", response=resp)
+        resp.raise_for_status.side_effect = http_err
+    else:
+        resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_openrouter_ocr_http_200_with_error_body(minimal_pdf: Path) -> None:
+    """HTTP 200 with {'error': {...}} body should raise a clean ExtractionError,
+    not KeyError: 'choices'. This is the exact failure mode we saw in production.
+
+    The error message is intentionally one that doesn't match any keyword in
+    _classify_api_error, so we can see our own ExtractionError text pass through.
+    """
+    error_response = _mock_error_response(200, {
+        "error": {"message": "file-parser plugin temporarily unavailable", "code": "plugin_error"},
+    })
+    with patch("requests.post", return_value=error_response):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+            with patch.dict(
+                "sys.modules",
+                {"docling": None, "docling.document_converter": None},
+            ):
+                with pytest.raises(ExtractionError) as exc_info:
+                    extract_text(minimal_pdf, use_cache=False)
+                # Must NOT be a KeyError: 'choices' — that was the production bug
+                assert "choices" not in str(exc_info.value) or "no choices" in str(exc_info.value)
+                assert "plugin" in str(exc_info.value) or "backends failed" in str(exc_info.value)
+
+
+def test_openrouter_ocr_classifies_402_as_spend_limit(minimal_pdf: Path) -> None:
+    """HTTP 200 with a credits-related error body should be classified into a
+    user-friendly spend limit message by the extraction orchestrator."""
+    error_response = _mock_error_response(200, {
+        "error": {"message": "Insufficient credits", "code": 402},
+    })
+    with patch("requests.post", return_value=error_response):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+            with patch.dict(
+                "sys.modules",
+                {"docling": None, "docling.document_converter": None},
+            ):
+                with pytest.raises(ExtractionError, match="spend limit"):
+                    extract_text(minimal_pdf, use_cache=False)
+
+
+def test_openrouter_ocr_no_choices_in_response(minimal_pdf: Path) -> None:
+    """HTTP 200 with no 'choices' and no 'error' should raise with diagnostic info."""
+    odd_response = _mock_error_response(200, {"something_else": "value"})
+    with patch("requests.post", return_value=odd_response):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+            with patch.dict(
+                "sys.modules",
+                {"docling": None, "docling.document_converter": None},
+            ):
+                with pytest.raises(ExtractionError, match="no choices"):
+                    extract_text(minimal_pdf, use_cache=False)
+
+
+def test_openrouter_ocr_malformed_annotation_falls_back_to_content(
+    minimal_pdf: Path,
+) -> None:
+    """Malformed annotations (e.g. missing 'file' key) should not crash;
+    should fall back to message.content instead."""
+    resp = _mock_error_response(200, {
+        "choices": [{
+            "message": {
+                "annotations": [{"type": "file"}],  # missing 'file' key entirely
+                "content": "Fallback markdown text",
+            }
+        }]
+    })
+    with patch("requests.post", return_value=resp):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+            result = extract_text(minimal_pdf, use_cache=False)
+    assert "Fallback markdown text" in result.full_markdown
+
+
+def test_openrouter_ocr_empty_content_raises(minimal_pdf: Path) -> None:
+    """When both annotations and content are empty, raise ExtractionError."""
+    empty_resp = _mock_error_response(200, {
+        "choices": [{"message": {"annotations": [], "content": ""}}]
+    })
+    with patch("requests.post", return_value=empty_resp):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+            with patch.dict(
+                "sys.modules",
+                {"docling": None, "docling.document_converter": None},
+            ):
+                with pytest.raises(ExtractionError, match="empty content"):
+                    extract_text(minimal_pdf, use_cache=False)
+
+
+def test_openrouter_ocr_retries_on_connection_error(
+    minimal_pdf: Path, mock_ocr_pages,
+) -> None:
+    """Transient connection errors should be retried up to _OCR_MAX_RETRIES."""
+    import requests as _r
+
+    success = _mock_ocr_response(mock_ocr_pages)
+    call_count = {"n": 0}
+
+    def flaky_post(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise _r.ConnectionError("simulated network blip")
+        return success
+
+    with patch("requests.post", side_effect=flaky_post):
+        with patch("time.sleep"):  # don't actually wait in tests
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                result = extract_text(minimal_pdf, use_cache=False)
+    assert "# Test Paper" in result.full_markdown
+    assert call_count["n"] == 3  # two failures + one success
+
+
+def test_openrouter_ocr_gives_up_after_max_retries(minimal_pdf: Path) -> None:
+    """Persistent connection errors should raise after the retry budget is spent."""
+    import requests as _r
+
+    def always_fails(*args, **kwargs):
+        raise _r.ConnectionError("down")
+
+    with patch("requests.post", side_effect=always_fails):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                with patch.dict(
+                    "sys.modules",
+                    {"docling": None, "docling.document_converter": None},
+                ):
+                    with pytest.raises(ExtractionError, match="network error after"):
+                        extract_text(minimal_pdf, use_cache=False)
+
+
+def test_openrouter_ocr_retries_on_503(
+    minimal_pdf: Path, mock_ocr_pages,
+) -> None:
+    """HTTP 503 should trigger a retry; subsequent success should be returned."""
+    success = _mock_ocr_response(mock_ocr_pages)
+    bad = _mock_error_response(503, {"error": "service unavailable"})
+    # First call 503, second call succeeds
+    with patch("requests.post", side_effect=[bad, success]):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                result = extract_text(minimal_pdf, use_cache=False)
+    assert "# Test Paper" in result.full_markdown
+
+
+def test_openrouter_ocr_does_not_retry_on_401(minimal_pdf: Path) -> None:
+    """4xx errors (except 408/429) are not transient — don't waste retries on them."""
+    bad = _mock_error_response(401, {"error": "Invalid API key"})
+    post_mock = MagicMock(return_value=bad)
+    with patch("requests.post", post_mock):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                with patch.dict(
+                    "sys.modules",
+                    {"docling": None, "docling.document_converter": None},
+                ):
+                    # 401 propagates through _classify_api_error → ExtractionError
+                    with pytest.raises(ExtractionError):
+                        extract_text(minimal_pdf, use_cache=False)
+    # Exactly one call — no retry on 401
+    assert post_mock.call_count == 1
 
 
 # --- Garble detection and normalization ---
@@ -190,8 +392,8 @@ def test_normalize_ocr_garble_preserves_clean_text():
 
 def test_extract_text_sets_garble_ratio(minimal_pdf: Path, mock_ocr_pages) -> None:
     """Extraction should compute and store garble ratio."""
-    with patch("litellm.ocr", return_value=_mock_ocr_response(mock_ocr_pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(mock_ocr_pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
     assert hasattr(result, "garble_ratio")
     assert result.garble_ratio == 0.0  # clean mock data
@@ -200,8 +402,8 @@ def test_extract_text_sets_garble_ratio(minimal_pdf: Path, mock_ocr_pages) -> No
 def test_extract_text_normalizes_garbled_ocr(minimal_pdf: Path) -> None:
     """Garbled OCR output should be auto-normalized."""
     garbled_pages = ["The ®nite case shows /C40x/C41"]
-    with patch("litellm.ocr", return_value=_mock_ocr_response(garbled_pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(garbled_pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
     assert "finite" in result.full_markdown
     assert "®nite" not in result.full_markdown
@@ -265,8 +467,8 @@ def test_garble_ratio_detects_mistral_artifacts():
 def test_extract_text_normalizes_mistral_artifacts(minimal_pdf: Path) -> None:
     """Mistral OCR artifacts should be normalized during extraction."""
     pages = ["Let glyph[lscript] &gt; 0 with <!-- formula-not-decoded --> here"]
-    with patch("litellm.ocr", return_value=_mock_ocr_response(pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
     assert "ℓ" in result.full_markdown
     assert "> 0" in result.full_markdown
@@ -338,8 +540,8 @@ def test_extract_file_missing() -> None:
 
 def test_extract_file_pdf_delegates(minimal_pdf: Path, mock_ocr_pages) -> None:
     """PDF files delegate to extract_text."""
-    with patch("litellm.ocr", return_value=_mock_ocr_response(mock_ocr_pages)):
-        with patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}):
+    with patch("requests.post", return_value=_mock_ocr_response(mock_ocr_pages)):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_file(minimal_pdf, use_cache=False)
     assert isinstance(result, PaperText)
     assert "# Test Paper" in result.full_markdown

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "coarse"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },

--- a/web/src/app/api/status/route.ts
+++ b/web/src/app/api/status/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 export const revalidate = 10; // ISR: revalidate every 10 seconds
 
-const MAX_CONCURRENT_REVIEWS = 10;
+const MAX_CONCURRENT_REVIEWS = 20;
 
 export async function GET() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/web/src/app/api/submit/route.ts
+++ b/web/src/app/api/submit/route.ts
@@ -5,7 +5,7 @@ import { checkRateLimit } from "@/lib/rateLimit";
 
 export const maxDuration = 30;
 
-const MAX_CONCURRENT_REVIEWS = 10;
+const MAX_CONCURRENT_REVIEWS = 20;
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");

--- a/web/src/app/api/submit/route.ts
+++ b/web/src/app/api/submit/route.ts
@@ -5,8 +5,6 @@ import { checkRateLimit } from "@/lib/rateLimit";
 
 export const maxDuration = 30;
 
-const MAX_CONCURRENT_REVIEWS = 20;
-
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
@@ -49,22 +47,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       {
         error: statusRow.banner_message || "Submissions are temporarily paused. Please try again later or use the CLI: pip install coarse",
-      },
-      { status: 503 },
-    );
-  }
-
-  // Check concurrent review capacity before accepting work
-  const { count: activeCount } = await supabaseAdmin
-    .from("reviews")
-    .select("id", { count: "exact", head: true })
-    .in("status", ["queued", "running"]);
-
-  if (activeCount !== null && activeCount >= MAX_CONCURRENT_REVIEWS) {
-    return NextResponse.json(
-      {
-        error:
-          "We are seeing high traffic right now. Please try again later or check out the command line version on our GitHub: https://github.com/Davidvandijcke/coarse",
       },
       { status: 503 },
     );


### PR DESCRIPTION
## Summary

Three hotfixes stacked on dev, to be merged as one release:

1. **`chore(deploy): raise max concurrent reviews from 10 to 20`** — Modal `max_containers` + web `MAX_CONCURRENT_REVIEWS` from 10 to 20. Zero idle cost, more headroom for bursts.

2. **`fix(web): remove hard rejection gate, let Modal queue overflow`** — submit route no longer returns 503 when active reviews ≥ capacity. Modal queues overflow automatically, which is a better UX than rejection.

3. **`fix(extraction): harden OpenRouter OCR and remove Mistral direct path`** — diagnoses and fixes the production bug where reviews crashed with `'Mistral OCR (OpenRouter) failed: 'choices''`:
   - Dead code removal of `_extract_mistral_direct` — all Mistral OCR now goes through OpenRouter's file-parser plugin, no MISTRAL_API_KEY needed anywhere.
   - Graceful handling of every broken response shape (HTTP 200 with error body, missing choices, malformed annotations, empty content, non-dict JSON).
   - Retry logic with exponential backoff on ConnectionError, Timeout, and transient HTTP statuses (408, 429, 500, 502, 503, 504). Non-transient 4xx fails fast.
   - `libgl1` + `libglib2.0-0` added to the Modal image so Docling actually works as offline fallback.
   - 9 new tests covering error paths, retry success, retry exhaustion, and the exact production bug as a regression test.

## Test plan

- [x] `uv run pytest tests/ -v` — 409 passed (was 400)
- [x] `uv run ruff check src/ tests/` — only pre-existing advisory issues
- [x] `modal deploy deploy/modal_worker.py` — deployed successfully
- [x] Modal health endpoint returns 200
- [ ] Vercel deploys on merge — web rejection gate goes away, capacity banner updates to /20

🤖 Generated with [Claude Code](https://claude.com/claude-code)