### PR TITLE
feat(web): log in with openrouter (OAuth PKCE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **Web: Log in with OpenRouter** — the submission form now has a "Log in with OpenRouter" button that runs OpenRouter's browser-only OAuth PKCE flow and fills in the API key automatically. The returned key is stored in the browser's localStorage so users stay logged in across visits; a "Log out" control clears it. The manual paste field is kept as a fallback for users who prefer to use a scoped key. The server contract is unchanged — the key is still only sent in the `/api/submit` body when a review is submitted and never persisted server-side. Closes #12.
+
 ### Changed
 
 - **Mistral OCR is now OpenRouter-only** — removed the `_extract_mistral_direct` backend that tried to hit Mistral's API directly with a `MISTRAL_API_KEY`. All PDF OCR now routes through OpenRouter's `file-parser` plugin, so users only ever need an `OPENROUTER_API_KEY`. The OCR → Docling fallback chain is unchanged for offline use.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,8 +1,22 @@
 import type { NextConfig } from "next";
 
+// Next.js Fast Refresh uses eval() in dev, so 'unsafe-eval' is required there.
+// Production keeps the strict policy.
+const isDev = process.env.NODE_ENV !== "production";
+const scriptSrc = [
+  "script-src",
+  "'self'",
+  "'unsafe-inline'",
+  isDev ? "'unsafe-eval'" : null,
+  "https://www.googletagmanager.com",
+  "https://cdnjs.cloudflare.com",
+]
+  .filter(Boolean)
+  .join(" ");
+
 const cspDirectives = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdnjs.cloudflare.com",
+  scriptSrc,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
   "font-src 'self'",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -5,7 +5,9 @@ import { useDropzone } from "react-dropzone";
 import { useRouter } from "next/navigation";
 import { CharcoalRule, HeroMarks } from "@/components/charcoal";
 import ModelPicker from "@/components/ModelPicker";
+import OpenRouterLoginButton from "@/components/OpenRouterLoginButton";
 import { estimateTokensFromPdf, estimateTokensFromText, estimateTokensFromDocx, estimateTokensFromEpub, getModelPricing, estimateReviewCost } from "@/lib/estimateCost";
+import { beginLogin, completeLogin, loadStoredKey, saveStoredKey, clearStoredKey } from "@/lib/openrouterAuth";
 
 /* ── Split-flap AI name display ────────────────────────────── */
 const AI_NAMES = ["Claude,", "Gemini,", "Qwen,", "ChatGPT,", "DeepSeek,", "Kimi,", "Grok,", "MiniMax,", "Mistral,", "Llama,"];
@@ -168,6 +170,7 @@ export default function Home() {
   const [costEstimate, setCostEstimate] = useState<number | null>(null);
   const [costLoading, setCostLoading] = useState(false);
   const tokenCacheRef = useRef<{ name: string; size: number; tokens: number } | null>(null);
+  const oauthConsumedRef = useRef(false);
   const [systemStatus, setSystemStatus] = useState<{
     accepting: boolean; banner: string | null; activeReviews: number; capacity: number;
   } | null>(null);
@@ -175,6 +178,40 @@ export default function Home() {
   // Fetch system capacity status on mount
   useEffect(() => {
     fetch("/api/status").then(r => r.json()).then(setSystemStatus).catch(() => {});
+  }, []);
+
+  // Hydrate OpenRouter key from localStorage and handle OAuth callback (?code=...)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const stored = loadStoredKey();
+
+    if (!code) {
+      if (stored) setApiKey(stored);
+      return;
+    }
+
+    if (oauthConsumedRef.current) return;
+    oauthConsumedRef.current = true;
+    // Strip ?code= immediately so a mid-flight reload won't re-submit a consumed code.
+    window.history.replaceState({}, "", window.location.pathname);
+
+    completeLogin(code)
+      .then((key) => {
+        setApiKey(key);
+        try {
+          saveStoredKey(key);
+        } catch {
+          setError(
+            "Logged in, but couldn't save the key to your browser. You'll need to log in again next visit.",
+          );
+        }
+      })
+      .catch((err) => {
+        console.error("OpenRouter login failed", err);
+        setError("OpenRouter login failed. Please try again or paste a key manually.");
+        if (stored) setApiKey(stored);
+      });
   }, []);
 
   const onDrop = useCallback((accepted: File[]) => {
@@ -652,6 +689,34 @@ export default function Home() {
                     get one →
                   </a>
                 </FieldLabel>
+                <div style={{ marginBottom: "0.9rem" }}>
+                  <OpenRouterLoginButton
+                    apiKey={apiKey}
+                    onLogin={() => {
+                      beginLogin(window.location.origin + "/").catch((err) => {
+                        setError(
+                          `OpenRouter login could not start: ${err instanceof Error ? err.message : String(err)}`,
+                        );
+                      });
+                    }}
+                    onLogout={() => {
+                      clearStoredKey();
+                      setApiKey("");
+                    }}
+                  />
+                </div>
+                {!apiKey && (
+                  <p
+                    style={{
+                      fontFamily: "var(--font-chalk)",
+                      fontSize: "1rem",
+                      color: "var(--dust)",
+                      margin: "0 0 0.4rem",
+                    }}
+                  >
+                    — or paste a key —
+                  </p>
+                )}
                 <input
                   type="password"
                   required
@@ -669,7 +734,7 @@ export default function Home() {
                     marginTop: "0.4rem",
                   }}
                 >
-                  Used once. Never stored.
+                  Stored on your device only. Never saved on our servers.
                 </p>
               </div>
             </div>

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -266,6 +266,32 @@ export default function SetupPage() {
             Takes about 2 minutes. You&apos;ll need a credit card for ~$1 in
             credits.
           </p>
+          <div
+            style={{
+              marginTop: "1.25rem",
+              padding: "0.75rem 1rem",
+              background: "rgba(224, 201, 112, 0.06)",
+              borderLeft: "3px solid var(--yellow-chalk)",
+              borderRadius: "0 2px 2px 0",
+            }}
+          >
+            <p
+              style={{
+                fontFamily: "Georgia, serif",
+                fontSize: "1rem",
+                lineHeight: 1.6,
+                color: "var(--chalk)",
+                margin: 0,
+              }}
+            >
+              <strong style={{ color: "var(--chalk-bright)" }}>Faster option:</strong>{" "}
+              on the main form you can click{" "}
+              <strong style={{ color: "var(--chalk-bright)" }}>&ldquo;Log in with OpenRouter&rdquo;</strong>{" "}
+              to authorize coarse and skip manual key creation. You still need an
+              OpenRouter account with credits (steps 1 and 2 below), and we still
+              recommend setting a per-key spend limit (step 4).
+            </p>
+          </div>
         </section>
 
         <CharcoalRule />

--- a/web/src/components/OpenRouterLoginButton.tsx
+++ b/web/src/components/OpenRouterLoginButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+interface Props {
+  apiKey: string;
+  onLogin: () => void;
+  onLogout: () => void;
+  disabled?: boolean;
+}
+
+export default function OpenRouterLoginButton({ apiKey, onLogin, onLogout, disabled }: Props) {
+  const isLoggedIn = apiKey.trim().length > 0;
+
+  if (isLoggedIn) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.75rem",
+          fontFamily: "var(--font-chalk)",
+          fontSize: "1.05rem",
+          color: "var(--yellow-chalk)",
+        }}
+      >
+        <span aria-live="polite">Connected to OpenRouter</span>
+        <button
+          type="button"
+          onClick={onLogout}
+          style={{
+            background: "transparent",
+            color: "var(--dust)",
+            border: "none",
+            padding: 0,
+            fontFamily: "var(--font-chalk)",
+            fontSize: "1.05rem",
+            textDecoration: "underline",
+            cursor: "pointer",
+          }}
+        >
+          Log out
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onLogin}
+      disabled={disabled}
+      style={{
+        background: "var(--yellow-chalk)",
+        color: "var(--board)",
+        border: "none",
+        padding: "0.6rem 1.25rem",
+        fontFamily: "var(--font-chalk)",
+        fontSize: "1.05rem",
+        fontWeight: 600,
+        cursor: disabled ? "not-allowed" : "pointer",
+        borderRadius: "2px",
+        transition: "background 0.2s, color 0.2s",
+      }}
+    >
+      Log in with OpenRouter →
+    </button>
+  );
+}

--- a/web/src/lib/openrouterAuth.ts
+++ b/web/src/lib/openrouterAuth.ts
@@ -1,0 +1,78 @@
+// OpenRouter OAuth PKCE helper.
+// Reference: https://github.com/OpenRouterTeam/skills/blob/main/skills/openrouter-oauth/SKILL.md
+
+const AUTH_URL = "https://openrouter.ai/auth";
+const KEY_EXCHANGE_URL = "https://openrouter.ai/api/v1/auth/keys";
+const VERIFIER_STORAGE_KEY = "coarse.or_verifier";
+const API_KEY_STORAGE_KEY = "coarse.or_key";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function sha256(input: string): Promise<Uint8Array> {
+  const data = new TextEncoder().encode(input);
+  const hash = await window.crypto.subtle.digest("SHA-256", data);
+  return new Uint8Array(hash);
+}
+
+async function generatePkcePair(): Promise<{ verifier: string; challenge: string }> {
+  const randomBytes = new Uint8Array(32);
+  window.crypto.getRandomValues(randomBytes);
+  const verifier = base64UrlEncode(randomBytes);
+  const challenge = base64UrlEncode(await sha256(verifier));
+  return { verifier, challenge };
+}
+
+export async function beginLogin(callbackUrl: string): Promise<void> {
+  if (!isBrowser()) return;
+  if (!window.crypto || !window.crypto.subtle) {
+    throw new Error("Web Crypto API not available (needs HTTPS or localhost)");
+  }
+  window.sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
+  const { verifier, challenge } = await generatePkcePair();
+  window.sessionStorage.setItem(VERIFIER_STORAGE_KEY, verifier);
+  const url =
+    `${AUTH_URL}?callback_url=${encodeURIComponent(callbackUrl)}` +
+    `&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256`;
+  window.location.assign(url);
+}
+
+export async function completeLogin(code: string): Promise<string> {
+  if (!isBrowser()) throw new Error("completeLogin called outside the browser");
+  const verifier = window.sessionStorage.getItem(VERIFIER_STORAGE_KEY);
+  if (!verifier) throw new Error("Missing PKCE verifier");
+  const res = await fetch(KEY_EXCHANGE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, code_verifier: verifier, code_challenge_method: "S256" }),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenRouter key exchange failed (${res.status})`);
+  }
+  const data = (await res.json()) as { key?: string };
+  if (!data.key) throw new Error("OpenRouter response missing key");
+  window.sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
+  return data.key;
+}
+
+export function loadStoredKey(): string | null {
+  if (!isBrowser()) return null;
+  return window.localStorage.getItem(API_KEY_STORAGE_KEY);
+}
+
+export function saveStoredKey(key: string): void {
+  if (!isBrowser()) return;
+  window.localStorage.setItem(API_KEY_STORAGE_KEY, key);
+}
+
+export function clearStoredKey(): void {
+  if (!isBrowser()) return;
+  window.localStorage.removeItem(API_KEY_STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary

- Adds a "Log in with OpenRouter" button to the web submission form that runs OpenRouter's browser-only OAuth PKCE flow (reference: [OpenRouterTeam/skills](https://github.com/OpenRouterTeam/skills/blob/main/skills/openrouter-oauth/SKILL.md)), auto-fills the API key field, and persists the returned key in `localStorage` so users stay logged in across visits. Manual paste is kept as a fallback. Closes #12.
- Fixes a dev-mode CSP bug discovered during verification: `'unsafe-eval'` is now conditionally allowed in `script-src` when `NODE_ENV !== "production"` so Next.js Fast Refresh can work. The production policy is unchanged.
- Security-reviewed: server contract unchanged (key is still only sent in the `/api/submit` body and never persisted server-side); verifier lives in `sessionStorage` and is rotated on each login attempt; URL is stripped of `?code=` before awaiting the key exchange; `localStorage.setItem` quota failures degrade gracefully; stale stored keys are not surfaced during an in-flight callback.

## Test plan

- [x] `npm run build` green in `web/`
- [x] Python `pytest tests/` still passes (413 tests, no Python code touched)
- [x] Manual end-to-end: click "Log in with OpenRouter" → redirected to OpenRouter auth page with correct PKCE params → complete login → redirected back to `/` with the "Connected to OpenRouter" chip showing and `?code=` stripped
- [x] Reload page while logged in: state persists via `localStorage`
- [x] Log out: chip disappears, paste field clears, `coarse.or_key` removed from devtools
- [ ] Reviewer: confirm the production CSP response header is unchanged (`NODE_ENV=production next build` → inspect headers)
- [ ] Reviewer: manual paste path still works (paste a key, submit a review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)