### PR TITLE
docs(setup): soften Step 4 opening to reference earlier $10 mention

### DIFF
--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -513,8 +513,8 @@ export default function SetupPage() {
               </a>
               , click the{" "}
               <strong style={{ color: "var(--chalk-bright)" }}>&#8942;</strong>
-              {" "}menu next to your new key and choose &ldquo;Edit&rdquo;. Set a
-              credit limit of{" "}
+              {" "}menu next to your new key and choose &ldquo;Edit&rdquo;.
+              Again, we recommend setting a credit limit of{" "}
               <strong style={{ color: "var(--chalk-bright)" }}>at least $10</strong>
               . The key stops working once the limit is hit — zero risk of
               surprise charges — but set it high enough that a single review


### PR DESCRIPTION
Small copy tweak: Step 4 now reads "Again, we recommend setting a credit limit of **at least $10**" instead of the fresh-instruction phrasing, since Step 3 already mentioned the $10 figure.