### PR TITLE
fix: persistent OCR retries + keep PDFs on failure + 4GB Modal memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@
 
 - **Mistral OCR is now OpenRouter-only** — removed the `_extract_mistral_direct` backend that tried to hit Mistral's API directly with a `MISTRAL_API_KEY`. All PDF OCR now routes through OpenRouter's `file-parser` plugin, so users only ever need an `OPENROUTER_API_KEY`. The OCR → Docling fallback chain is unchanged for offline use.
 - **Raised Modal concurrency from 10 → 20 containers**, removed the web-side hard rejection gate so bursts beyond the container limit are queued by Modal instead of erroring out.
+- **OpenRouter OCR retry budget raised from 3 to 5 attempts.** Total exponential backoff window is now 1s + 2s + 4s + 8s + 16s = 31s, giving more headroom for slow recovery on the file-parser plugin.
+- **Modal function memory raised from 2 GB to 4 GB.** Large PDFs (8+ MB) plus the Docling torch/RapidOCR stack can exceed 2 GB when OCR falls through to offline mode. 4 GB keeps the offline fallback usable for big documents.
+- **PDFs are no longer deleted from Supabase Storage on the `finally` path** of the Modal worker. They're only deleted on the success path now; failed reviews keep their PDF so Modal's infrastructure retries (or a manual resubmit of the same job_id) can actually find it. Stale PDFs from failed runs are swept by the daily cleanup cron at 24h.
 
 ### Fixed
 
 - **Docling fallback works in production** — added `libgl1` + `libglib2.0-0` to the Modal image. Without them, Docling crashed on first import with `libGL.so.1: cannot open shared object file`, meaning the "offline fallback" wasn't actually a fallback when the OpenRouter OCR path failed.
 - **OpenRouter OCR error handling** — when OpenRouter returns HTTP 200 with an error body (rate limit, plugin unavailable, content policy), extraction no longer crashes with `KeyError: 'choices'`. Instead it raises a clean `ExtractionError` with the provider's error message, which the orchestrator can then classify into a user-facing message. Also handles missing `choices`, malformed annotations, empty content, and non-dict JSON responses.
-- **OpenRouter OCR retry logic** — added bounded retries (3 attempts, exponential backoff 1s/2s/4s) on connection errors, read timeouts, and transient HTTP statuses (408, 429, 500, 502, 503, 504). Non-transient 4xx errors (401 bad key, 402 spend limit) fail fast without wasting retries. Diagnostic logging on every retry and every unexpected response shape.
+- **OpenRouter OCR retry logic** — added bounded retries (3 → 5 attempts, exponential backoff 1s/2s/4s/8s/16s) on connection errors, read timeouts, and transient HTTP statuses (408, 429, 500, 502, 503, 504). Non-transient 4xx errors (401 bad key, 402 spend limit) fail fast without wasting retries. Diagnostic logging on every retry and every unexpected response shape.
+- **Retry OpenRouter OCR when the error is wrapped in a 200 response body.** The file-parser plugin occasionally returns `HTTP 200` with `{"error": {"code": 504, "message": "Timed out parsing ..."}}` instead of a raw `504`. The previous retry logic only matched on transport status codes, so it treated these as immediate failures. Now retries whenever the body's `error.code` is in the same retryable set (408, 429, 500, 502, 503, 504).
+- **Modal-level retries work again.** Previously, if Modal infrastructure retried a review (after an OOM or container crash), the retry would 404 on the PDF because the `finally` block had already deleted it from Supabase Storage. See the PDF storage change above.
 
 ## v1.1.0 — 2026-04-10
 

--- a/deploy/modal_worker.py
+++ b/deploy/modal_worker.py
@@ -147,7 +147,9 @@ class ReviewRequest(BaseModel):
 @app.function(
     image=image,
     timeout=7200,
-    memory=2048,
+    # 4 GB: large PDFs + Docling's torch/RapidOCR stack can blow past 2 GB when
+    # the OpenRouter OCR path fails and we fall through to offline extraction.
+    memory=4096,
     max_containers=20,
     secrets=[
         modal.Secret.from_name("coarse-supabase"),
@@ -227,6 +229,16 @@ def do_review(req_dict: dict):
             "completed_at": datetime.now(timezone.utc).isoformat(),
         }).eq("id", job_id).execute()
 
+        # Delete the PDF from Supabase Storage on success only. Failed reviews
+        # keep their PDF so Modal's infrastructure-level retries (or a manual
+        # resubmit of the same job_id) can find it. The cleanup_papers cron
+        # (.github/workflows/cleanup_papers.yml) sweeps any PDF older than 24h,
+        # which is well above the 2-hour Modal review timeout.
+        try:
+            db.storage.from_("papers").remove([pdf_storage_path])
+        except Exception:
+            pass  # Non-critical; cleanup cron will sweep it
+
         # Send completion email
         if email:
             _send_email(
@@ -262,15 +274,12 @@ def do_review(req_dict: dict):
         if original_key is not None:
             os.environ["OPENROUTER_API_KEY"] = original_key
 
-        # Clean up temp file
+        # Clean up temp file on local disk (always — no retry needs this).
+        # NOTE: we intentionally do NOT delete the PDF from Supabase Storage
+        # here. On the success path it's deleted above; on failure it stays
+        # so the cleanup cron can sweep it at 24h and Modal can retry.
         if os.path.exists(pdf_path):
             os.unlink(pdf_path)
-
-        # Delete PDF from storage (user's paper, no reason to retain)
-        try:
-            db.storage.from_("papers").remove([pdf_storage_path])
-        except Exception:
-            pass  # Non-critical; don't fail the review
 
 
 @app.function(

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -114,11 +114,38 @@ _MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB
 # Retry config for transient OpenRouter failures. Only applied to idempotent
 # POSTs; network errors and these specific HTTP statuses are retried.
 _OCR_RETRY_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
-_OCR_MAX_RETRIES = 3  # total attempts = 1 + _OCR_MAX_RETRIES
+_OCR_MAX_RETRIES = 5  # total attempts = 1 + _OCR_MAX_RETRIES
 _OCR_BACKOFF_BASE = 2.0  # seconds; actual wait = base ** attempt
+# With base=2 and max_retries=5, backoff sequence is 1s + 2s + 4s + 8s + 16s = 31s total.
 
 # Truncate diagnostic log output so a runaway response body doesn't flood logs.
 _OCR_LOG_TRUNCATE = 500
+
+
+def _body_retry_code(resp) -> int | None:
+    """Return a retryable error code if the response body wraps one, else None.
+
+    OpenRouter's plugin layer (including the Mistral OCR file-parser) sometimes
+    returns HTTP 200 with an error body like
+    ``{"error": {"message": "Timed out parsing tmp.pdf", "code": 504}}``
+    when the upstream provider hiccups. Without checking the body, the transport-
+    level retry loop would see HTTP 200, return the response as "successful",
+    and then the parser would raise ExtractionError and the review would fall
+    through to Docling. We want to retry these just like a raw HTTP 504.
+    """
+    try:
+        data = resp.json()
+    except (ValueError, AttributeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    err = data.get("error")
+    if not isinstance(err, dict):
+        return None
+    code = err.get("code")
+    if isinstance(code, int) and code in _OCR_RETRY_STATUSES:
+        return code
+    return None
 
 
 def _post_openrouter_ocr(
@@ -165,6 +192,20 @@ def _post_openrouter_ocr(
             logger.warning(
                 "OpenRouter OCR returned %d (attempt %d/%d), retrying in %.1fs",
                 resp.status_code, attempt + 1, _OCR_MAX_RETRIES + 1, wait,
+            )
+            time.sleep(wait)
+            continue
+
+        # HTTP 200 with a retryable error body (e.g. {"error": {"code": 504}}).
+        # OpenRouter's plugin layer uses this shape when the upstream provider
+        # (Mistral OCR) times out or hiccups. Treat it the same as a raw HTTP
+        # status in _OCR_RETRY_STATUSES.
+        body_code = _body_retry_code(resp)
+        if body_code is not None and attempt < _OCR_MAX_RETRIES:
+            wait = _OCR_BACKOFF_BASE ** attempt
+            logger.warning(
+                "OpenRouter OCR returned 200 with body error code %d (attempt %d/%d), retrying in %.1fs",
+                body_code, attempt + 1, _OCR_MAX_RETRIES + 1, wait,
             )
             time.sleep(wait)
             continue

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -335,6 +335,81 @@ def test_openrouter_ocr_retries_on_503(
     assert "# Test Paper" in result.full_markdown
 
 
+def test_openrouter_ocr_retries_on_200_with_body_error_504(
+    minimal_pdf: Path, mock_ocr_pages,
+) -> None:
+    """The real production failure mode: HTTP 200 with {error: {code: 504,
+    message: "Timed out parsing tmp.pdf"}}. Should be retried just like raw 504."""
+    success = _mock_ocr_response(mock_ocr_pages)
+    timeout_body = _mock_error_response(200, {
+        "error": {"message": "Timed out parsing tmp.pdf", "code": 504},
+    })
+    # First call returns the 200-with-504 body, second call succeeds
+    with patch("requests.post", side_effect=[timeout_body, success]):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                result = extract_text(minimal_pdf, use_cache=False)
+    assert "# Test Paper" in result.full_markdown
+
+
+def test_openrouter_ocr_retries_on_200_with_body_error_502(
+    minimal_pdf: Path, mock_ocr_pages,
+) -> None:
+    """200 with {error: {code: 502}} is also a transient upstream error."""
+    success = _mock_ocr_response(mock_ocr_pages)
+    bad_gateway = _mock_error_response(200, {
+        "error": {"message": "Upstream bad gateway", "code": 502},
+    })
+    with patch("requests.post", side_effect=[bad_gateway, success]):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                result = extract_text(minimal_pdf, use_cache=False)
+    assert "# Test Paper" in result.full_markdown
+
+
+def test_openrouter_ocr_does_not_retry_on_200_with_body_error_402(
+    minimal_pdf: Path,
+) -> None:
+    """Non-retryable body codes (402 spend limit, 401 auth) should fail fast —
+    no point wasting retries on a billing problem."""
+    spend_limit = _mock_error_response(200, {
+        "error": {"message": "Insufficient credits", "code": 402},
+    })
+    post_mock = MagicMock(return_value=spend_limit)
+    with patch("requests.post", post_mock):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                with patch.dict(
+                    "sys.modules",
+                    {"docling": None, "docling.document_converter": None},
+                ):
+                    with pytest.raises(ExtractionError):
+                        extract_text(minimal_pdf, use_cache=False)
+    # Exactly one call — no retry on 402
+    assert post_mock.call_count == 1
+
+
+def test_openrouter_ocr_retries_on_200_body_504_then_gives_up(
+    minimal_pdf: Path,
+) -> None:
+    """Persistent 200-with-504-body should exhaust retries and raise."""
+    timeout_body = _mock_error_response(200, {
+        "error": {"message": "Timed out parsing", "code": 504},
+    })
+    post_mock = MagicMock(return_value=timeout_body)
+    with patch("requests.post", post_mock):
+        with patch("time.sleep"):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                with patch.dict(
+                    "sys.modules",
+                    {"docling": None, "docling.document_converter": None},
+                ):
+                    with pytest.raises(ExtractionError, match="Timed out parsing"):
+                        extract_text(minimal_pdf, use_cache=False)
+    # _OCR_MAX_RETRIES + 1 = 6 total attempts
+    assert post_mock.call_count == 6
+
+
 def test_openrouter_ocr_does_not_retry_on_401(minimal_pdf: Path) -> None:
     """4xx errors (except 408/429) are not transient — don't waste retries on them."""
     bad = _mock_error_response(401, {"error": "Invalid API key"})


### PR DESCRIPTION
## Summary

Four compounding fixes driven by a real production failure where a 10 MB PDF got stuck in a retry loop and the user saw "Object not found":

### What was happening
- **Run 1**: OpenRouter OCR returned HTTP 200 with \`{"error": {"code": 504, "message": "Timed out parsing tmp.pdf"}}\` → our parser didn't treat this as retryable → fell through to Docling
- **Docling**: loaded weights on a 10 MB PDF, container silently died (probably OOM on 2 GB)
- **Run 2**: Modal infrastructure retried the function. PDF download 404'd because the \`finally\` block had already deleted the PDF from Supabase Storage. User saw "Object not found"

### Fixes

1. **Retry on 200-with-body-5xx** — the exact failure was a transient provider timeout wrapped in an HTTP 200. Added \`_body_retry_code()\` that detects retryable error codes inside \`data["error"]["code"]\` and hooks into the existing retry loop.

2. **Retry budget 3 → 5** — total backoff window 7s → 31s. More persistence for hard-to-parse PDFs without going unbounded.

3. **Keep PDFs on failure** — the \`finally\` block used to delete the PDF on every exit. Now it only deletes on the success path inside the \`try\` block. Failed reviews keep their PDF so retries can find it; the \`cleanup_papers.yml\` cron sweeps stale PDFs at 24h (well above the 2h Modal timeout).

4. **Modal memory 2 GB → 4 GB** — the Docling + torch + RapidOCR stack plus a big PDF easily exceeds 2 GB. Prevents silent OOM kills on the offline fallback path.

## Test plan

- [x] \`uv run pytest tests/ -q\` — 413 passed (was 409)
- [x] 4 new tests cover the exact failure modes:
  - \`test_openrouter_ocr_retries_on_200_with_body_error_504\` (the production regression test)
  - \`test_openrouter_ocr_retries_on_200_with_body_error_502\`
  - \`test_openrouter_ocr_does_not_retry_on_200_with_body_error_402\` (spend limit — fail fast)
  - \`test_openrouter_ocr_retries_on_200_body_504_then_gives_up\` (6-attempt exhaustion)
- [x] Lint clean on changed files
- [ ] \`modal deploy deploy/modal_worker.py\` after merge (required for memory + finally changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)