### PR TITLE
docs: OpenRouter spend limit + cost estimate warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ literature search, and PDF extraction (Mistral OCR is always routed through
 OpenRouter's file-parser plugin, so there's no separate key for it). For
 step-by-step setup instructions, see the [API key guide](https://coarse.vercel.app/setup).
 
+> **Set your OpenRouter per-key spend limit to at least $10** (ideally matching
+> the `max_cost_usd` default of `$10`). If the limit is hit mid-review the run
+> will fail and you'll need to raise the limit and resubmit. Cost estimates
+> shown before each review are approximate (~15% buffer) — they're a guide,
+> not a hard ceiling, so leave yourself headroom.
+
 For direct provider access to chat models (lower latency, separate billing),
 you can set the provider-specific key instead:
 
@@ -131,6 +137,11 @@ coarse estimates cost before running and asks for confirmation. The estimate inc
 |-----------------|---------------|
 | Short (< 20pp)  | $0.25 - $0.50 |
 | Long (30+ pp)   | $0.50 - $1    |
+
+**Actual costs can run up to ~2× the estimate** on complex papers depending on
+model reasoning depth, critique agent rewrites, and proof-verification chains
+for math-heavy sections. The 15% buffer is a first approximation, not a ceiling.
+Make sure your OpenRouter per-key spend limit has headroom above the estimate.
 
 The default spending cap is **$10 per review** (`max_cost_usd` in config). Use `--yes` to skip the
 confirmation prompt. Use `--no-qa` to skip the post-extraction quality check (vision LLM).

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -355,7 +355,8 @@ export default function SetupPage() {
               >
                 Settings → Credits
               </a>
-              . Add $5 — enough for 4-5 reviews with an open-source model or 1 review with Claude. Unused credits don&apos;t
+              . Add at least $10 — enough for ~10 reviews with an open-source
+              model or 3–5 reviews with Claude. Unused credits don&apos;t
               expire.
             </p>
 
@@ -380,7 +381,7 @@ export default function SetupPage() {
                       color: "var(--chalk)",
                     }}
                   >
-                    $5.00
+                    $10.00
                   </div>
                 </div>
                 <MockButton highlight>Add credits</MockButton>
@@ -513,8 +514,11 @@ export default function SetupPage() {
               , click the{" "}
               <strong style={{ color: "var(--chalk-bright)" }}>&#8942;</strong>
               {" "}menu next to your new key and choose &ldquo;Edit&rdquo;. Set a
-              credit limit (e.g. $5). The key stops working once the limit is
-              hit — zero risk of surprise charges.
+              credit limit of{" "}
+              <strong style={{ color: "var(--chalk-bright)" }}>at least $10</strong>
+              . The key stops working once the limit is hit — zero risk of
+              surprise charges — but set it high enough that a single review
+              doesn&apos;t exhaust it, or the review will fail mid-run.
             </p>
 
             <ChalkSketch annotation="key menu">
@@ -590,7 +594,7 @@ export default function SetupPage() {
                       width: "80px",
                     }}
                   >
-                    $5.00
+                    $10.00
                   </div>
                   <MockButton highlight>Save</MockButton>
                 </div>
@@ -635,6 +639,38 @@ export default function SetupPage() {
                 discarded — it is never stored. But you don&apos;t have to trust
                 us: the per-key limit guarantees it can never spend more than you
                 allow, even in the worst case.
+              </p>
+            </div>
+
+            <div
+              style={{
+                marginTop: "0.75rem",
+                padding: "0.75rem 1rem",
+                background: "rgba(224, 201, 112, 0.06)",
+                borderLeft: "3px solid var(--yellow-chalk)",
+                borderRadius: "0 2px 2px 0",
+              }}
+            >
+              <p
+                style={{
+                  fontFamily: "Georgia, serif",
+                  fontSize: "1rem",
+                  lineHeight: 1.6,
+                  color: "var(--chalk)",
+                  margin: 0,
+                }}
+              >
+                <strong style={{ color: "var(--chalk-bright)" }}>
+                  A note on cost estimates:
+                </strong>{" "}
+                coarse shows an approximate cost before each review (typically
+                $0.25&ndash;$2). That&apos;s a heuristic with a ~15% buffer, not
+                a hard ceiling. Actual cost can run up to ~2&times; the estimate
+                on complex papers depending on how much the model reasons,
+                how the critique agent rewrites comments, and whether
+                proof-verification kicks in for math-heavy sections. If your
+                per-key limit is set right at the estimate, a single review can
+                drain it and fail mid-run. Leave headroom.
               </p>
             </div>
           </Step>


### PR DESCRIPTION
## Summary

Closes #20. Docs-only change to warn users about two related pitfalls in the setup flow:

1. **Per-key spend limit too low** → review fails mid-run with a cryptic error after the user has already been waiting 5-15 minutes. We were recommending \`$5\` on the setup page; bumped to \`$10\`.
2. **Cost estimates are approximate, not a hard ceiling** → real variance can approach 2x the estimate on complex papers. The existing wording implied the estimate was reliable.

## Changes

- **\`web/src/app/setup/page.tsx\`**
  - Step 3 (credits): recommended top-up raised from \`$5\` → \`$10\`, text updated to reflect real per-review costs
  - Step 4 (spend limit): recommended limit raised from \`$5\` → \`$10\`, bolded the "at least $10" guidance, added text explaining that too-low a limit fails the review mid-run
  - New yellow-bordered callout below the existing "Why this matters" block that explicitly warns that cost estimates are approximate and actual cost can run up to ~2x on complex papers
  - Mock screenshots updated from \`$5.00\` → \`$10.00\` for consistency
- **\`README.md\`**
  - New blockquote under "API keys" with the spend-limit warning
  - New paragraph under "Cost" explaining that actual costs can exceed the estimate

## Test plan

- [x] \`npx tsc --noEmit\` clean on web (no new TS errors)
- [ ] Visual check on the rendered setup page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)