### PR TITLE
docs: stale-reference audit sweep + dead CoarseConfig kwarg

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,43 +139,15 @@ Explanation of issue + constructive remediation guidance.
 
 ## Git Workflow
 
-### Branch Naming
+**See `CONTRIBUTING.md` for the full workflow.** Short version:
 
-```
-feat/<issue>-<description>    # New features
-fix/<issue>-<description>     # Bug fixes
-docs/<description>            # Documentation only
-```
+- **`main`** — stable, tagged releases only. Protected: changes land via release PR from `dev`.
+- **`dev`** — active development. Feature work branches off `dev` and PRs back into `dev`.
+- **Release cycle**: `feat/my-thing` → PR into `dev` → merge → periodically PR `dev` → `main` + version bump + tag.
+- **Commits**: conventional commits (`feat(scope):`, `fix(scope):`, `docs:`, `test(scope):`, `chore(scope):`).
+- **Pre-PR**: `make check` (ruff + pytest), update `CHANGELOG.md` under `## Unreleased`, new code has tests in `tests/test_{module}.py`. Version bumps happen only on release PRs from `dev` to `main`, not on feature PRs.
 
-### Conventional Commits
-
-```
-feat(pipeline): add parallel section processing
-fix(extraction): handle scanned PDFs without text layer
-docs: update changelog for v0.1.1
-test(agents): add edge case for empty sections
-refactor(llm): simplify cost tracking
-```
-
-### Before Every Commit
-
-1. `uv run ruff check src/ tests/` — fix lint errors
-2. `uv run pytest tests/ -v` — all tests pass
-3. Verify version consistency: `pyproject.toml` matches `src/coarse/__init__.py`
-
-### Pre-PR Checklist
-
-1. **CHANGELOG.md** — Add entry for the change. Every PR, no exceptions.
-2. **Tests** — New functionality has tests. Existing tests pass.
-3. **Lint** — `ruff check` passes.
-4. **Version** — Bump in both `pyproject.toml` and `__init__.py` if releasing.
-
-### CI Pipeline (.github/workflows/ci.yml)
-
-Runs on every push to main and every PR:
-- **Ruff lint** — advisory (non-blocking)
-- **pytest** — blocking
-- **Version consistency** — blocking (pyproject.toml must match __init__.py)
+CI (`.github/workflows/ci.yml`) runs on every push to `main` or `dev` and on every PR. Pytest and version consistency (pyproject.toml must match `src/coarse/__init__.py`) are blocking; ruff lint is advisory.
 
 ## Development Rules
 
@@ -191,7 +163,7 @@ Runs on every push to main and every PR:
 
 **`src/coarse/models.py` is the single source of truth for ALL model IDs.** Never hardcode model strings in any other file — always `from coarse.models import DEFAULT_MODEL, VISION_MODEL, CHEAP_MODELS`.
 
-Current models (verified 2026-03-04):
+Current models (verified 2026-04-10):
 - **Default**: `qwen/qwen3.5-plus-02-15` (via OpenRouter, 1M ctx, $0.26/1.56 per 1M tok)
 - **Vision**: `gemini/gemini-3-flash-preview` (1M ctx, $0.50/3.00 per 1M tok) — post-extraction QA (litellm uses `gemini/` prefix)
 - **OCR**: Mistral OCR, always routed through OpenRouter's `file-parser` plugin (never direct). Required: only `OPENROUTER_API_KEY`.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,13 @@ Use `--cheap` to automatically select the cheapest model for which you have an A
 
 ## API keys
 
-Only `OPENROUTER_API_KEY` is needed. For step-by-step setup instructions, see the
-[API key guide](https://coarse.vercel.app/setup). For direct provider access (lower latency),
-set the provider-specific key instead:
+Only `OPENROUTER_API_KEY` is needed. This covers everything: review agents,
+literature search, and PDF extraction (Mistral OCR is always routed through
+OpenRouter's file-parser plugin, so there's no separate key for it). For
+step-by-step setup instructions, see the [API key guide](https://coarse.vercel.app/setup).
+
+For direct provider access to chat models (lower latency, separate billing),
+you can set the provider-specific key instead:
 
 | Provider   | Environment variable   |
 |------------|------------------------|

--- a/deploy/CAPACITY.md
+++ b/deploy/CAPACITY.md
@@ -40,7 +40,7 @@ WHERE id = 1;
 
 **Expand**: Add a payment method in the Modal dashboard. Modal charges per compute-second beyond the free tier — no plan upgrade needed.
 
-**Emergency**: Reduce `max_containers` from 10 to 5 in `deploy/modal_worker.py` and redeploy (`modal deploy deploy/modal_worker.py`) to slow the burn rate. Or pause submissions via SQL above.
+**Emergency**: Reduce `max_containers` from 20 to 10 (or lower) in `deploy/modal_worker.py` and redeploy (`modal deploy deploy/modal_worker.py`) to slow the burn rate. Also update `MAX_CONCURRENT_REVIEWS` in `web/src/app/api/status/route.ts` to match so the frontend busy banner is accurate. Or pause submissions via SQL above.
 
 ---
 

--- a/deploy/modal_worker.py
+++ b/deploy/modal_worker.py
@@ -208,7 +208,7 @@ def do_review(req_dict: dict):
         print(f"[{job_id}] Import OK — OPENROUTER_API_KEY={'set' if has_or_key else 'MISSING'}")
         print(f"[{job_id}] Starting pipeline")
 
-        config = CoarseConfig(use_coding_agents=False, extraction_qa=True)
+        config = CoarseConfig(extraction_qa=True)
         review, markdown, paper_text = review_paper(
             pdf_path, model=model, skip_cost_gate=True, config=config
         )

--- a/scripts/ocr_reviewer3.py
+++ b/scripts/ocr_reviewer3.py
@@ -3,7 +3,8 @@
 Usage:
     uv run python scripts/ocr_reviewer3.py
 
-Requires MISTRAL_API_KEY in environment or .env file.
+Requires OPENROUTER_API_KEY in environment or .env file — extraction
+routes through OpenRouter's Mistral OCR file-parser plugin.
 """
 from pathlib import Path
 

--- a/src/coarse/config.py
+++ b/src/coarse/config.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 # Maps provider name -> environment variable name.
 # Extensible: add entries as more providers are supported.
+# Note: "mistral" is kept here for users who want to call Mistral chat models
+# directly (e.g. `coarse review --model mistral/mistral-large`). Mistral OCR
+# (for PDF extraction) is NOT routed through this — it always goes through
+# OpenRouter's file-parser plugin; see src/coarse/extraction.py.
 PROVIDER_ENV_VARS: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",


### PR DESCRIPTION
## Summary

Full audit pass on docs and code for leftover references to removed/changed architecture. Single commit: \`docs: sweep for stale references and fix a dead CoarseConfig kwarg\`.

Fixes (all low-risk, no runtime behavior change except the Modal kwarg):

- **\`deploy/modal_worker.py\`**: remove \`use_coding_agents=False\` from the \`CoarseConfig()\` call. The kwarg doesn't exist on the Pydantic model — pydantic was silently ignoring it. Removing for clarity.
- **\`deploy/CAPACITY.md\`**: emergency runbook said \"Reduce max_containers from 10 to 5\" — stale since 20 is the current value. Updated to \"from 20 to 10\" + note to keep web \`MAX_CONCURRENT_REVIEWS\` in sync.
- **\`CLAUDE.md\`**: Git Workflow section was pre-dev-branch; now points to CONTRIBUTING.md for the two-branch workflow. Also bumped the model \"verified\" date.
- **\`README.md\`**: clarified that \`OPENROUTER_API_KEY\` covers PDF extraction too (Mistral OCR routes through OpenRouter, not direct), and the provider table is for direct chat-model access only.
- **\`src/coarse/config.py\`**: comment on why \"mistral\" is still in PROVIDER_ENV_VARS (Mistral chat models, not OCR).
- **\`scripts/ocr_reviewer3.py\`**: docstring said \"Requires MISTRAL_API_KEY\"; the script actually uses \`extract_text()\` which now routes through OpenRouter. Updated.

## Test plan

- [x] \`uv run pytest tests/ -q\` — 409 passed
- [x] \`uv run ruff check\` on changed files — all checks passed
- [x] Post-deploy review sample from the last hour: 7 done / 1 failed (user error), success rate 100% excluding user faults

Modal **does** need redeploy because \`modal_worker.py\` changed. I'll run \`modal deploy\` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)