### PR TITLE
release: v1.1.2

### DIFF
--- a/.claude/commands/architecture-review.md
+++ b/.claude/commands/architecture-review.md
@@ -1,0 +1,260 @@
+# Architecture Review for coarse
+
+Macro-level structural review of the `src/coarse/` package. Run when you've
+just landed a big feature, added a new agent, or are about to reshape the
+pipeline. This is the counterpart to `/module-review` — that one looks at a
+single file, this one looks at how the package fits together.
+
+coarse is small (~20 modules), so this command doesn't need a long-running
+orchestrator script. It uses 1 quick Python AST scan + 3 parallel in-session
+agents via the Agent tool.
+
+## Arguments
+
+`$ARGUMENTS`:
+- `/architecture-review` — full review with the 3-agent panel (~$1.50)
+- `/architecture-review --scan-only` — import graph + layer check, no LLM
+- `/architecture-review --scope coupling,data-flow` — restrict which agents run
+
+## Package layer rules
+
+These rules are enforced by the static scan in Step 1. Each is either HIGH
+(structural) or MEDIUM (smell).
+
+**Structural (HIGH):**
+1. **`models.py` has zero internal dependencies.** It must not `from coarse ...` anything. It is the single source of truth for model IDs.
+2. **No import cycles.** Anywhere.
+3. **`agents/*.py` must not import from** `pipeline.py`, `cli.py`, `synthesis.py`, `extraction.py`, `extraction_qa.py`. They run before the orchestrator and must not close that loop.
+4. **`pipeline.py` is the orchestrator.** Only `cli.py`, `__init__.py`, `__main__.py`, and `deploy/*.py` may import from it.
+
+**Smell (MEDIUM — the LLM agent judges whether to act):**
+5. **No file larger than 800 lines** in `src/coarse/`. Over that → flag for Agent C (simplification) to decide whether to split.
+6. **`types.py` may import from `models.py` only.** Other imports are a smell worth explaining.
+7. **`prompts.py` may import from `types.py` and `models.py` only** (for type hints on prompt-builder functions).
+
+## Process
+
+### Step 1: Static AST scan
+
+Run this inline — a ~50-line Python block that parses every `.py` under
+`src/coarse/` and builds the import graph. Write it as a heredoc and pipe to
+python3; no new script file needed. Report:
+
+- **Cycles**: list any strongly connected component with > 1 node
+- **Layer violations**: flag any edge that breaks rules 1-6 above
+- **Oversized files**: files over 800 lines
+- **Coupling hotspots**: the 3 modules with the most in-edges (fan-in)
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && python3 <<'PY'
+import ast
+from pathlib import Path
+
+root = Path("src/coarse")
+AGENT_DENY = {"pipeline", "cli", "synthesis", "extraction", "extraction_qa"}
+PIPELINE_CALLERS = {"cli", "__init__", "__main__"}  # plus deploy/*.py
+TYPES_ALLOW = {"models"}
+PROMPTS_ALLOW = {"models", "types"}
+
+graph: dict[str, set[str]] = {}
+sizes: dict[str, int] = {}
+for p in sorted(root.rglob("*.py")):
+    mod = p.relative_to(root).with_suffix("").as_posix().replace("/", ".")
+    src = p.read_text()
+    sizes[mod] = src.count("\n")
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        continue
+    imports: set[str] = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.ImportFrom) and n.module and n.module.startswith("coarse"):
+            imports.add(n.module.removeprefix("coarse.").split(".")[0] or "")
+        elif isinstance(n, ast.Import):
+            for a in n.names:
+                if a.name.startswith("coarse."):
+                    imports.add(a.name.removeprefix("coarse.").split(".")[0])
+    graph[mod] = {i for i in imports if i}
+
+structural: list[str] = []
+smells: list[str] = []
+for mod, imps in graph.items():
+    name = mod.split(".")[-1]
+    if name == "models" and imps:
+        structural.append(f"HIGH: models.py imports {sorted(imps)} (must have zero internal deps)")
+    if name == "types" and imps - TYPES_ALLOW:
+        smells.append(f"MEDIUM: types.py imports {sorted(imps - TYPES_ALLOW)} (only models.py is allowed)")
+    if name == "prompts" and imps - PROMPTS_ALLOW:
+        smells.append(f"MEDIUM: prompts.py imports {sorted(imps - PROMPTS_ALLOW)} (only models.py, types.py allowed)")
+    if mod.startswith("agents.") and imps & AGENT_DENY:
+        structural.append(f"HIGH: {mod} imports {sorted(imps & AGENT_DENY)} (agents must not import orchestration)")
+
+# cycles via iterative DFS
+WHITE, GRAY, BLACK = 0, 1, 2
+color = {m: WHITE for m in graph}
+cycles: list[list[str]] = []
+def resolve(name: str) -> str | None:
+    if name in graph:
+        return name
+    for m in graph:
+        if m == name or m.endswith("." + name):
+            return m
+    return None
+def dfs(start: str) -> None:
+    stack = [(start, iter(graph.get(start, ())))]
+    path = [start]
+    color[start] = GRAY
+    while stack:
+        node, it = stack[-1]
+        try:
+            nxt = next(it)
+        except StopIteration:
+            color[node] = BLACK
+            stack.pop()
+            path.pop()
+            continue
+        tgt = resolve(nxt)
+        if not tgt:
+            continue
+        if color.get(tgt) == GRAY:
+            i = path.index(tgt)
+            cycles.append(path[i:] + [tgt])
+        elif color.get(tgt) == WHITE:
+            color[tgt] = GRAY
+            path.append(tgt)
+            stack.append((tgt, iter(graph.get(tgt, ()))))
+for m in list(graph):
+    if color[m] == WHITE:
+        dfs(m)
+
+fan_in = {m: 0 for m in graph}
+for imps in graph.values():
+    for i in imps:
+        tgt = resolve(i)
+        if tgt:
+            fan_in[tgt] += 1
+top = sorted(fan_in.items(), key=lambda x: -x[1])[:3]
+oversized = [f"{m} ({n} lines)" for m, n in sizes.items() if n > 800]
+
+print(f"modules: {len(graph)}")
+print(f"oversized (>800 lines): {oversized or 'none'}")
+print(f"structural (HIGH): {structural or 'none'}")
+print(f"smells (MEDIUM): {smells or 'none'}")
+print(f"cycles: {cycles or 'none'}")
+print(f"fan-in leaders: {top}")
+PY
+```
+
+If `$ARGUMENTS` contains `--scan-only`, stop here and report the results.
+
+### Step 2: Launch 3 parallel agents (Agent tool, one message)
+
+All three share the static scan output as context. Budget ~$0.50 each.
+
+**Agent A — Coupling & cohesion**
+*(subagent_type: system-architect)*
+
+Read `src/coarse/pipeline.py`, the `fan-in leaders` from Step 1, and any
+flagged layer violations. Answer:
+- Are any modules doing two unrelated jobs that should be split?
+- Is any pair of modules so tightly coupled they should be merged?
+- Are layer violations accidental (fix in place) or structural (needs rethink)?
+
+Output: ranked proposals with file paths and estimated effort (small/medium/large).
+
+**Agent B — Data flow & type boundaries**
+*(subagent_type: system-architect)*
+
+Read `src/coarse/types.py`, `pipeline.py`, and `synthesis.py`. Trace the path
+of a single `PaperText` → `PaperStructure` → `Review`. Answer:
+- Are there type gaps where a `dict[str, Any]` is being passed that should be
+  a Pydantic model?
+- Are any fields on `Review` / `DetailedComment` computed in more than one
+  place (duplication)?
+- Does every agent return a Pydantic model, or do any return raw strings that
+  need parsing downstream?
+
+Output: ranked violations with `file.py:line`.
+
+**Agent C — Simplification**
+*(subagent_type: refactoring-specialist)*
+
+Read every file flagged as oversized (>800 lines) plus `pipeline.py`. Answer:
+- Where is the 200-line function that could be 50?
+- Where is the abstraction that only has one concrete subclass?
+- Where is the dead code path that never runs?
+- Where is the pre-emptive config flag that was never flipped?
+
+Output: for each suggestion, the current line count vs. the proposed line
+count, and a one-sentence justification.
+
+### Step 3: Adversarial pass (inline, no new agent)
+
+Take the three agent reports and challenge them yourself:
+
+- For each proposal, ask: "does the current code actually have this problem,
+  or is the agent pattern-matching on what it expects to see?"
+- For each refactor: "does the new shape break anything the existing tests
+  depend on?"
+- For each split proposal: "will there be a meaningful API change that
+  breaks callers in `deploy/` or `web/`?"
+
+Cross-reference against CLAUDE.md's documented pipeline — if an agent
+proposes changing the pipeline's phase order, that's an escalation to the
+user, not an auto-approval.
+
+### Step 4: Classify and present
+
+Produce a ranked list:
+
+```
+ARCHITECTURE REVIEW — <branch>
+Modules: <N>  Violations: <N>  Cycles: <N>  Oversized: <N>
+
+Proposals:
+  1. [HIGH  / small ] Split structure.py metadata LLM call into its own module
+     Why: violates single-responsibility; 310 lines including unrelated LLM logic
+     Files: src/coarse/structure.py → src/coarse/structure.py + src/coarse/structure_llm.py
+     Adversarial check: no public API break, all tests scoped to structure.py
+
+  2. [MEDIUM / medium] Remove unused `PaperMetadata.arxiv_id` field
+     Why: never read anywhere in the codebase
+     Files: src/coarse/types.py:47, src/coarse/structure.py (1 ref)
+     Adversarial check: passes — confirmed zero readers via grep
+
+  ...
+```
+
+**Always escalate to the user:**
+- Anything that changes `types.py`, `models.py`, or `pipeline.py` phase order
+- Anything that touches `agents/base.py` (ABC — affects every agent)
+- Any proposal the adversarial step flagged
+- Any proposal with effort = large
+
+**Auto-apply (after telling the user what you're about to do):**
+- Removing genuinely dead code you verified with grep
+- Tightening a Pydantic field type (e.g., `str` → `Literal[...]`)
+- Moving an obvious utility to a more natural home
+
+### Step 5: Apply approved changes and verify
+
+For each approved change:
+1. Edit in place
+2. Run `uv run pytest tests/ -v`
+3. Run `python3 scripts/security_scanner.py`
+4. If both pass, commit with a conventional-commits message scoped to `arch`
+
+Stop and report if any change breaks tests.
+
+## Important notes
+
+- **Don't use subprocess parallelism.** Launch the 3 agents in-session via
+  the Agent tool, one message with 3 tool uses. That's how coarse does
+  parallelism — not `claude -p` subprocesses.
+- **One pass per session.** Unlike hsf's multi-round loop, a single
+  architecture review should produce a finite action list. If the review
+  finds so much that it needs multiple rounds, that's a signal the user
+  should prioritize manually.
+- **Respect CLAUDE.md's "simplicity first" rule.** When in doubt between
+  two proposals, favour the one that removes code rather than the one that
+  reorganises it.

--- a/.claude/commands/module-review.md
+++ b/.claude/commands/module-review.md
@@ -1,0 +1,179 @@
+# Module Review for coarse
+
+Focused code review of a single module (or all modules) against coarse's
+11-point bug checklist. Use this when you want a thorough audit of one file
+before a release, after a big refactor, or when you suspect a specific module
+has drift.
+
+This is the counterpart to `/architecture-review` — that one looks at how
+modules fit together, this one looks at one module's internal quality.
+
+## Arguments
+
+`$ARGUMENTS`:
+- `/module-review --module src/coarse/synthesis.py` — single module (default use)
+- `/module-review --all` — walk every module in dependency order, ask before each
+- `/module-review --changed` — only modules touched on this branch vs. `dev`
+- `/module-review --review-only` — produce a report, no fixes
+
+## The 11-point bug checklist
+
+Every module is reviewed against these. Each violation is a finding with
+severity CRITICAL / HIGH / MEDIUM / LOW.
+
+1. **Model IDs only in `models.py`.** Any `"provider/name"` literal outside
+   `src/coarse/models.py` is a violation of CLAUDE.md's hard rule.
+2. **LLM calls go through `LLMClient`.** No direct `litellm.completion(...)`
+   outside `src/coarse/llm.py`.
+3. **Structured output uses `instructor` + Pydantic.** No raw JSON parsing
+   of LLM responses outside `llm.py`.
+4. **Prompts live in `prompts.py`.** Scattered prompt strings in agents or
+   pipeline code is a violation.
+5. **No `print()` in library code.** CLI code uses `rich`; internals use
+   `logging`. `print()` is only allowed in `cli.py` top-level flow.
+6. **Every `.py` in `src/coarse/` has a matching `tests/test_{name}.py`.**
+   Missing test file is a HIGH finding.
+7. **Context managers for resources.** `ThreadPoolExecutor`, file handles,
+   `requests.Session` — all must use `with` statements.
+8. **Cost tracking uses `LLMClient.cumulative_cost`.** No manual per-call
+   cost arithmetic outside `llm.py`.
+9. **API keys through `resolve_api_key()`.** No bare `os.getenv("*_API_KEY")`
+   outside `config.py`.
+10. **OCR / extraction paths handle empty or garbled output.** `extraction.py`
+    and `extraction_qa.py` must degrade gracefully, never raise on empty.
+11. **Verbatim quotes pass `quote_verify.py`.** Any agent that produces a
+    `DetailedComment.quote` must run it through `quote_verify.verify_quote`
+    before returning.
+
+## Process
+
+### Step 1: Select modules
+
+If `$ARGUMENTS` contains `--module <path>`, target that one file.
+
+If `--changed`:
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git diff dev...HEAD --name-only -- 'src/coarse/*.py'
+```
+
+If `--all`, list every `.py` under `src/coarse/` sorted by fan-in ascending
+(review the most foundational modules first so later reviews can rely on
+them being clean):
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && find src/coarse -name '*.py' -not -name '__init__.py' -not -name '__main__.py'
+```
+
+Present the list to the user and confirm before proceeding if more than 3
+modules are queued.
+
+### Step 2: Per-module review loop
+
+For each selected module, do this sequence. Stop the whole loop if the user
+flags any step.
+
+#### 2a. Read the module and its test
+
+```
+Read src/coarse/<module>.py
+Read tests/test_<module>.py   # HIGH finding if missing
+```
+
+#### 2b. Run the 11-point checklist inline
+
+Go through the checklist in order. For each item, state one of:
+- `[OK]` — no violation found
+- `[FINDING: <severity>] <file>:<line> <description>`
+
+Don't delegate this to a subagent — you're the reviewer. The checklist is
+concrete enough that you can apply it directly.
+
+#### 2c. Run one specialized code-review agent for the subjective pass
+
+Launch a single Agent (subagent_type: code-quality-reviewer) with:
+
+```
+Review <file>.py for:
+  - Dead code (functions/classes never called, unused private helpers)
+  - Duplicated logic that already exists elsewhere in the package
+  - Overly complex functions (>80 lines without clear sub-sections)
+  - Unclear variable names, confusing control flow
+  - Missing type hints on public functions
+  - Error messages that leak implementation details or API response bodies
+
+Context: coarse's development rules from CLAUDE.md — simplicity first,
+surgical changes, minimum code, no speculative abstractions.
+```
+
+#### 2d. Run module-specific tests
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && uv run pytest tests/test_<module>.py -v 2>&1 | tail -20
+```
+
+If any existing test fails, stop and report — something's broken before you
+touched it.
+
+#### 2e. Produce the plan
+
+For each finding, decide one of:
+
+| Decision | When |
+|---|---|
+| **AUTO-FIX** | Mechanical, safe, scoped to the file (e.g., `print` → `logger.info`, missing type hint, unused import, missing `with` on a file handle) |
+| **PROPOSE** | Needs thought (e.g., deduplicating logic, splitting a function). Present to user, wait. |
+| **ESCALATE** | Touches `types.py` / `models.py` / `pipeline.py` / `agents/base.py`, or breaks a public API. User decides. |
+| **DEFER** | Real finding but out of scope for this review (e.g., pre-existing tech debt unrelated to the module's job). Note it, don't fix. |
+
+#### 2f. Apply AUTO-FIXes
+
+Apply every auto-fix in the module. After applying:
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && uv run pytest tests/test_<module>.py -v && uv run ruff check src/coarse/<module>.py && python3 scripts/security_scanner.py --scope model-ids
+```
+
+All three must pass. If any fails, revert the fix that broke it.
+
+#### 2g. Report for this module
+
+```
+MODULE: src/coarse/<module>.py
+  Tests:         <N passing / N total>
+  Checklist:     <N OK>  <N findings>
+  Agent review:  <N additional findings>
+
+  Auto-fixed:    <list with file:line>
+  Proposed:      <list with file:line + reasoning>
+  Escalated:     <list — requires user decision>
+  Deferred:      <list — noted for future>
+```
+
+Then either continue to the next module (if `--all`) or stop.
+
+### Step 3: Final summary
+
+After all queued modules are done (or the loop stops), present:
+
+```
+MODULE REVIEW — <branch>
+Reviewed: <N> modules
+Total findings: <N>
+Auto-fixed: <N>
+Still open: <N> (list with severities)
+
+Next suggested action: <one sentence>
+```
+
+## Important notes
+
+- **Don't touch files outside the module being reviewed** unless the finding
+  is a cross-module auto-fix (e.g., `print()` in a helper that's called from
+  the module under review). State the cross-file edit explicitly before making
+  it.
+- **Don't refactor pre-existing tech debt** the checklist turns up unless
+  it's in scope for this module's review. Note it in `Deferred` and move on.
+- **The 11-point checklist is the source of truth.** If you think a rule is
+  wrong, update the checklist in this file in a separate PR — don't just
+  skip it.
+- **Commit after each module.** Conventional commit message with scope
+  matching the module name: `fix(synthesis): apply module-review auto-fixes`.

--- a/.claude/commands/pre-pr.md
+++ b/.claude/commands/pre-pr.md
@@ -1,91 +1,139 @@
 # Pre-PR Checklist for coarse
 
-Run this before creating a pull request. Reviews code in parallel, fixes issues, ensures tests pass, docs are current, and changelog is updated.
+Run this before creating a pull request. Security gate first, then parallel
+review agents, then lint, tests, doc sync, and changelog.
 
-## Steps
+Base branch is **`dev`**, not `main`. Release PRs from `dev` → `main` are
+handled separately.
+
+## Process
+
+### Step 0: Security gate (BLOCKING)
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && python3 scripts/security_scanner.py
+```
+
+If the scanner reports any `CRITICAL` finding, **halt**. Print the finding,
+tell the user the file and line, and propose a fix. Do not proceed to Step 1
+until the finding is resolved.
+
+`HIGH` and `MEDIUM` findings are reported but don't block (they surface in
+the agent review later). To escalate `HIGH` to blocking for this run, use
+`/pre-pr --strict`.
 
 ### Step 1: Identify what changed
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git diff main...HEAD --stat
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git diff main...HEAD
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git log main..HEAD --oneline
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git diff dev...HEAD --stat
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git diff dev...HEAD
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git log dev..HEAD --oneline
 ```
 
-Use the diff output to identify all modified files. This context is needed for the review agents.
+If the current branch is itself `dev` (we're preparing a release PR into
+`main`), substitute `main` for `dev` in the commands above.
+
+Use the diff output to identify all modified files. Pass this context to the
+review agents in Step 2.
+
+### Step 1.5: Doc-sync check
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && bash scripts/doc-sync-check.sh
+```
+
+If the script exits non-zero, fix the reported issues before proceeding:
+- **Modules missing from CLAUDE.md**: add them to the package structure tree
+- **Missing Unreleased section**: add `## Unreleased` near the top of `CHANGELOG.md`
+- **Version mismatch**: align `pyproject.toml` and `src/coarse/__init__.py`
+- **New model-ID literal**: move it to `src/coarse/models.py` and import the constant
+
+Re-run `doc-sync-check.sh` until it exits 0.
 
 ### Step 2: Launch 5 parallel review agents
 
-Launch ALL of these simultaneously using the Agent tool. Pass the full diff and file list to each agent so they have context.
+Launch ALL of these simultaneously using the Agent tool in one message. Pass
+the full diff and file list to each so they have context.
 
 **Agent 1: Architecture & Integration Review** (subagent_type: system-architect)
 - Does the new code integrate cleanly with existing modules?
-- Are there hidden dependencies or circular imports?
-- Does it follow coarse's patterns: litellm wrapper in llm.py, instructor structured output, Docling extraction, prompts centralized in prompts.py?
-- Are there hardcoded model strings that should use config.py defaults?
-- Are module boundaries clean (agents/ vs pipeline.py vs synthesis.py)?
+- Any hidden dependencies or circular imports?
+- Follows coarse's patterns: `litellm` wrapper in `llm.py`, `instructor` structured output, prompts centralized in `prompts.py`?
+- Any hardcoded model strings that should use `models.py` constants?
+- Are module boundaries clean (`agents/` vs `pipeline.py` vs `synthesis.py`)?
 
 **Agent 2: Code Quality & Style Review** (subagent_type: code-quality-reviewer)
-- Are variable/function names clear and consistent with the codebase?
-- Is there duplicated logic between old and new code paths?
-- Are there unused imports, variables, or dead code introduced by the change?
-- Is error handling consistent with existing patterns?
-- Is the code the minimum necessary to solve the problem (Karpathy principle: simplicity first)?
+- Variable/function names clear and consistent with the codebase?
+- Duplicated logic between old and new code paths?
+- Unused imports, variables, dead code introduced by the change?
+- Error handling consistent with existing patterns?
+- Is the code the minimum necessary to solve the problem (Karpathy principle)?
 
 **Agent 3: Bug & Edge Case Review** (subagent_type: debugging-specialist)
-- Are there unhandled None/empty values from LLM responses or PDF extraction?
-- Is resource cleanup handled properly (ThreadPoolExecutor, file handles)?
-- Are LLM fallback paths correct (e.g., when instructor parsing fails)?
-- Could any code path raise an unhandled exception?
-- Are cost tracking accumulations correct (cumulative vs per-call)?
+- Unhandled None/empty values from LLM responses or PDF extraction?
+- Resource cleanup handled (`ThreadPoolExecutor`, file handles)?
+- LLM fallback paths correct (instructor parsing failures)?
+- Any code path that could raise an unhandled exception?
+- Cost tracking accumulations correct (cumulative vs. per-call)?
 
 **Agent 4: Test Coverage Review** (subagent_type: test-engineer)
-- Are there tests for every new code path?
-- Are edge cases covered (empty sections, missing API keys, malformed PDF, zero-token input)?
-- Do existing tests still cover the refactored code?
-- Does the mock strategy match existing patterns in tests/?
-- Is test data realistic?
+- Tests for every new code path?
+- Edge cases covered (empty sections, missing API keys, malformed PDF, zero-token input)?
+- Existing tests still cover the refactored code?
+- Mock strategy matches existing patterns in `tests/`?
+- Test data realistic?
 
-**Agent 5: Documentation & API Review** (subagent_type: technical-documentation-writer)
-- Are docstrings updated for changed functions?
-- Are new CLI flags documented in cli.py help text?
-- Are there stale comments referencing old behavior?
-- Is CLAUDE.md current (package structure, types, architecture)?
-- Are prompt templates in prompts.py properly documented?
+**Agent 5: Security re-check on diff** (subagent_type: general-purpose)
+- Run `python3 scripts/security_scanner.py --strict --json` and parse the output
+- Cross-reference findings against the diff from Step 1 — do any NEW findings come from lines this branch introduced? (vs. pre-existing findings on `dev`)
+- Check that no new `os.getenv("*_API_KEY")` call bypasses `resolve_api_key`
+- Check that any new HTTP call uses HTTPS + has a timeout
+- Check that any new prompt template separates system instructions from untrusted content
+
+Report all findings back as: `[CRITICAL|HIGH|MEDIUM|LOW] file.py:line — description`.
 
 ### Step 3: Aggregate and prioritize
 
-Collect all findings from the 5 agents and categorize:
+Collect all findings from the 5 agents plus Step 0 scanner output. Categorize:
 - **Critical**: Bugs, data loss, security issues, crashes
-- **High**: Missing tests, broken API contracts, hardcoded values, resource leaks
+- **High**: Missing tests, broken API contracts, hardcoded values, resource leaks, new security findings from Agent 5
 - **Medium**: Style issues, missing docs, code duplication
 - **Low**: Minor naming, comment quality
 
 ### Step 4: Fix Critical and High issues
 
-Fix them directly. For Medium issues, fix if straightforward. For Low issues, note them but skip unless trivial.
+Fix them directly. For Medium issues, fix if straightforward. For Low issues,
+note them but skip unless trivial. If a Critical finding can't be auto-fixed
+(e.g., requires a design decision), **stop and ask the user**.
 
 ### Step 5: Run lint
 
 ```bash
 cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && uv run ruff check src/ tests/
 ```
-Fix any errors. Warnings are acceptable.
+
+Fix errors in files you modified. Pre-existing errors in files you didn't
+touch are out of scope — don't touch them (surgical changes rule).
 
 ### Step 6: Run tests
 
 ```bash
 cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && uv run pytest tests/ -v
 ```
-All tests must pass. If any fail after fixes, fix them.
+
+All tests must pass. If any fail after fixes, fix them or revert the change
+that broke them.
 
 ### Step 7: Version consistency
 
 Verify `pyproject.toml` version matches `src/coarse/__init__.py` `__version__`.
+On feature branches these should NOT change (version bumps happen only on
+release PRs from `dev` to `main`).
 
 ### Step 8: Verify CHANGELOG.md
 
-Check that CHANGELOG.md has an entry for this change under `[Unreleased]` or the current version section. If not, add one. Format:
+Check that `CHANGELOG.md` has an entry for this change under `## Unreleased`.
+If not, add one. Format:
 
 ```markdown
 ### Added / Changed / Fixed
@@ -95,9 +143,10 @@ Check that CHANGELOG.md has an entry for this change under `[Unreleased]` or the
 ### Step 9: Commit any fixes and doc changes
 
 ```bash
-git add -A
-git commit -m "chore: pre-pr review fixes and doc updates"
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git add -A && git commit -m "chore: pre-pr review fixes and doc updates"
 ```
+
+Skip this step if there's nothing new to commit.
 
 ### Step 10: Push and create PR
 
@@ -105,9 +154,9 @@ git commit -m "chore: pre-pr review fixes and doc updates"
 git push -u origin HEAD
 ```
 
-Create the PR with `gh pr create`. Include:
+Create the PR into `dev` with `gh pr create --base dev`. Include:
 - Summary of changes (1-3 bullets)
-- Test plan
+- Test plan (what to verify manually, if anything)
 
 ### Step 11: Report
 
@@ -121,4 +170,13 @@ Output a summary table of review findings:
 | Low      | X     | 0     | N         |
 ```
 
-Then: what was checked, what was fixed, PR URL. List any remaining Medium/Low items the developer should address manually.
+Then: security gate result (clean/findings), doc-sync result (OK/fixed),
+what was checked, what was fixed, PR URL. List any remaining Medium/Low
+items the developer should address manually.
+
+## Important notes
+
+- **Base branch is `dev`** for feature PRs. Only release PRs from `dev` to `main` use `main` as the base.
+- **Step 0 is blocking** — a `CRITICAL` finding stops the pipeline. Use `--strict` to also block on `HIGH`.
+- **Doc-sync is blocking** — fix or revert before continuing.
+- **Don't touch unrelated files** during fix-up steps. The pre-PR review's job is to catch issues in the diff, not refactor the whole repo.

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,158 @@
+# Security Review for coarse
+
+Run a structured security review of the repo. Combines a fast static scanner
+(runs in ~1 second, zero deps) with 3 parallel in-session agents that audit
+key handling, HTTP surface, and prompt injection risks.
+
+coarse handles user-provided API keys and ingests untrusted PDFs, so the goal
+is narrow and concrete: **no secret ever leaves the allowed env files, no
+untrusted PDF content ever reaches an instruction channel, and no dependency
+ships with a known CVE we could have caught.**
+
+## Arguments
+
+`$ARGUMENTS` is passed through. Examples:
+- `/security-review` — full review (static + 3 LLM agents), ~$1.50
+- `/security-review --fast` — static scanner only, zero LLM cost
+- `/security-review --scope secrets,perms` — restrict the static scan
+- `/security-review --strict` — escalate HIGH findings to blocking
+
+## Process
+
+### Step 1: Static scan (always runs)
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && python3 scripts/security_scanner.py $ARGUMENTS
+```
+
+Record every finding. `CRITICAL` = leaked fingerprint found outside `.env`.
+`HIGH` = provider-key pattern, insecure env perms, or model-ID literal in
+`src/coarse/` outside `models.py`. `MEDIUM` = provider-hint false-positive
+zone.
+
+**Halt if any CRITICAL is present.** Do not proceed to Step 2. Report the
+finding, tell the user which file + line, and propose the exact fix (usually
+`chmod 600 <file>` or stripping the line + rotating the key).
+
+### Step 2: Dependency audit (fast mode skips this)
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && uv run --with pip-audit pip-audit --strict 2>&1 | tail -40
+```
+
+`pip-audit` is run via `uv run --with` so it doesn't have to be a permanent
+dev dependency. Report any vulnerabilities at HIGH or CRITICAL CVSS.
+
+### Step 3: Launch 3 parallel LLM agents (skip if `--fast`)
+
+Launch **all three in one message** using the Agent tool (subagent_type:
+general-purpose). Pass each the paths listed below so they don't have to
+search. Budget each agent ~$0.50.
+
+**Agent 1 — API key lifecycle audit**
+
+Read `src/coarse/config.py`, `src/coarse/llm.py`, `src/coarse/cli.py`,
+`src/coarse/extraction.py`, `deploy/modal_worker.py`, and any file under
+`web/api/`. For every path that touches an API key, verify:
+
+1. The key is never passed to `logger.{debug,info,warning,error,exception}`.
+2. The key is never included in `repr()` / `str()` / f-strings that feed into
+   an exception raised from that function.
+3. The key is never written to a cache file (`.extraction_cache.json`,
+   `~/.coarse/config.toml`) unless that file has 0o600 enforced at write time.
+4. 401/403 response handling strips the `Authorization` header before logging
+   or re-raising.
+5. `resolve_api_key` is the only entry point for key lookup (no direct
+   `os.getenv("…_API_KEY")` bypasses).
+
+Output: `file.py:line  [OK|VIOLATION] <description>` per checkpoint, then a
+summary of any violations ranked CRITICAL / HIGH / MEDIUM.
+
+**Agent 2 — HTTP surface audit**
+
+Grep the codebase (`src/`, `deploy/`, `web/`) for every outbound HTTP call:
+`requests.`, `httpx.`, `litellm.completion`, `fetch(`, `axios.`, `urllib`,
+`urlopen`. For each call site, verify:
+
+1. The URL is HTTPS (or an explicit localhost for dev).
+2. No API key is embedded in the URL path or query string.
+3. `verify=False` / `rejectUnauthorized: false` is NOT set.
+4. A timeout is set (or the caller has a documented justification for blocking
+   indefinitely).
+5. Error paths do not echo request headers back to the user.
+
+Output: ranked violations with `file:line` references.
+
+**Agent 3 — Prompt injection audit**
+
+coarse pipes untrusted PDF content into LLM prompts. Read
+`src/coarse/prompts.py` and every agent under `src/coarse/agents/`. For each
+prompt template, verify:
+
+1. System-prompt text and user content live in separate `messages` entries
+   (not concatenated into one string).
+2. Untrusted content is fenced with clear delimiters (e.g., XML tags like
+   `<paper_text>…</paper_text>`) so the model can ignore instructions inside.
+3. No prompt takes user content and interpolates it into a `do this: {content}`
+   format where the content could be interpreted as a directive.
+4. Tool use is either disabled for untrusted-content steps or the tool surface
+   is reviewed (only the scanner's `extraction_qa` uses vision — confirm it
+   cannot be coerced into executing user-supplied instructions).
+
+Output: for each prompt template, `template_name  [SAFE|UNSAFE] <reason>`.
+
+### Step 4: Aggregate + decide
+
+Collect findings from all three agents plus the static scanner. Classify each
+as:
+
+| Severity | Examples |
+|---|---|
+| **CRITICAL** | Leaked fingerprint in tracked file, key printed in logger, `verify=False` on a production call, raw user content in a system prompt |
+| **HIGH** | Provider-key pattern match outside env files, missing timeout on litellm call, untrusted content without delimiter fencing, known-CVE dependency at CVSS ≥ 7 |
+| **MEDIUM** | Pre-existing model-ID hardcode, permissive-but-not-leaking cache write, stale error message that echoes part of an API response |
+| **LOW** | Style / hardening recommendations |
+
+**Always escalate to the user:**
+- Any CRITICAL finding — do not auto-fix; present the plan and wait for approval.
+- Any HIGH finding that would require modifying `src/coarse/llm.py` or `src/coarse/config.py` (these are load-bearing).
+- Any finding in `deploy/` (production path).
+
+**May auto-fix without asking:**
+- Stripping a newly-added secret from an unpushed commit.
+- Adding a `# security: ignore` marker on a line the agent confirmed is a true false positive.
+- Running `chmod 600` on a local env file.
+- Adding a missing timeout to a non-production `httpx.get` call.
+
+### Step 5: Report
+
+Output a single summary block:
+
+```
+Security review: <branch>
+  Static:       <N> findings (CRITICAL=<a> HIGH=<b> MEDIUM=<c>)
+  Dependencies: <N> vulnerable packages (fast: skipped)
+  Key lifecycle:   <N> violations
+  HTTP surface:    <N> violations
+  Prompt injection: <N> violations
+
+  Auto-fixed: <N> (list with file:line)
+  Requires review: <N> (list with file:line and proposed change)
+```
+
+If `/security-review` was invoked as a step from `/pre-pr`, return a terse
+pass/fail signal: `security: OK` or `security: BLOCKED — <one-line reason>`.
+
+## Important notes
+
+- The static scanner has **zero** external deps. If `pip-audit` is missing,
+  Step 2 prints a warning and continues.
+- The fingerprint list in `scripts/security_scanner.py::LEAKED_FINGERPRINTS`
+  is the source of truth. Add a new fingerprint every time a key is scrubbed
+  from the repo.
+- Suppress a true false-positive on a single line with a trailing
+  `# security: ignore` comment (works in `.py`, `.sh`, `.ts`, `.md`).
+- Whole-file exemption requires adding the repo-relative path to
+  `SELF_EXEMPT_PATHS` in the scanner — use sparingly.
+- CI runs `python3 scripts/security_scanner.py --strict` on every PR
+  (`.github/workflows/security.yml`). Keep it green.

--- a/.claude/commands/worktree-start.md
+++ b/.claude/commands/worktree-start.md
@@ -1,6 +1,8 @@
 # Start Worktree for coarse
 
-Create a dedicated git worktree for a new feature or fix. Argument: GitHub issue number or description.
+Create a dedicated git worktree for a new feature or fix. Argument: GitHub
+issue number or description. Worktrees live under `/private/tmp/` and branch
+off `dev`, per CONTRIBUTING.md.
 
 ## Steps
 
@@ -21,36 +23,42 @@ From the issue title, create a branch name:
 - `feat/<issue-number>-<short-description>` for features
 - `fix/<issue-number>-<short-description>` for bugs
 - `docs/<issue-number>-<short-description>` for documentation
+- `chore/<issue-number>-<short-description>` for tooling/CI
 
-### 3. Ensure main is clean
+### 3. Ensure dev is clean and up to date
+
+Feature branches live on `dev`, not `main` (see CONTRIBUTING.md).
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git status && git pull origin main
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git fetch origin dev && git status
 ```
 
-### 4. Create worktree
+### 4. Create worktree off dev
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git worktree add /private/tmp/coarse-<short-description> -b <branch-name>
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && git worktree add /private/tmp/coarse-<issue-number>-<short-description> -b <branch-name> origin/dev
 ```
 
 ### 5. Set up environment
 
 ```bash
-cd /private/tmp/coarse-<short-description> && uv sync --extra dev
+cd /private/tmp/coarse-<issue-number>-<short-description> && uv sync --extra dev
 ```
 
 ### 6. Output reminder
 
 Print:
 ```
-Worktree ready at: /private/tmp/coarse-<description>
-Branch: <branch-name>
+Worktree ready at: /private/tmp/coarse-<issue-number>-<description>
+Branch: <branch-name> (tracking origin/dev)
 Issue: #<number>
 
 Remember:
-- Use full paths for Edit/Write: /private/tmp/coarse-<description>/...
+- Use full paths for Edit/Write: /private/tmp/coarse-<issue-number>-<description>/...
+- The shell cwd resets between Bash calls — prefix file-modifying commands with
+  `cd /private/tmp/coarse-<issue-number>-<description> &&`
 - Run `uv run pytest tests/ -v` before committing
-- Update CHANGELOG.md with your changes
-- Use /pre-pr before creating the pull request
+- Update CHANGELOG.md under ## Unreleased with your changes
+- Use /pre-pr before creating the pull request (Step 0 is a security gate)
+- PR base branch is `dev`, not `main`: `gh pr create --base dev`
 ```

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,28 @@
+name: security
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Static secret + model-ID scan
+        run: python3 scripts/security_scanner.py --strict
+
+      - name: Dependency vulnerability audit (advisory)
+        continue-on-error: true
+        run: |
+          pip install --quiet pip-audit
+          pip-audit --strict --desc 2>&1 | tail -80

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@ dist/
 .DS_Store
 .env
 .coarse/
-.claude/
+
+# Ignore everything inside .claude/ except the shared slash commands and
+# agent definitions, which are team-wide workflow tooling.
+.claude/*
+!.claude/commands
+!.claude/agents
 CLAUDE.md
 *.pdf
 !data/**/*.pdf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Pre-commit hooks for coarse.
+# Install once per clone with: make install-hooks
+# Run on every commit automatically after that.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: detect-private-key
+      - id: check-merge-conflict
+
+  # Coarse's own zero-dep secret scanner — catches known leaked fingerprints
+  # and provider-key patterns before they reach the remote.
+  - repo: local
+    hooks:
+      - id: security-scanner
+        name: security-scanner
+        entry: python3 scripts/security_scanner.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **Automated incident posting to X/Twitter** — new `deploy/incident_monitor.py` Modal app (`coarse-monitor`) that runs every 2 minutes, watches four independent signals (backend error spike, queue stall, Modal `/health` down, upstream provider 5xx pattern), and posts an "investigating" tweet when the backend is actually broken. Auto-resolves (threaded reply) once signals have been clear for 10 minutes. Explicitly ignores user-side errors (bad API keys, spending limits, 429s from the user's own provider) so it never tweets because someone pasted a dead key. Ships in `INCIDENT_MONITOR_MODE=dry_run` by default; flip to `live` via Modal secret once dry-run logs look right. Includes 30 min cooldown between incidents to suppress flapping and an `INCIDENT_MONITOR_ENABLED=false` kill switch.
+- **Structured error classification on failed reviews** — new `reviews.error_category` column distinguishes `user_auth` / `user_quota` / `user_forbidden` / `user_rate_limit` from `provider_5xx` / `extraction` / `backend_timeout` / `backend_unknown`. Classifier lives in `deploy/error_classify.py` so the incident monitor can query it without re-parsing unstructured `error_message` strings. Requires `deploy/migrate_incidents.sql` to be applied to Supabase.
+
+## v1.1.2 — 2026-04-11
+
+Internal tooling release. No user-facing changes to the `coarse` package on
+PyPI — this release ships dev-workflow automation (security scanner, slash
+commands, pre-commit hooks, CI gates) plus a small refactor that re-aligns
+`src/coarse/llm.py` with the "model IDs live in `models.py` only" rule.
+
 ### Fixed
 
 - **`llm.py` no longer hardcodes model IDs** — the `_CUSTOM_MODEL_INFO` dict keyed on literal `"qwen/qwen3.5-plus-02-15"` and `"moonshotai/kimi-k2.5"` now imports `DEFAULT_MODEL` and the new `KIMI_K2_5_MODEL` constant from `coarse.models`, restoring the "model IDs live in `models.py` only" invariant from CLAUDE.md. The security scanner's `hardcoded-model-id` check was also extended to cover `moonshotai`, `kimi`, `groq`, `together`, `xai`, and `cohere` provider prefixes so future drift gets caught.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Added
+
+- **Security scanner + `/security-review` command** — new zero-dep `scripts/security_scanner.py` (stdlib only) scans the repo for known leaked secret fingerprints (stored as SHA-256 hashes, never plaintext), provider-key patterns (OpenAI / Anthropic / Google / OpenRouter / Perplexity / Supabase / Stripe / GitHub / AWS / private keys / URL-embedded creds), insecure `.env` permissions, and model-ID string literals outside `src/coarse/models.py`. Skips docstrings via AST and supports inline `# security: ignore` suppression. Backed by 14 tests in `tests/test_security.py` (synthetic fingerprint via monkeypatch — no real key material in the test fixtures). Runs in CI (`.github/workflows/security.yml --strict`), from `make security`, and from the `/security-review` slash command which adds 3 parallel in-session agents for API-key lifecycle, HTTP surface, and prompt-injection audits.
+- **`/architecture-review` command** — lightweight macro-level structural review with inline AST-based import-graph analysis (cycles, layer violations, oversized files, fan-in leaders) plus 3 parallel in-session agents for coupling, data flow, and simplification.
+- **`/module-review` command** — focused per-module audit against coarse's 11-point bug checklist (model-IDs-only-in-models.py, LLMClient wrapper, instructor/Pydantic, prompts centralization, no-print, test coverage, context managers, cost tracking, resolve_api_key, extraction robustness, quote verification). Supports `--module`, `--changed`, `--all`, `--review-only`.
+- **`scripts/doc-sync-check.sh`** — lightweight bash sync check used by `/pre-pr`: verifies every `src/coarse/*.py` is listed in CLAUDE.md, CHANGELOG has an `## Unreleased` section, `pyproject.toml` version matches `src/coarse/__init__.py`, and no new model-ID literals slipped into the diff outside `models.py`.
+- **Pre-commit hooks** — `.pre-commit-config.yaml` wires ruff, ruff-format, trailing-whitespace, end-of-file-fixer, check-yaml/toml, large-file guard, private-key detector, merge-conflict check, plus the local security scanner. Install with `make install-hooks`.
+- **CI security workflow** — `.github/workflows/security.yml` runs the scanner in `--strict` mode on every push and PR to `main`/`dev`, plus advisory `pip-audit`.
+- **CLAUDE.md: Worktree Discipline + Parallel Development sections** documenting the `/private/tmp/coarse-<slug>/` pattern, full-path rule for Edit/Write, and the 4-concurrent-worktree cap for parallel Claude Code sessions.
+- **CLAUDE.md: Slash Commands section** listing every command and its purpose.
+- **Makefile targets**: `make security`, `make install-hooks`.
+
+### Changed
+
+- **`/pre-pr` upgraded** — new Step 0 is a BLOCKING security gate via `security_scanner.py` (CRITICAL halts, `--strict` also halts on HIGH); new Step 1.5 runs `doc-sync-check.sh`; git diff base fixed from `main...HEAD` to `dev...HEAD` (feature PRs target `dev` per CONTRIBUTING.md); added a 6th review agent that re-runs the scanner against the diff and checks new code for `os.getenv("*_API_KEY")` bypasses, missing HTTP timeouts, and prompt-injection-unsafe templates.
+- **`/worktree-start` bases worktrees off `dev`** (was `main`). Worktree slug format now `coarse-<issue>-<slug>`. Reminder output mentions the shell-cwd-resets-between-Bash-calls trap and the `gh pr create --base dev` convention.
+- **CLAUDE.md package structure** — added the 5 agents that had drifted off the tree (`completeness.py`, `cross_section.py`, `editorial.py`, `contradiction.py`, plus top-level `recall.py`). Marks `crossref.py`, `contradiction.py`, `critique.py` as legacy (superseded by `editorial.py`).
+- **Stripped 10 cached curl commands** containing inline Supabase/OpenRouter secrets from `.claude/settings.local.json` (local-only file, never tracked in git, `.gitignore` already covers `.claude/`). Tightened `.env` and `web/.env.local` permissions from 0o644 → 0o600.
+
 ## v1.1.1 — 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`llm.py` no longer hardcodes model IDs** — the `_CUSTOM_MODEL_INFO` dict keyed on literal `"qwen/qwen3.5-plus-02-15"` and `"moonshotai/kimi-k2.5"` now imports `DEFAULT_MODEL` and the new `KIMI_K2_5_MODEL` constant from `coarse.models`, restoring the "model IDs live in `models.py` only" invariant from CLAUDE.md. The security scanner's `hardcoded-model-id` check was also extended to cover `moonshotai`, `kimi`, `groq`, `together`, `xai`, and `cohere` provider prefixes so future drift gets caught.
+
 ### Added
 
 - **Security scanner + `/security-review` command** — new zero-dep `scripts/security_scanner.py` (stdlib only) scans the repo for known leaked secret fingerprints (stored as SHA-256 hashes, never plaintext), provider-key patterns (OpenAI / Anthropic / Google / OpenRouter / Perplexity / Supabase / Stripe / GitHub / AWS / private keys / URL-embedded creds), insecure `.env` permissions, and model-ID string literals outside `src/coarse/models.py`. Skips docstrings via AST and supports inline `# security: ignore` suppression. Backed by 14 tests in `tests/test_security.py` (synthetic fingerprint via monkeypatch — no real key material in the test fixtures). Runs in CI (`.github/workflows/security.yml --strict`), from `make security`, and from the `/security-review` slash command which adds 3 parallel in-session agents for API-key lifecycle, HTTP surface, and prompt-injection audits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ uv run python -m coarse paper.pdf
 
 ```
 paper (PDF, TXT, MD, TeX, DOCX, HTML, EPUB)
-    → [extraction.py]    Mistral OCR via OpenRouter / Docling fallback → PaperText (markdown)
+    → [extraction.py]    Mistral OCR (OpenRouter) → pdf-text (OpenRouter) → Docling → PaperText (markdown)
     → [extraction_qa.py] Vision LLM spot-check (auto-triggers on garbled text)
     → [structure.py]     Parse headings + LLM → PaperStructure (sections, math detection, domain)
     → [calibrate_domain] Domain-specific review criteria (parallel with literature)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,18 @@ src/coarse/
 ├── pipeline.py              # review_paper() orchestrator
 ├── synthesis.py             # Review → markdown string
 ├── quality.py               # Quality eval against reference (dev only)
+├── recall.py                # Recall eval vs. ground-truth expert reviews (dev only)
 └── agents/
     ├── __init__.py
     ├── base.py              # ReviewAgent ABC + _build_messages helper + prompt caching
     ├── overview.py          # 3-judge panel overview (macro-level feedback, 4-6 issues)
     ├── section.py           # Per-section detailed review
-    ├── crossref.py          # Cross-reference consistency
-    ├── critique.py          # Self-critique quality gate
+    ├── completeness.py      # Flags structural gaps and missing content
+    ├── cross_section.py     # Cross-section synthesis: discussion claims vs formal results
+    ├── editorial.py         # Merged filtering pass (dedup, contradiction, quality, ordering)
+    ├── crossref.py          # Cross-reference consistency (legacy, superseded by editorial)
+    ├── contradiction.py     # Flags comments contradicting the paper's contribution (legacy)
+    ├── critique.py          # Self-critique quality gate (legacy, superseded by editorial)
     ├── verify.py            # Adversarial proof verification (math sections)
     └── literature.py        # Literature search (Perplexity Sonar Pro, arXiv fallback)
 ```
@@ -158,6 +163,58 @@ CI (`.github/workflows/ci.yml`) runs on every push to `main` or `dev` and on eve
 5. **Don't over-engineer.** No abstractions for single-use code. No speculative features.
 6. **Prompts in prompts.py.** All LLM prompt templates go in one file, not scattered.
 7. **Structured output.** Use instructor + Pydantic models for all LLM responses.
+
+## Slash Commands
+
+Workflow automation commands live in `.claude/commands/`. Invoke with a `/`
+in chat.
+
+| Command | Purpose |
+|---|---|
+| `/security-review` | Fingerprint + pattern scan, env perms, key lifecycle audit, HTTP surface audit, prompt-injection check. Runs `scripts/security_scanner.py` + 3 parallel in-session agents. Blocking in `/pre-pr` Step 0. |
+| `/architecture-review` | Static import-graph scan (cycles, layer violations, oversized files) + 3 parallel agents (coupling, data flow, simplification). Escalates structural changes to user. |
+| `/module-review` | Focused per-module audit against the 11-point bug checklist. Supports `--module <path>`, `--changed`, `--all`, `--review-only`. |
+| `/pre-pr` | Blocking checklist before every push: security gate → diff capture → doc-sync → 5 parallel review agents → lint → tests → version → changelog → PR. |
+| `/dev-loop` | Supervised autonomous development loop (existing). |
+| `/worktree-start` | Create a worktree off `dev` for a new feature/fix (existing). |
+
+`scripts/security_scanner.py` is standalone — it runs in CI
+(`.github/workflows/security.yml`) and from `make security` without needing
+a Claude Code session.
+
+## Worktree Discipline
+
+Parallel work happens in ephemeral git worktrees under `/private/tmp/coarse-<slug>/`.
+The main repo stays on `dev` (or `main` for release branches) and is used
+only for read-only exploration.
+
+**Hard rules:**
+
+1. **Never edit files directly in the main worktree** during a feature task.
+   Use `/worktree-start` first, then all edits go through the full worktree path.
+2. **Full paths on every Edit/Write.** `/private/tmp/coarse-<slug>/src/coarse/foo.py`,
+   not `src/coarse/foo.py`. The shell cwd resets between `Bash` calls — `cd` alone
+   doesn't persist, so relative paths break silently.
+3. **Prefix every file-modifying `Bash` command** with
+   `cd /private/tmp/coarse-<slug> &&`.
+4. **Always `uv sync --extra dev`** in the new worktree before running tests or
+   scripts — bare `uv sync` misses the dev extras.
+5. **Merging back**: create PR from the worktree (`gh pr create --base dev`), merge
+   via `gh pr merge --squash`, then `git -C <main-repo> pull origin dev`, then
+   `git worktree remove /private/tmp/coarse-<slug>`.
+
+## Parallel Development
+
+coarse supports multiple concurrent Claude Code sessions as long as each
+session operates in its own worktree.
+
+- **Cap: 4 concurrent worktrees.** Beyond that, merge conflicts start to bite.
+- **Every branch references a GitHub issue.** `/worktree-start <issue-number>`.
+- **Worktree slug format:** `/private/tmp/coarse-<issue-number>-<short-slug>`.
+- **No two worktrees touch the same file** without coordinating through the
+  user — the autopilot doesn't resolve three-way merges.
+- **Cross-worktree state lives only in the repo** (git branches, PRs, issues).
+  Don't rely on `~/.coarse/` or any local path for cross-session coordination.
 
 ## Model Manifest (models.py)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,12 +133,31 @@ Version bumps happen **only on release PRs from `dev` to `main`**. Feature PRs i
 
 ### Pre-PR checklist
 
+If you use Claude Code, run `/pre-pr` — it runs every check below plus the
+security scanner and five parallel review agents. Otherwise, run them
+manually:
+
+- [ ] `python3 scripts/security_scanner.py` reports no CRITICAL findings (or `make security`)
+- [ ] `bash scripts/doc-sync-check.sh` exits 0
 - [ ] `uv run ruff check src/ tests/` passes (or `make lint`)
 - [ ] `uv run pytest tests/ -v` passes (or `make test`)
 - [ ] `CHANGELOG.md` updated under `## Unreleased` in the appropriate subsection (`Added` / `Changed` / `Fixed` / `Removed`)
 - [ ] New code has tests in `tests/test_<module>.py`
 - [ ] Commit messages follow conventional commits
 - [ ] PR targets `dev` (not `main`) — unless you're the maintainer cutting a release
+
+### Claude Code slash commands
+
+Workflow automation lives in `.claude/commands/`. Run with a `/` in chat.
+
+| Command | When to use it |
+|---|---|
+| `/pre-pr` | Before every push. Security gate + doc sync + 5 parallel review agents + lint/tests/changelog. |
+| `/security-review` | Standalone security audit. Blocking gate inside `/pre-pr`; also runs in CI via `.github/workflows/security.yml`. |
+| `/architecture-review` | After a big refactor or new agent. Import graph + layer check + 3 parallel structural agents. |
+| `/module-review` | Focused audit of one module against the 11-point bug checklist. Supports `--module <path>`, `--changed`, `--all`. |
+| `/worktree-start` | Create a new worktree off `dev` for a feature/fix. |
+| `/dev-loop` | Supervised autonomous development loop for component builds. |
 
 ## Submitting a PR
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-all lint format check
+.PHONY: test test-all lint format check security install-hooks
 
 test:
 	uv run pytest tests/ -v
@@ -12,4 +12,10 @@ lint:
 format:
 	uv run ruff format src/ tests/
 
-check: lint test
+security:
+	python3 scripts/security_scanner.py
+
+check: lint security test
+
+install-hooks:
+	uv run --with pre-commit pre-commit install

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure,
 
 ## Version
 
-1.1.1
+1.1.2
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coarse"
-version = "1.1.1"
+version = "1.1.2"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
 license = "MIT"

--- a/scripts/doc-sync-check.sh
+++ b/scripts/doc-sync-check.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Lightweight documentation sync check for coarse.
+# Reports (but does not fix) gaps between source and docs. Run from /pre-pr.
+#
+# Checks:
+#   1. Every .py in src/coarse/ is listed in CLAUDE.md's package-structure tree
+#   2. CHANGELOG.md has an "## Unreleased" section
+#   3. pyproject.toml version matches src/coarse/__init__.py
+#   4. No model-ID literals added to the diff outside src/coarse/models.py
+#
+# Exit codes:
+#   0 = in sync
+#   2 = at least one check failed
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FAIL=0
+
+note() { printf "  %s\n" "$1"; }
+fail() { printf "FAIL: %s\n" "$1" >&2; FAIL=1; }
+
+echo "== doc-sync =="
+
+# 1) Modules listed in CLAUDE.md
+missing_modules=()
+while IFS= read -r -d '' file; do
+    name=$(basename "$file")
+    case "$name" in
+        __init__.py|__main__.py) continue ;;
+    esac
+    if ! grep -qF "$name" CLAUDE.md; then
+        missing_modules+=("$file")
+    fi
+done < <(find src/coarse -name '*.py' -print0)
+
+if [ "${#missing_modules[@]}" -eq 0 ]; then
+    note "[OK] every src/coarse/*.py referenced in CLAUDE.md"
+else
+    fail "modules missing from CLAUDE.md package structure:"
+    printf "       %s\n" "${missing_modules[@]}" >&2
+fi
+
+# 2) CHANGELOG has an Unreleased section
+if grep -qE '^## \[?Unreleased\]?' CHANGELOG.md 2>/dev/null; then
+    note "[OK] CHANGELOG.md has an Unreleased section"
+else
+    fail "CHANGELOG.md is missing a '## Unreleased' section"
+fi
+
+# 3) Version consistency
+py_version=$(grep -E '^version *= *' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+init_version=$(grep -E '__version__ *= *' src/coarse/__init__.py | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$py_version" ] || [ -z "$init_version" ]; then
+    fail "could not parse version from pyproject.toml or src/coarse/__init__.py"
+elif [ "$py_version" != "$init_version" ]; then
+    fail "version mismatch: pyproject.toml=$py_version  __init__.py=$init_version"
+else
+    note "[OK] version $py_version consistent"
+fi
+
+# 4) No new model-ID literals in the diff outside src/coarse/models.py
+base="${DOC_SYNC_BASE:-dev}"
+if git rev-parse --verify "$base" >/dev/null 2>&1; then
+    diff_files=$(git diff --name-only "${base}...HEAD" 2>/dev/null \
+        | grep -E '^src/coarse/.*\.py$' \
+        | grep -v '^src/coarse/models\.py$' || true)
+    if [ -n "$diff_files" ]; then
+        offenders=$(git diff "${base}...HEAD" -- $diff_files \
+            | grep -E '^\+' \
+            | grep -v '^+++' \
+            | grep -Ev '^\+ *#|^\+ *"""|^\+ *\x27\x27\x27' \
+            | grep -Eo '"(openai|anthropic|google|gemini|perplexity|mistral|qwen|openrouter|deepseek)/[^"]+"' \
+            | grep -v '/auto"$' \
+            | sort -u || true)
+        if [ -n "$offenders" ]; then
+            fail "model-ID literal added to src/coarse/ outside models.py:"
+            echo "$offenders" | sed 's/^/       /' >&2
+        else
+            note "[OK] no new model-ID literals in diff"
+        fi
+    else
+        note "[OK] no src/coarse/ changes in diff"
+    fi
+else
+    note "[WARN] base branch '$base' not found; skipping diff checks"
+fi
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+    echo "doc-sync: OK"
+    exit 0
+fi
+echo "doc-sync: FAILED"
+exit 2

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Security scanner for the coarse repo.
+
+Scans for:
+  1. Known leaked secret fingerprints (CRITICAL if found outside env files)
+  2. Generic provider key patterns (OpenAI/Anthropic/Google/OpenRouter/etc.)
+  3. Insecure .env file permissions (should be 0o600)
+  4. Hardcoded model-ID string literals outside src/coarse/models.py
+  5. Real secrets masquerading as placeholders in .env.example
+
+Zero external deps: stdlib only. Runs in under a second on coarse.
+Runnable from CI, pre-commit, and the /security-review slash command.
+
+Exit codes:
+    0  clean (or only MEDIUM/LOW/INFO findings)
+    1  scanner error
+    2  CRITICAL (always) or HIGH (only with --strict) findings present
+
+Suppression: add a trailing `# security: ignore` comment on any line to
+suppress findings on that line. Whole files can be exempted by adding their
+repo-relative path to SELF_EXEMPT_PATHS below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Paths where real secrets are allowed to live (all gitignored env files).
+ALLOWED_SECRET_PATHS = {
+    ".env",
+    ".env.local",
+    "web/.env",
+    "web/.env.local",
+    "web/.env.development.local",
+    "web/.env.production.local",
+}
+
+# Directories never walked.
+SKIP_DIRS = {
+    ".git", ".venv", "venv", "env", "node_modules", "dist", "build",
+    "__pycache__", ".ruff_cache", ".pytest_cache", ".mypy_cache",
+    ".next", ".vercel", ".modal", ".coarse", "reviews", "data",
+    ".extraction_cache",
+}
+
+# Extensions worth opening.
+TEXT_EXTS = {
+    ".py", ".pyi", ".sh", ".bash", ".zsh",
+    ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+    ".json", ".jsonc", ".yaml", ".yml", ".toml",
+    ".md", ".mdx", ".txt", ".rst",
+    ".html", ".css", ".scss",
+    ".ini", ".cfg", ".conf",
+}
+
+# Extensionless or dotfile names to also scan.
+TEXT_BASENAMES = {
+    "Makefile", "Dockerfile", ".gitignore",
+    ".env", ".env.example", ".env.local",
+    ".env.production", ".env.production.local",
+    ".env.development", ".env.development.local",
+}
+
+MAX_FILE_SIZE = 500_000
+
+# Paths where the scanner's own signatures live, so the scanner doesn't flag
+# itself. Paths here are repo-relative posix strings.
+SELF_EXEMPT_PATHS = {
+    "scripts/security_scanner.py",
+    "tests/test_security.py",
+}
+
+# Inline suppression marker.
+IGNORE_MARKER = "security: ignore"
+
+# ---------------------------------------------------------------------------
+# Signatures
+# ---------------------------------------------------------------------------
+
+# Known leaked fingerprints, stored as SHA-256 hashes so the scanner itself
+# never ships the plaintext secret. If a token in a scanned line hashes to
+# one of these values it is flagged CRITICAL regardless of context (unless
+# the file is in ALLOWED_SECRET_PATHS).
+#
+# To register a new leaked key, compute its hash locally:
+#   python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' "$KEY"
+# then add the hash below. NEVER paste the plaintext key into this file.
+LEAKED_FINGERPRINT_HASHES: dict[str, str] = {
+    # Scrubbed from .claude/settings.local.json on 2026-04-10.
+    "42bd174bc504f8f76c9bad6b330b69f4c2a714fc16ece57b25777d0801ba97db":
+        "Supabase service-role key",
+    "b656462688773c2f4a33370e556088dcb3fa4dcd97b5ef2274af8e2239e2526c":
+        "OpenRouter API key",
+}
+
+# Tokenizer used to extract candidate secret strings for hash matching.
+# Matches runs of identifier-like chars (letters, digits, underscore, hyphen,
+# period) of length >= 20 — long enough to cover every real provider key
+# format while skipping common words.
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_.\-]{20,}")
+
+
+def _fingerprint_hits(line: str) -> list[str]:
+    """Return labels of any leaked fingerprint whose hash matches a token
+    in this line. Empty list if nothing matches."""
+    hits: list[str] = []
+    for token in _TOKEN_RE.findall(line):
+        h = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        label = LEAKED_FINGERPRINT_HASHES.get(h)
+        if label:
+            hits.append(label)
+    return hits
+
+# Generic provider key patterns. Matches outside ALLOWED_SECRET_PATHS are HIGH
+# unless a placeholder marker is present on the same line.
+PROVIDER_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    ("OpenAI key",
+     re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{32,}"),
+     "OPENAI_API_KEY"),
+    ("OpenRouter key",
+     re.compile(r"sk-or-v1-[a-f0-9]{40,}"),
+     "OPENROUTER_API_KEY"),
+    ("Anthropic key",
+     re.compile(r"sk-ant-[A-Za-z0-9_-]{40,}"),
+     "ANTHROPIC_API_KEY"),
+    ("Google AI key",
+     re.compile(r"AIza[A-Za-z0-9_-]{35}"),
+     "GEMINI_API_KEY"),
+    ("Perplexity key",
+     re.compile(r"pplx-[A-Za-z0-9]{32,}"),
+     "PERPLEXITY_API_KEY"),
+    ("GitHub token",
+     re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),
+     "GITHUB_TOKEN"),
+    ("AWS access key",
+     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+     "AWS_ACCESS_KEY_ID"),
+    ("Supabase secret",
+     re.compile(r"\bsb_secret_[A-Za-z0-9_]{20,}"),
+     "SUPABASE_SERVICE_ROLE_KEY"),
+    ("Stripe key",
+     re.compile(r"\bsk_(?:test|live)_[A-Za-z0-9]{24,}"),
+     "STRIPE_SECRET_KEY"),
+    ("Private key block",
+     re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"),
+     "PRIVATE_KEY"),
+    ("URL-embedded credentials",
+     re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s:/@]+:[^\s@/]{4,}@"),
+     "URL_CREDS"),
+]
+
+# Lowercased substrings that downgrade a provider-key match to a placeholder.
+PLACEHOLDER_MARKERS = (
+    "xxxxxxxx", "your_key", "your-key", "your_api_key", "your-api-key",
+    "example", "placeholder", "changeme", "replace_me", "<your", "dummy",
+    "sk-or-v1-aaaa", "sk-or-v1-0000", "sk-or-v1-xxxx", "sk-ant-xxxx",
+    "sk-proj-xxxx", "aizax", "pplx-xxxx", "fake", "test_key", "test-key",
+)
+
+# Any "<provider>/<id>" string literal in src/coarse/ outside models.py is a
+# violation of the "model IDs live in models.py only" rule from CLAUDE.md.
+# Excludes `<provider>/auto` which is a routing hint used by resolve_api_key.
+MODEL_ID_PATTERN = re.compile(
+    r'["\'](?:openai|anthropic|google|gemini|perplexity|mistral|qwen|openrouter|deepseek)/'
+    r'(?!auto["\'])[A-Za-z0-9._-]+["\']'
+)
+
+# ---------------------------------------------------------------------------
+# Finding
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Finding:
+    severity: str
+    kind: str
+    path: str
+    line: int
+    message: str
+    excerpt: str = ""
+
+    def fmt(self) -> str:
+        loc = f"{self.path}:{self.line}" if self.line else self.path
+        head = f"[{self.severity}] {self.kind}  {loc}"
+        body = f"  {self.message}"
+        tail = f"\n  > {self.excerpt}" if self.excerpt else ""
+        return f"{head}\n{body}{tail}"
+
+
+SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "INFO": 4}
+
+# ---------------------------------------------------------------------------
+# Walk helpers
+# ---------------------------------------------------------------------------
+
+def _should_scan(path: Path) -> bool:
+    if path.name in TEXT_BASENAMES:
+        return True
+    return path.suffix in TEXT_EXTS
+
+
+def _iter_files(root: Path):
+    """Yield every scannable file under root, including .claude/ and .github/."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = Path(dirpath).relative_to(root)
+        # prune unwanted directories but keep .claude/ and .github/ (dot dirs)
+        pruned = []
+        for d in dirnames:
+            if d in SKIP_DIRS:
+                continue
+            if d.startswith(".") and d not in {".claude", ".github"}:
+                continue
+            pruned.append(d)
+        dirnames[:] = pruned
+        for name in filenames:
+            p = Path(dirpath) / name
+            if not _should_scan(p):
+                continue
+            try:
+                if p.stat().st_size > MAX_FILE_SIZE:
+                    continue
+            except OSError:
+                continue
+            yield p, rel_dir / name
+
+
+def _read_lines(path: Path) -> list[str]:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+
+
+def _excerpt(line: str, maxlen: int = 140) -> str:
+    s = line.strip()
+    return s if len(s) <= maxlen else s[:maxlen] + "…"
+
+
+def _is_allowed_secret_path(rel: Path) -> bool:
+    rel_s = rel.as_posix()
+    return rel_s in ALLOWED_SECRET_PATHS
+
+
+# ---------------------------------------------------------------------------
+# Scanners
+# ---------------------------------------------------------------------------
+
+def scan_secrets(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for abs_path, rel in _iter_files(root):
+        rel_s = rel.as_posix()
+        if rel_s in SELF_EXEMPT_PATHS:
+            continue
+        allowed = _is_allowed_secret_path(rel)
+        for i, line in enumerate(_read_lines(abs_path), start=1):
+            if IGNORE_MARKER in line:
+                continue
+            if not allowed:
+                for label in _fingerprint_hits(line):
+                    findings.append(Finding(
+                        severity="CRITICAL",
+                        kind="leaked-fingerprint",
+                        path=rel_s,
+                        line=i,
+                        message=f"Known leaked {label} present outside allowed env files",
+                        excerpt=_excerpt(line),
+                    ))
+            if allowed:
+                continue
+            lower = line.lower()
+            if any(ph in lower for ph in PLACEHOLDER_MARKERS):
+                continue
+            for label, rx, envname in PROVIDER_PATTERNS:
+                if not rx.search(line):
+                    continue
+                findings.append(Finding(
+                    severity="HIGH",
+                    kind="secret-pattern",
+                    path=rel_s,
+                    line=i,
+                    message=f"{label} literal — move to {envname} env var",
+                    excerpt=_excerpt(line),
+                ))
+                break
+    return findings
+
+
+def scan_env_permissions(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for rel_s in ALLOWED_SECRET_PATHS:
+        p = root / rel_s
+        if not p.exists() or not p.is_file():
+            continue
+        mode = p.stat().st_mode & 0o777
+        if mode & 0o077:
+            findings.append(Finding(
+                severity="HIGH",
+                kind="env-perm",
+                path=rel_s,
+                line=0,
+                message=f"mode {oct(mode)} is group/other-readable; run: chmod 600 {rel_s}",
+            ))
+    return findings
+
+
+def _docstring_line_numbers(source: str) -> set[int]:
+    """Return the set of line numbers that fall inside a docstring.
+
+    Uses the ast module so only genuine module/class/function docstrings count,
+    and string *values* (dict keys, function arguments) are not treated as
+    docstrings. Falls back to an empty set if the file cannot be parsed.
+    """
+    import ast
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+    inside: set[int] = set()
+    def _maybe_add(node: ast.AST) -> None:
+        body = getattr(node, "body", None)
+        if not body:
+            return
+        first = body[0]
+        if (isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)):
+            start = first.lineno
+            end = getattr(first, "end_lineno", start) or start
+            for ln in range(start, end + 1):
+                inside.add(ln)
+    _maybe_add(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            _maybe_add(node)
+    return inside
+
+
+def scan_model_id_literals(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    src = root / "src" / "coarse"
+    if not src.exists():
+        return findings
+    for path in sorted(src.rglob("*.py")):
+        rel = path.relative_to(root)
+        if rel.as_posix() == "src/coarse/models.py":
+            continue
+        source = path.read_text(encoding="utf-8", errors="replace")
+        docstring_lines = _docstring_line_numbers(source)
+        for i, line in enumerate(source.splitlines(), start=1):
+            if i in docstring_lines:
+                continue
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if IGNORE_MARKER in line:
+                continue
+            if MODEL_ID_PATTERN.search(line):
+                findings.append(Finding(
+                    severity="MEDIUM",
+                    kind="hardcoded-model-id",
+                    path=rel.as_posix(),
+                    line=i,
+                    message="Model ID literal outside src/coarse/models.py",
+                    excerpt=_excerpt(line),
+                ))
+    return findings
+
+
+def scan_env_example(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    example = root / ".env.example"
+    if not example.exists():
+        return findings
+    rel = example.relative_to(root).as_posix()
+    for i, line in enumerate(_read_lines(example), start=1):
+        if IGNORE_MARKER in line:
+            continue
+        for label in _fingerprint_hits(line):
+            findings.append(Finding(
+                severity="CRITICAL",
+                kind="env-example-leaked",
+                path=rel,
+                line=i,
+                message=f"Real {label} in .env.example — replace with placeholder",
+                excerpt=_excerpt(line),
+            ))
+        lower = line.lower()
+        if any(ph in lower for ph in PLACEHOLDER_MARKERS):
+            continue
+        for label, rx, _ in PROVIDER_PATTERNS:
+            if rx.search(line):
+                findings.append(Finding(
+                    severity="HIGH",
+                    kind="env-example-real-secret",
+                    path=rel,
+                    line=i,
+                    message=f"{label} in .env.example looks real (no placeholder marker on line)",
+                    excerpt=_excerpt(line),
+                ))
+                break
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def print_human(findings: list[Finding]) -> None:
+    if not findings:
+        print("security: clean")
+        return
+    findings.sort(key=lambda f: (SEVERITY_RANK.get(f.severity, 9), f.path, f.line))
+    for f in findings:
+        print(f.fmt())
+        print()
+    counts = {sev: sum(1 for f in findings if f.severity == sev)
+              for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")}
+    summary = " ".join(f"{k}={v}" for k, v in counts.items())
+    print(f"security: {len(findings)} finding(s)  [{summary}]")
+
+
+def print_json(findings: list[Finding]) -> None:
+    payload = {
+        "findings": [asdict(f) for f in findings],
+        "counts": {
+            sev: sum(1 for f in findings if f.severity == sev)
+            for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO")
+        },
+    }
+    print(json.dumps(payload, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+ALL_SCOPES = ("secrets", "perms", "model-ids", "env-example")
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Zero-dep security scanner for coarse",
+    )
+    ap.add_argument("--root", type=Path, default=REPO_ROOT,
+                    help="Repo root to scan (default: auto-detect).")
+    ap.add_argument("--json", action="store_true", help="Emit JSON for CI.")
+    ap.add_argument("--strict", action="store_true",
+                    help="Exit 2 on HIGH findings (default: only CRITICAL blocks).")
+    ap.add_argument("--scope", default=",".join(ALL_SCOPES),
+                    help=f"Comma-separated scopes: {','.join(ALL_SCOPES)}")
+    args = ap.parse_args(argv)
+
+    scopes = {s.strip() for s in args.scope.split(",") if s.strip()}
+    unknown = scopes - set(ALL_SCOPES)
+    if unknown:
+        print(f"unknown scope(s): {sorted(unknown)}", file=sys.stderr)
+        return 1
+
+    findings: list[Finding] = []
+    try:
+        if "secrets" in scopes:
+            findings.extend(scan_secrets(args.root))
+        if "env-example" in scopes:
+            findings.extend(scan_env_example(args.root))
+        if "perms" in scopes:
+            findings.extend(scan_env_permissions(args.root))
+        if "model-ids" in scopes:
+            findings.extend(scan_model_id_literals(args.root))
+    except Exception as exc:  # noqa: BLE001
+        print(f"scanner error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print_json(findings)
+    else:
+        print_human(findings)
+
+    blocking_sevs = {"CRITICAL", "HIGH"} if args.strict else {"CRITICAL"}
+    blocking = any(f.severity in blocking_sevs for f in findings)
+    return 2 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/security_scanner.py
+++ b/scripts/security_scanner.py
@@ -46,28 +46,68 @@ ALLOWED_SECRET_PATHS = {
 
 # Directories never walked.
 SKIP_DIRS = {
-    ".git", ".venv", "venv", "env", "node_modules", "dist", "build",
-    "__pycache__", ".ruff_cache", ".pytest_cache", ".mypy_cache",
-    ".next", ".vercel", ".modal", ".coarse", "reviews", "data",
+    ".git",
+    ".venv",
+    "venv",
+    "env",
+    "node_modules",
+    "dist",
+    "build",
+    "__pycache__",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".next",
+    ".vercel",
+    ".modal",
+    ".coarse",
+    "reviews",
+    "data",
     ".extraction_cache",
 }
 
 # Extensions worth opening.
 TEXT_EXTS = {
-    ".py", ".pyi", ".sh", ".bash", ".zsh",
-    ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
-    ".json", ".jsonc", ".yaml", ".yml", ".toml",
-    ".md", ".mdx", ".txt", ".rst",
-    ".html", ".css", ".scss",
-    ".ini", ".cfg", ".conf",
+    ".py",
+    ".pyi",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".json",
+    ".jsonc",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".md",
+    ".mdx",
+    ".txt",
+    ".rst",
+    ".html",
+    ".css",
+    ".scss",
+    ".ini",
+    ".cfg",
+    ".conf",
 }
 
 # Extensionless or dotfile names to also scan.
 TEXT_BASENAMES = {
-    "Makefile", "Dockerfile", ".gitignore",
-    ".env", ".env.example", ".env.local",
-    ".env.production", ".env.production.local",
-    ".env.development", ".env.development.local",
+    "Makefile",
+    "Dockerfile",
+    ".gitignore",
+    ".env",
+    ".env.example",
+    ".env.local",
+    ".env.production",
+    ".env.production.local",
+    ".env.development",
+    ".env.development.local",
 }
 
 MAX_FILE_SIZE = 500_000
@@ -96,10 +136,8 @@ IGNORE_MARKER = "security: ignore"
 # then add the hash below. NEVER paste the plaintext key into this file.
 LEAKED_FINGERPRINT_HASHES: dict[str, str] = {
     # Scrubbed from .claude/settings.local.json on 2026-04-10.
-    "42bd174bc504f8f76c9bad6b330b69f4c2a714fc16ece57b25777d0801ba97db":
-        "Supabase service-role key",
-    "b656462688773c2f4a33370e556088dcb3fa4dcd97b5ef2274af8e2239e2526c":
-        "OpenRouter API key",
+    "42bd174bc504f8f76c9bad6b330b69f4c2a714fc16ece57b25777d0801ba97db": "Supabase service-role key",
+    "b656462688773c2f4a33370e556088dcb3fa4dcd97b5ef2274af8e2239e2526c": "OpenRouter API key",
 }
 
 # Tokenizer used to extract candidate secret strings for hash matching.
@@ -120,63 +158,69 @@ def _fingerprint_hits(line: str) -> list[str]:
             hits.append(label)
     return hits
 
+
 # Generic provider key patterns. Matches outside ALLOWED_SECRET_PATHS are HIGH
 # unless a placeholder marker is present on the same line.
 PROVIDER_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
-    ("OpenAI key",
-     re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{32,}"),
-     "OPENAI_API_KEY"),
-    ("OpenRouter key",
-     re.compile(r"sk-or-v1-[a-f0-9]{40,}"),
-     "OPENROUTER_API_KEY"),
-    ("Anthropic key",
-     re.compile(r"sk-ant-[A-Za-z0-9_-]{40,}"),
-     "ANTHROPIC_API_KEY"),
-    ("Google AI key",
-     re.compile(r"AIza[A-Za-z0-9_-]{35}"),
-     "GEMINI_API_KEY"),
-    ("Perplexity key",
-     re.compile(r"pplx-[A-Za-z0-9]{32,}"),
-     "PERPLEXITY_API_KEY"),
-    ("GitHub token",
-     re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),
-     "GITHUB_TOKEN"),
-    ("AWS access key",
-     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-     "AWS_ACCESS_KEY_ID"),
-    ("Supabase secret",
-     re.compile(r"\bsb_secret_[A-Za-z0-9_]{20,}"),
-     "SUPABASE_SERVICE_ROLE_KEY"),
-    ("Stripe key",
-     re.compile(r"\bsk_(?:test|live)_[A-Za-z0-9]{24,}"),
-     "STRIPE_SECRET_KEY"),
-    ("Private key block",
-     re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"),
-     "PRIVATE_KEY"),
-    ("URL-embedded credentials",
-     re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s:/@]+:[^\s@/]{4,}@"),
-     "URL_CREDS"),
+    ("OpenAI key", re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{32,}"), "OPENAI_API_KEY"),
+    ("OpenRouter key", re.compile(r"sk-or-v1-[a-f0-9]{40,}"), "OPENROUTER_API_KEY"),
+    ("Anthropic key", re.compile(r"sk-ant-[A-Za-z0-9_-]{40,}"), "ANTHROPIC_API_KEY"),
+    ("Google AI key", re.compile(r"AIza[A-Za-z0-9_-]{35}"), "GEMINI_API_KEY"),
+    ("Perplexity key", re.compile(r"pplx-[A-Za-z0-9]{32,}"), "PERPLEXITY_API_KEY"),
+    ("GitHub token", re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"), "GITHUB_TOKEN"),
+    ("AWS access key", re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AWS_ACCESS_KEY_ID"),
+    ("Supabase secret", re.compile(r"\bsb_secret_[A-Za-z0-9_]{20,}"), "SUPABASE_SERVICE_ROLE_KEY"),
+    ("Stripe key", re.compile(r"\bsk_(?:test|live)_[A-Za-z0-9]{24,}"), "STRIPE_SECRET_KEY"),
+    (
+        "Private key block",
+        re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"),
+        "PRIVATE_KEY",
+    ),
+    (
+        "URL-embedded credentials",
+        re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s:/@]+:[^\s@/]{4,}@"),
+        "URL_CREDS",
+    ),
 ]
 
 # Lowercased substrings that downgrade a provider-key match to a placeholder.
 PLACEHOLDER_MARKERS = (
-    "xxxxxxxx", "your_key", "your-key", "your_api_key", "your-api-key",
-    "example", "placeholder", "changeme", "replace_me", "<your", "dummy",
-    "sk-or-v1-aaaa", "sk-or-v1-0000", "sk-or-v1-xxxx", "sk-ant-xxxx",
-    "sk-proj-xxxx", "aizax", "pplx-xxxx", "fake", "test_key", "test-key",
+    "xxxxxxxx",
+    "your_key",
+    "your-key",
+    "your_api_key",
+    "your-api-key",
+    "example",
+    "placeholder",
+    "changeme",
+    "replace_me",
+    "<your",
+    "dummy",
+    "sk-or-v1-aaaa",
+    "sk-or-v1-0000",
+    "sk-or-v1-xxxx",
+    "sk-ant-xxxx",
+    "sk-proj-xxxx",
+    "aizax",
+    "pplx-xxxx",
+    "fake",
+    "test_key",
+    "test-key",
 )
 
 # Any "<provider>/<id>" string literal in src/coarse/ outside models.py is a
 # violation of the "model IDs live in models.py only" rule from CLAUDE.md.
 # Excludes `<provider>/auto` which is a routing hint used by resolve_api_key.
 MODEL_ID_PATTERN = re.compile(
-    r'["\'](?:openai|anthropic|google|gemini|perplexity|mistral|qwen|openrouter|deepseek)/'
+    r'["\'](?:openai|anthropic|google|gemini|perplexity|mistral|qwen|openrouter|'
+    r"deepseek|moonshotai|kimi|groq|together|xai|cohere)/"
     r'(?!auto["\'])[A-Za-z0-9._-]+["\']'
 )
 
 # ---------------------------------------------------------------------------
 # Finding
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class Finding:
@@ -200,6 +244,7 @@ SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "INFO": 4}
 # ---------------------------------------------------------------------------
 # Walk helpers
 # ---------------------------------------------------------------------------
+
 
 def _should_scan(path: Path) -> bool:
     if path.name in TEXT_BASENAMES:
@@ -253,6 +298,7 @@ def _is_allowed_secret_path(rel: Path) -> bool:
 # Scanners
 # ---------------------------------------------------------------------------
 
+
 def scan_secrets(root: Path) -> list[Finding]:
     findings: list[Finding] = []
     for abs_path, rel in _iter_files(root):
@@ -265,14 +311,16 @@ def scan_secrets(root: Path) -> list[Finding]:
                 continue
             if not allowed:
                 for label in _fingerprint_hits(line):
-                    findings.append(Finding(
-                        severity="CRITICAL",
-                        kind="leaked-fingerprint",
-                        path=rel_s,
-                        line=i,
-                        message=f"Known leaked {label} present outside allowed env files",
-                        excerpt=_excerpt(line),
-                    ))
+                    findings.append(
+                        Finding(
+                            severity="CRITICAL",
+                            kind="leaked-fingerprint",
+                            path=rel_s,
+                            line=i,
+                            message=f"Known leaked {label} present outside allowed env files",
+                            excerpt=_excerpt(line),
+                        )
+                    )
             if allowed:
                 continue
             lower = line.lower()
@@ -281,14 +329,16 @@ def scan_secrets(root: Path) -> list[Finding]:
             for label, rx, envname in PROVIDER_PATTERNS:
                 if not rx.search(line):
                     continue
-                findings.append(Finding(
-                    severity="HIGH",
-                    kind="secret-pattern",
-                    path=rel_s,
-                    line=i,
-                    message=f"{label} literal — move to {envname} env var",
-                    excerpt=_excerpt(line),
-                ))
+                findings.append(
+                    Finding(
+                        severity="HIGH",
+                        kind="secret-pattern",
+                        path=rel_s,
+                        line=i,
+                        message=f"{label} literal — move to {envname} env var",
+                        excerpt=_excerpt(line),
+                    )
+                )
                 break
     return findings
 
@@ -301,13 +351,15 @@ def scan_env_permissions(root: Path) -> list[Finding]:
             continue
         mode = p.stat().st_mode & 0o777
         if mode & 0o077:
-            findings.append(Finding(
-                severity="HIGH",
-                kind="env-perm",
-                path=rel_s,
-                line=0,
-                message=f"mode {oct(mode)} is group/other-readable; run: chmod 600 {rel_s}",
-            ))
+            findings.append(
+                Finding(
+                    severity="HIGH",
+                    kind="env-perm",
+                    path=rel_s,
+                    line=0,
+                    message=f"mode {oct(mode)} is group/other-readable; run: chmod 600 {rel_s}",
+                )
+            )
     return findings
 
 
@@ -319,23 +371,28 @@ def _docstring_line_numbers(source: str) -> set[int]:
     docstrings. Falls back to an empty set if the file cannot be parsed.
     """
     import ast
+
     try:
         tree = ast.parse(source)
     except SyntaxError:
         return set()
     inside: set[int] = set()
+
     def _maybe_add(node: ast.AST) -> None:
         body = getattr(node, "body", None)
         if not body:
             return
         first = body[0]
-        if (isinstance(first, ast.Expr)
-                and isinstance(first.value, ast.Constant)
-                and isinstance(first.value.value, str)):
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
             start = first.lineno
             end = getattr(first, "end_lineno", start) or start
             for ln in range(start, end + 1):
                 inside.add(ln)
+
     _maybe_add(tree)
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -363,14 +420,16 @@ def scan_model_id_literals(root: Path) -> list[Finding]:
             if IGNORE_MARKER in line:
                 continue
             if MODEL_ID_PATTERN.search(line):
-                findings.append(Finding(
-                    severity="MEDIUM",
-                    kind="hardcoded-model-id",
-                    path=rel.as_posix(),
-                    line=i,
-                    message="Model ID literal outside src/coarse/models.py",
-                    excerpt=_excerpt(line),
-                ))
+                findings.append(
+                    Finding(
+                        severity="MEDIUM",
+                        kind="hardcoded-model-id",
+                        path=rel.as_posix(),
+                        line=i,
+                        message="Model ID literal outside src/coarse/models.py",
+                        excerpt=_excerpt(line),
+                    )
+                )
     return findings
 
 
@@ -384,27 +443,33 @@ def scan_env_example(root: Path) -> list[Finding]:
         if IGNORE_MARKER in line:
             continue
         for label in _fingerprint_hits(line):
-            findings.append(Finding(
-                severity="CRITICAL",
-                kind="env-example-leaked",
-                path=rel,
-                line=i,
-                message=f"Real {label} in .env.example — replace with placeholder",
-                excerpt=_excerpt(line),
-            ))
+            findings.append(
+                Finding(
+                    severity="CRITICAL",
+                    kind="env-example-leaked",
+                    path=rel,
+                    line=i,
+                    message=f"Real {label} in .env.example — replace with placeholder",
+                    excerpt=_excerpt(line),
+                )
+            )
         lower = line.lower()
         if any(ph in lower for ph in PLACEHOLDER_MARKERS):
             continue
         for label, rx, _ in PROVIDER_PATTERNS:
             if rx.search(line):
-                findings.append(Finding(
-                    severity="HIGH",
-                    kind="env-example-real-secret",
-                    path=rel,
-                    line=i,
-                    message=f"{label} in .env.example looks real (no placeholder marker on line)",
-                    excerpt=_excerpt(line),
-                ))
+                findings.append(
+                    Finding(
+                        severity="HIGH",
+                        kind="env-example-real-secret",
+                        path=rel,
+                        line=i,
+                        message=(
+                            f"{label} in .env.example looks real (no placeholder marker on line)"
+                        ),
+                        excerpt=_excerpt(line),
+                    )
+                )
                 break
     return findings
 
@@ -412,6 +477,7 @@ def scan_env_example(root: Path) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Reporting
 # ---------------------------------------------------------------------------
+
 
 def print_human(findings: list[Finding]) -> None:
     if not findings:
@@ -421,8 +487,10 @@ def print_human(findings: list[Finding]) -> None:
     for f in findings:
         print(f.fmt())
         print()
-    counts = {sev: sum(1 for f in findings if f.severity == sev)
-              for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")}
+    counts = {
+        sev: sum(1 for f in findings if f.severity == sev)
+        for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")
+    }
     summary = " ".join(f"{k}={v}" for k, v in counts.items())
     print(f"security: {len(findings)} finding(s)  [{summary}]")
 
@@ -444,17 +512,25 @@ def print_json(findings: list[Finding]) -> None:
 
 ALL_SCOPES = ("secrets", "perms", "model-ids", "env-example")
 
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         description="Zero-dep security scanner for coarse",
     )
-    ap.add_argument("--root", type=Path, default=REPO_ROOT,
-                    help="Repo root to scan (default: auto-detect).")
+    ap.add_argument(
+        "--root", type=Path, default=REPO_ROOT, help="Repo root to scan (default: auto-detect)."
+    )
     ap.add_argument("--json", action="store_true", help="Emit JSON for CI.")
-    ap.add_argument("--strict", action="store_true",
-                    help="Exit 2 on HIGH findings (default: only CRITICAL blocks).")
-    ap.add_argument("--scope", default=",".join(ALL_SCOPES),
-                    help=f"Comma-separated scopes: {','.join(ALL_SCOPES)}")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 2 on HIGH findings (default: only CRITICAL blocks).",
+    )
+    ap.add_argument(
+        "--scope",
+        default=",".join(ALL_SCOPES),
+        help=f"Comma-separated scopes: {','.join(ALL_SCOPES)}",
+    )
     args = ap.parse_args(argv)
 
     scopes = {s.strip() for s in args.scope.split(",") if s.strip()}

--- a/src/coarse/__init__.py
+++ b/src/coarse/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 from coarse.pipeline import review_paper  # noqa: F401

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -143,12 +143,20 @@ def _response_was_billed(resp) -> bool:
     usage = data.get("usage")
     if not isinstance(usage, dict):
         return False
+    # bool is a subclass of int in Python — reject it explicitly so a
+    # malformed `usage: {"total_cost": true}` can't trip the billing guard
+    # on an otherwise-free error response.
+    def _positive_number(val: object) -> bool:
+        return (
+            isinstance(val, (int, float))
+            and not isinstance(val, bool)
+            and val > 0
+        )
+
     for key in ("total_cost", "cost"):
-        val = usage.get(key)
-        if isinstance(val, (int, float)) and val > 0:
+        if _positive_number(usage.get(key)):
             return True
-    total_tokens = usage.get("total_tokens")
-    if isinstance(total_tokens, (int, float)) and total_tokens > 0:
+    if _positive_number(usage.get("total_tokens")):
         return True
     return False
 
@@ -207,7 +215,10 @@ def _post_openrouter_ocr(
     for attempt in range(_OCR_MAX_RETRIES + 1):
         try:
             resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
-        except (requests.ConnectionError, requests.Timeout) as exc:
+        except requests.RequestException as exc:
+            # RequestException is the base class for ConnectionError, Timeout,
+            # ChunkedEncodingError, ContentDecodingError, SSLError, etc. — all
+            # network-layer failures where retry is the right move.
             last_network_exc = exc
             if attempt < _OCR_MAX_RETRIES:
                 wait = _wait_for(attempt)

--- a/src/coarse/llm.py
+++ b/src/coarse/llm.py
@@ -3,6 +3,7 @@
 Wraps litellm + instructor for structured output. Tracks cumulative cost across calls.
 API keys are set in env vars by the caller; litellm picks them up automatically.
 """
+
 from __future__ import annotations
 
 import logging
@@ -15,7 +16,12 @@ import litellm
 from pydantic import BaseModel
 
 from coarse.config import PROVIDER_ENV_VARS, CoarseConfig, load_config
-from coarse.models import JSON_MODE_PREFIXES, MARKDOWN_JSON_PREFIXES
+from coarse.models import (
+    DEFAULT_MODEL,
+    JSON_MODE_PREFIXES,
+    KIMI_K2_5_MODEL,
+    MARKDOWN_JSON_PREFIXES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,13 +32,13 @@ litellm.suppress_debug_info = True
 # litellm.model_cost is the lookup used by _clamp_max_tokens.
 # Values from OpenRouter /api/v1/models (verified 2026-03-04).
 _CUSTOM_MODEL_INFO: dict[str, dict] = {
-    "qwen/qwen3.5-plus-02-15": {
+    DEFAULT_MODEL: {
         "max_tokens": 1_000_000,
         "max_output_tokens": 65_536,
         "input_cost_per_token": 0.26e-6,
         "output_cost_per_token": 1.56e-6,
     },
-    "moonshotai/kimi-k2.5": {
+    KIMI_K2_5_MODEL: {
         "max_tokens": 131_072,
         "max_output_tokens": 32_768,
         "input_cost_per_token": 0.35e-6,

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -10,6 +10,9 @@ Last verified: 2026-03-04
 # Primary review model (routed via OpenRouter for non-direct providers)
 DEFAULT_MODEL = "qwen/qwen3.5-plus-02-15"
 
+# Secondary reasoning model; carries its own litellm cost entry.
+KIMI_K2_5_MODEL = "moonshotai/kimi-k2.5"
+
 # Vision model for post-extraction QA (multimodal, spot-checks Docling output)
 # litellm uses 'gemini/' prefix for Google AI Studio (not 'google/')
 VISION_MODEL = "gemini/gemini-3-flash-preview"
@@ -46,4 +49,3 @@ JSON_MODE_PREFIXES = ("qwen", "deepseek", "mistral", "together", "gemini")
 # These models struggle with both tool-calling and raw JSON but handle
 # markdown-wrapped JSON well.  Also need temperature ≤ 0.1 and higher max_tokens.
 MARKDOWN_JSON_PREFIXES = ("moonshotai", "kimi")
-

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -11,6 +11,7 @@ from coarse.extraction import (
     SUPPORTED_EXTENSIONS,
     _estimate_tokens,
     _extract_latex_regex,
+    _response_was_billed,
     compute_garble_ratio,
     extract_file,
     extract_text,
@@ -485,6 +486,137 @@ def test_ocr_retry_stops_when_response_is_billed(minimal_pdf: Path) -> None:
     # pdf-text fallback is still tried — but the same billing guard applies
     # there too, so it also bails after one call.
     assert pdftext_post_count["n"] == 1
+
+
+# --- _response_was_billed direct unit tests ---
+
+
+def _billed_resp(body: object):
+    """Tiny fake Response whose .json() returns body (or raises if callable)."""
+    r = MagicMock()
+    if callable(body):
+        r.json.side_effect = body
+    else:
+        r.json.return_value = body
+    return r
+
+
+def test_response_was_billed_total_cost_positive():
+    assert _response_was_billed(_billed_resp({"usage": {"total_cost": 0.0042}})) is True
+
+
+def test_response_was_billed_cost_positive():
+    assert _response_was_billed(_billed_resp({"usage": {"cost": 0.01}})) is True
+
+
+def test_response_was_billed_total_tokens_positive():
+    assert _response_was_billed(_billed_resp({"usage": {"total_tokens": 5}})) is True
+
+
+def test_response_was_billed_all_zero():
+    body = {"usage": {"total_cost": 0, "cost": 0.0, "total_tokens": 0}}
+    assert _response_was_billed(_billed_resp(body)) is False
+
+
+def test_response_was_billed_missing_usage_field():
+    assert _response_was_billed(_billed_resp({"choices": []})) is False
+
+
+def test_response_was_billed_usage_is_not_dict():
+    assert _response_was_billed(_billed_resp({"usage": "free"})) is False
+    assert _response_was_billed(_billed_resp({"usage": None})) is False
+    assert _response_was_billed(_billed_resp({"usage": [1, 2, 3]})) is False
+
+
+def test_response_was_billed_json_raises():
+    def raise_value_error():
+        raise ValueError("not json")
+    assert _response_was_billed(_billed_resp(raise_value_error)) is False
+
+
+def test_response_was_billed_response_is_not_dict():
+    assert _response_was_billed(_billed_resp("literal string")) is False
+    assert _response_was_billed(_billed_resp([1, 2, 3])) is False
+
+
+def test_response_was_billed_rejects_bool_total_cost():
+    """bool is a subclass of int in Python — the guard must not be fooled
+    by a malformed `usage: {"total_cost": true}` response, since True would
+    coerce to >0 and kill retries on a free error body."""
+    body = {"usage": {"total_cost": True, "total_tokens": 0}}
+    assert _response_was_billed(_billed_resp(body)) is False
+
+
+def test_response_was_billed_rejects_bool_tokens():
+    body = {"usage": {"total_tokens": True}}
+    assert _response_was_billed(_billed_resp(body)) is False
+
+
+def test_response_was_billed_accepts_float_total_cost():
+    """Real OpenRouter responses report costs as floats; verify we handle them."""
+    body = {"usage": {"total_cost": 0.000001, "total_tokens": 0}}
+    assert _response_was_billed(_billed_resp(body)) is True
+
+
+# --- Backoff cap and fallback-order tests ---
+
+
+def test_ocr_backoff_waits_are_capped_at_max_backoff(minimal_pdf: Path) -> None:
+    """Verify _OCR_MAX_BACKOFF actually caps per-retry waits. Without this
+    test, someone could delete the `min(..., _OCR_MAX_BACKOFF)` in
+    _post_openrouter_ocr and every other test would still pass because
+    they all patch time.sleep to a no-op."""
+    from coarse.extraction import _OCR_MAX_BACKOFF, _OCR_MAX_RETRIES
+
+    timeout_body = _mock_error_response(200, {
+        "error": {"message": "Timed out parsing", "code": 504},
+    })
+    sleep_args: list[float] = []
+
+    def fake_sleep(seconds):
+        sleep_args.append(seconds)
+
+    with patch("requests.post", return_value=timeout_body):
+        with patch("time.sleep", side_effect=fake_sleep):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                with patch.dict(
+                    "sys.modules",
+                    {"docling": None, "docling.document_converter": None},
+                ):
+                    with pytest.raises(ExtractionError):
+                        extract_text(minimal_pdf, use_cache=False)
+
+    # Each engine (mistral-ocr, pdf-text) runs _OCR_MAX_RETRIES sleeps.
+    # Per-engine sequence: 1, 2, 4, 8, 16, 32, 32, 32, 32 (exponential then capped).
+    per_engine = sleep_args[:_OCR_MAX_RETRIES]
+    assert per_engine[:5] == [1.0, 2.0, 4.0, 8.0, 16.0]
+    assert all(w == _OCR_MAX_BACKOFF for w in per_engine[5:]), (
+        f"backoff not capped: tail is {per_engine[5:]}"
+    )
+    # Same pattern repeats for the pdf-text tier.
+    assert sleep_args[_OCR_MAX_RETRIES:2 * _OCR_MAX_RETRIES] == per_engine
+
+
+def test_pdftext_is_not_called_when_mistral_ocr_succeeds(
+    minimal_pdf: Path, mock_ocr_pages,
+) -> None:
+    """pdf-text is strictly a fallback — when mistral-ocr succeeds on the
+    first try, pdf-text must not be hit at all."""
+    success = _mock_ocr_response(mock_ocr_pages)
+    posted_engines: list[str] = []
+
+    def spy_post(url, headers, json, timeout):  # noqa: A002
+        plugins = json.get("plugins") or []
+        engine = plugins[0].get("pdf", {}).get("engine") if plugins else None
+        posted_engines.append(engine)
+        return success
+
+    with patch("requests.post", side_effect=spy_post):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+            result = extract_text(minimal_pdf, use_cache=False)
+
+    assert "# Test Paper" in result.full_markdown
+    assert posted_engines == ["mistral-ocr"]
 
 
 def test_openrouter_ocr_does_not_retry_on_401(minimal_pdf: Path) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,222 @@
+"""Tests for scripts/security_scanner.py.
+
+The scanner is stdlib-only, so these tests import it via importlib directly
+from the scripts directory without adding it to the package.
+
+IMPORTANT: this file must never contain a real API key or a real leaked
+fingerprint. Fingerprint tests use a synthetic fake value whose hash is
+injected into LEAKED_FINGERPRINT_HASHES via monkeypatch for the test's
+lifetime. Pattern tests use strings shaped like provider keys but
+constructed from clearly-synthetic alphabets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+SCANNER_PATH = Path(__file__).resolve().parent.parent / "scripts" / "security_scanner.py"
+
+_spec = importlib.util.spec_from_file_location("security_scanner", SCANNER_PATH)
+assert _spec and _spec.loader
+scanner = importlib.util.module_from_spec(_spec)
+sys.modules["security_scanner"] = scanner  # required before dataclass defs
+_spec.loader.exec_module(scanner)
+
+# Synthetic fingerprint used by fingerprint tests. It is NOT a real key; its
+# only purpose is to match the `sb_secret_` provider pattern so we can
+# exercise the "known leaked" code path. Tests register its hash into the
+# scanner via monkeypatch.
+FAKE_FINGERPRINT = "sb_secret_TEST_FIXTURE_NOT_A_REAL_KEY_0000000000000000"
+FAKE_FINGERPRINT_HASH = hashlib.sha256(FAKE_FINGERPRINT.encode()).hexdigest()
+FAKE_FINGERPRINT_LABEL = "TEST fixture key"
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Minimal fake repo layout the scanner expects."""
+    (tmp_path / "src" / "coarse").mkdir(parents=True)
+    (tmp_path / "src" / "coarse" / "models.py").write_text(
+        'DEFAULT_MODEL = "openai/gpt-5"\n'
+    )
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "tests").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def register_fake_fingerprint(monkeypatch: pytest.MonkeyPatch):
+    """Add FAKE_FINGERPRINT_HASH to the scanner's fingerprint table."""
+    monkeypatch.setitem(
+        scanner.LEAKED_FINGERPRINT_HASHES,
+        FAKE_FINGERPRINT_HASH,
+        FAKE_FINGERPRINT_LABEL,
+    )
+
+
+def run(repo: Path, *extra: str) -> tuple[int, list[scanner.Finding]]:
+    """Invoke the scanner against repo and return (exit_code, findings)."""
+    old_root = scanner.REPO_ROOT
+    scanner.REPO_ROOT = repo
+    try:
+        findings: list[scanner.Finding] = []
+        findings.extend(scanner.scan_secrets(repo))
+        findings.extend(scanner.scan_env_example(repo))
+        findings.extend(scanner.scan_env_permissions(repo))
+        findings.extend(scanner.scan_model_id_literals(repo))
+    finally:
+        scanner.REPO_ROOT = old_root
+    strict = "--strict" in extra
+    blocking_sevs = {"CRITICAL", "HIGH"} if strict else {"CRITICAL"}
+    code = 2 if any(f.severity in blocking_sevs for f in findings) else 0
+    return code, findings
+
+
+def test_clean_repo(repo: Path) -> None:
+    code, findings = run(repo)
+    assert code == 0
+    assert findings == []
+
+
+def test_leaked_fingerprint_is_critical(
+    repo: Path, register_fake_fingerprint: None
+) -> None:
+    (repo / "scripts" / "deploy.sh").write_text(
+        f'curl -H "apikey: {FAKE_FINGERPRINT}"\n'
+    )
+    code, findings = run(repo)
+    assert code == 2
+    kinds = {f.kind for f in findings}
+    assert "leaked-fingerprint" in kinds
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+def test_fingerprint_allowed_in_env_file(
+    repo: Path, register_fake_fingerprint: None
+) -> None:
+    (repo / ".env").write_text(
+        f"SUPABASE_SERVICE_ROLE_KEY={FAKE_FINGERPRINT}\n"
+    )
+    os.chmod(repo / ".env", 0o600)
+    code, findings = run(repo)
+    assert not any(f.kind == "leaked-fingerprint" for f in findings)
+    assert code == 0
+
+
+def test_provider_pattern_is_high(repo: Path) -> None:
+    (repo / "scripts" / "deploy.sh").write_text(
+        'OPENAI="sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCDEF"\n'
+    )
+    code, findings = run(repo)
+    assert any(
+        f.kind == "secret-pattern" and f.severity == "HIGH" for f in findings
+    )
+    assert code == 0
+    strict_code, _ = run(repo, "--strict")
+    assert strict_code == 2
+
+
+def test_placeholder_marker_skipped(repo: Path) -> None:
+    (repo / ".env.example").write_text(
+        'OPENAI_API_KEY="sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"\n'
+    )
+    code, findings = run(repo)
+    assert not any(f.kind == "secret-pattern" for f in findings)
+    assert not any(f.kind == "env-example-real-secret" for f in findings)
+    assert code == 0
+
+
+def test_inline_ignore_marker(repo: Path) -> None:
+    (repo / "scripts" / "deploy.sh").write_text(
+        'KEY="sk-proj-realrealrealrealrealrealrealreal12"  # security: ignore\n'
+    )
+    code, findings = run(repo)
+    assert not any(f.kind == "secret-pattern" for f in findings)
+    assert code == 0
+
+
+def test_env_permissions_too_open(repo: Path) -> None:
+    env = repo / ".env"
+    env.write_text("FOO=bar\n")
+    os.chmod(env, 0o644)
+    code, findings = run(repo)
+    assert any(f.kind == "env-perm" and f.severity == "HIGH" for f in findings)
+    assert code == 0
+
+
+def test_env_permissions_tight(repo: Path) -> None:
+    env = repo / ".env"
+    env.write_text("FOO=bar\n")
+    os.chmod(env, 0o600)
+    _, findings = run(repo)
+    assert not any(f.kind == "env-perm" for f in findings)
+
+
+def test_docstring_model_id_skipped(repo: Path) -> None:
+    (repo / "src" / "coarse" / "llm.py").write_text(
+        '"""Example model IDs like \'openai/gpt-4o\' go here."""\n'
+        'x = 1\n'
+    )
+    _, findings = run(repo)
+    assert not any(f.kind == "hardcoded-model-id" for f in findings)
+
+
+def test_real_model_id_literal_flagged(repo: Path) -> None:
+    (repo / "src" / "coarse" / "llm.py").write_text(
+        'COSTS = {\n'
+        '    "openai/gpt-5.1": {"input": 1.0, "output": 5.0},\n'
+        '}\n'
+    )
+    _, findings = run(repo)
+    assert any(
+        f.kind == "hardcoded-model-id" and f.severity == "MEDIUM"
+        for f in findings
+    )
+
+
+def test_models_py_itself_not_flagged(repo: Path) -> None:
+    _, findings = run(repo)
+    assert not any(f.kind == "hardcoded-model-id" for f in findings)
+
+
+def test_provider_auto_suffix_not_flagged(repo: Path) -> None:
+    (repo / "src" / "coarse" / "llm.py").write_text(
+        'api_key = resolve_api_key("openrouter/auto")\n'
+    )
+    _, findings = run(repo)
+    assert not any(f.kind == "hardcoded-model-id" for f in findings)
+
+
+def test_scanner_self_exempt(
+    repo: Path, register_fake_fingerprint: None
+) -> None:
+    # Drop the fake fingerprint into the scanner path and verify it is
+    # ignored there (SELF_EXEMPT).
+    target = repo / "scripts" / "security_scanner.py"
+    target.write_text(f'LEAKED = "{FAKE_FINGERPRINT}"\n')
+    code, findings = run(repo)
+    assert not any(f.kind == "leaked-fingerprint" for f in findings)
+    assert code == 0
+
+
+def test_json_output_roundtrip(
+    repo: Path,
+    capsys: pytest.CaptureFixture,
+    register_fake_fingerprint: None,
+) -> None:
+    (repo / "scripts" / "deploy.sh").write_text(
+        f'curl -H "apikey: {FAKE_FINGERPRINT}"\n'
+    )
+    rc = scanner.main(["--root", str(repo), "--json"])
+    out = capsys.readouterr().out
+    import json
+
+    payload = json.loads(out)
+    assert rc == 2
+    assert payload["counts"]["CRITICAL"] >= 1
+    assert payload["findings"]

--- a/tests/test_structure-analysis.py
+++ b/tests/test_structure-analysis.py
@@ -452,11 +452,16 @@ def test_detect_math_sections_falls_back_on_instructor_length_limit():
             section_type=SectionType.METHODOLOGY,
         ),
     ]
+    from instructor.core import InstructorRetryException
+
     client = MagicMock()
-    # Mimic instructor's own exception message so the fallback path is
-    # exercised with a realistic error.
-    client.complete.side_effect = RuntimeError(
-        "The output is incomplete due to a max_tokens length limit."
+    # Use the real exception class so the test still passes if the
+    # _detect_math_sections catch clause is ever tightened from
+    # `except Exception` to `except InstructorRetryException`.
+    client.complete.side_effect = InstructorRetryException(
+        "The output is incomplete due to a max_tokens length limit.",
+        n_attempts=3,
+        total_usage=0,
     )
 
     result = _detect_math_sections(sections, client)


### PR DESCRIPTION
## Summary

Post-review follow-ups on top of the extraction + math-detection fixes that shipped in v1.1.1. No user-facing behavior changes — all hardening, coverage, and doc sync. Clean rebase on top of the v1.1.1 release tag.

- **Billing-guard hardening** — `_response_was_billed` now rejects `bool` values explicitly (since `isinstance(True, int) is True`, a malformed `usage: {"total_cost": true}` would have tripped the guard on a free error body). Also broadened the retry catch from `(ConnectionError, Timeout)` to the base `requests.RequestException` so `ChunkedEncodingError` / `ContentDecodingError` / `SSLError` get retried instead of immediately falling through.
- **Test coverage gaps closed** — 11 new unit tests for `_response_was_billed` covering every branch (positive cost/tokens, all-zero, missing/non-dict usage, JSON parse failure, bool coercion, floats); a new test asserting `time.sleep` actually receives the capped `1,2,4,8,16,32,32,32,32` sequence; a new test proving pdf-text is strictly a fallback and not called when mistral-ocr succeeds on the first try; `InstructorRetryException` mock swapped for the real class.
- **Docs** — `CLAUDE.md` Review Pipeline diagram updated to the three-tier `Mistral OCR → pdf-text → Docling` chain.

## Test plan

- [x] `uv run pytest tests/` — 464 passed (was 449 pre-review; 15 new tests)
- [x] `uv run ruff check` — no new violations (12 pre-existing, unchanged)
- [x] Rebased cleanly onto v1.1.1; no conflicts in `src/` or `tests/`
- [ ] CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)