### PR TITLE
docs(setup): correct Claude review count to 2 per $10

### DIFF
--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -356,7 +356,7 @@ export default function SetupPage() {
                 Settings → Credits
               </a>
               . Add at least $10 — enough for ~10 reviews with an open-source
-              model or 3–5 reviews with Claude. Unused credits don&apos;t
+              model or 2 reviews with Claude. Unused credits don&apos;t
               expire.
             </p>
 


### PR DESCRIPTION
Claude runs are ~$5 each in practice (model reasoning, long prompts, critique rewrites), so $10 covers 2 reviews with headroom, not 3-5. One-line text fix on the setup page's credits step.