### PR TITLE
release: v1.1.3

### DIFF
--- a/.claude/hooks/session-brief.sh
+++ b/.claude/hooks/session-brief.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SessionStart hook: injects a mandatory onboarding brief at the top of every
+# new Claude Code session in this repo. Wired in .claude/settings.json.
+#
+# The hook prints to stdout; Claude Code captures that output as additional
+# session context. Nothing here runs against the user's message yet — this
+# is about giving Claude a working mental model of coarse before it takes
+# its first action.
+#
+# Edit this script to adjust the mandatory-reading list as the codebase
+# evolves. Keep it short: the goal is "enough to understand", not "read
+# everything".
+
+set -euo pipefail
+
+cat <<'BRIEF'
+# Session brief — coarse
+
+This repo is `coarse`, a free open-source AI academic paper reviewer (BYOK).
+Before responding to the user's first message, you MUST read the files listed
+under "Required" below so you have a working model of the codebase. This is
+a hard requirement, not a suggestion — the rest of the project assumes you've
+seen these files.
+
+## Required reading (do these first, in order)
+
+1. `CLAUDE.md` — project overview, pipeline diagram, package structure,
+   slash commands, worktree discipline, model manifest rules, development
+   principles. Everything else in the repo assumes you know this.
+2. `CONTRIBUTING.md` — git workflow (dev/main split), pre-PR checklist,
+   branch naming, versioning, release process, security reporting.
+3. `src/coarse/__init__.py` — the public Python API surface.
+4. `src/coarse/types.py` — Pydantic models that are the vocabulary of the
+   whole pipeline (`PaperText`, `PaperStructure`, `SectionInfo`, `Review`,
+   `DetailedComment`, etc.). You cannot reason about the code without these.
+5. `src/coarse/models.py` — single source of truth for every model ID.
+   NEVER write a model ID string literal outside this file.
+6. `src/coarse/pipeline.py` — `review_paper()` orchestrator, i.e. the main
+   control flow the whole project hangs off.
+
+## Skim (run `ls` or glance, don't deep-read)
+
+7. `src/coarse/` — top-level module names
+8. `src/coarse/agents/` — agent module names (one file per agent class)
+9. `tests/` — test file names (tests mirror modules 1:1)
+10. `.claude/commands/` — available slash commands (`/pre-pr`,
+    `/security-review`, `/architecture-review`, `/module-review`,
+    `/dev-loop`, `/worktree-start`)
+
+## Read on demand (only if the user's task touches the area)
+
+| Area                        | File(s) to read                                    |
+|-----------------------------|----------------------------------------------------|
+| PDF / OCR / extraction      | `src/coarse/extraction.py`, `extraction_qa.py`     |
+| Section parsing / structure | `src/coarse/structure.py`                          |
+| A specific agent            | `src/coarse/agents/<name>.py` + `tests/test_<name>.py` |
+| LLM provider routing / cost | `src/coarse/llm.py`                                |
+| CLI behaviour               | `src/coarse/cli.py`                                |
+| Prompt templates            | `src/coarse/prompts.py` (~1700 lines — grep, don't linear-read) |
+| Quote verification          | `src/coarse/quote_verify.py`                       |
+| Output format               | `src/coarse/synthesis.py`, `data/refine_examples/r3d/feedback-*.md` |
+| Config / API keys           | `src/coarse/config.py`                             |
+| Web frontend / submission   | `web/`                                             |
+| Modal deploy / worker       | `deploy/modal_worker.py`                           |
+| Security scanner            | `scripts/security_scanner.py`, `tests/test_security.py` |
+
+## Hard rules (from CLAUDE.md — re-stated so you don't miss them)
+
+- **Model IDs live in `src/coarse/models.py` only.** Import constants, never
+  hardcode the string anywhere else. `/security-review` enforces this.
+- **Prompts live in `src/coarse/prompts.py` only.** Don't scatter prompt
+  strings across agents.
+- **LLM calls go through `LLMClient`** (wraps litellm + instructor). No
+  direct `litellm.completion(...)` outside `src/coarse/llm.py`.
+- **Structured output uses `instructor` + Pydantic.** No raw JSON parsing
+  of LLM responses outside `llm.py`.
+- **Worktree discipline** for any non-trivial change: branch off `dev` in
+  `/private/tmp/coarse-<issue>-<slug>/`, use full paths on every Edit/Write,
+  prefix file-modifying Bash with `cd /private/tmp/coarse-<slug> &&`.
+- **Feature PRs target `dev`**, not `main`. Release PRs from `dev` to `main`
+  are the maintainer's job.
+- **Before pushing**, run `/pre-pr` (or at minimum `make security &&
+  make check`).
+
+## What to do after reading
+
+Reply to the user's first message normally. Do NOT recite what you read —
+one sentence acknowledging you have the context is enough. Then answer
+their actual question.
+
+If the user's first message is a trivial question that doesn't require
+codebase knowledge (e.g. "what time is it", "help"), skip steps 3–6 but
+still read 1 and 2.
+BRIEF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-brief.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -70,7 +70,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_KEY }}" \
             -H "Content-Type: application/json" \
             -H "Prefer: return=minimal" \
-            -d '{"accepting_reviews": false, "banner_message": "Monthly capacity reached. Please use the CLI: pip install coarse", "updated_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
+            -d '{"accepting_reviews": false, "banner_message": "Monthly capacity reached. Please use the CLI: pip install coarse-ink", "updated_at": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
           echo "Submissions auto-paused."
 
       - name: Send alert email

--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,14 @@ dist/
 .env
 .coarse/
 
-# Ignore everything inside .claude/ except the shared slash commands and
-# agent definitions, which are team-wide workflow tooling.
+# Ignore everything inside .claude/ except the shared slash commands,
+# agent definitions, hook scripts, and project-level settings, which are
+# team-wide workflow tooling. Keep .claude/settings.local.json ignored.
 .claude/*
 !.claude/commands
 !.claude/agents
+!.claude/hooks
+!.claude/settings.json
 CLAUDE.md
 *.pdf
 !data/**/*.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **PyPI distribution renamed to `coarse-ink`** — the bare `coarse` name on PyPI was already taken by an unrelated, abandoned package (`coarse==0.0.1` by a different author), so `uvx coarse` / `pip install coarse` resolved to the wrong package and users hit `Package 'coarse' does not provide any executables` (#17). Installing is now `uvx coarse-ink review paper.pdf ...` or `pip install coarse-ink`. The Python import name (`import coarse`) and the `coarse` CLI command are unchanged — a `coarse-ink` console script is also registered so `uvx coarse-ink ...` resolves directly, and `uv tool install coarse-ink` still puts a `coarse` command on your PATH.
+
 ### Added
 
 - **Automated incident posting to X/Twitter** — new `deploy/incident_monitor.py` Modal app (`coarse-monitor`) that runs every 2 minutes, watches four independent signals (backend error spike, queue stall, Modal `/health` down, upstream provider 5xx pattern), and posts an "investigating" tweet when the backend is actually broken. Auto-resolves (threaded reply) once signals have been clear for 10 minutes. Explicitly ignores user-side errors (bad API keys, spending limits, 429s from the user's own provider) so it never tweets because someone pasted a dead key. Ships in `INCIDENT_MONITOR_MODE=dry_run` by default; flip to `live` via Modal secret once dry-run logs look right. Includes 30 min cooldown between incidents to suppress flapping and an `INCIDENT_MONITOR_ENABLED=false` kill switch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v1.1.3 — 2026-04-11
+
+First release under the new `coarse-ink` PyPI name. `uvx coarse-ink review paper.pdf ...` now works end-to-end. The PyPI version history for `coarse-ink` skips 1.1.1 and 1.1.2 — 1.1.0 was published manually from an earlier branch while the rename was still in draft, and this release catches up to the in-repo version. Also ships new incident monitoring and structured error classification for backend observability.
+
 ### Fixed
 
 - **PyPI distribution renamed to `coarse-ink`** — the bare `coarse` name on PyPI was already taken by an unrelated, abandoned package (`coarse==0.0.1` by a different author), so `uvx coarse` / `pip install coarse` resolved to the wrong package and users hit `Package 'coarse' does not provide any executables` (#17). Installing is now `uvx coarse-ink review paper.pdf ...` or `pip install coarse-ink`. The Python import name (`import coarse`) and the `coarse` CLI command are unchanged — a `coarse-ink` console script is also registered so `uvx coarse-ink ...` resolves directly, and `uv tool install coarse-ink` still puts a `coarse` command on your PATH.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 Free, open-source AI academic paper reviewer. The rough alternative to refine.ink.
 Users provide their own API keys and pay only the LLM provider directly (~$2-5 per review vs refine.ink's ~$50).
 
-**Package:** `coarse` (Python 3.12+, Pydantic, litellm, instructor)
-**Install:** `pip install coarse` / `pipx install coarse` / `uvx coarse paper.pdf`
+**Package:** `coarse-ink` on PyPI; import name is still `coarse` (Python 3.12+, Pydantic, litellm, instructor). The bare `coarse` name on PyPI is held by an unrelated package — see CHANGELOG Unreleased / #17.
+**Install:** `pip install coarse-ink` / `pipx install coarse-ink` / `uvx coarse-ink paper.pdf`
 
 ## Python Environment
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Don't want to run it locally? Use the [web interface](https://coarse.vercel.app/
 Get an API key from [OpenRouter](https://openrouter.ai/keys) (free to sign up), then:
 
 ```bash
-uvx coarse review paper.pdf --api-key sk-or-v1-YOUR_KEY
+uvx coarse-ink review paper.pdf --api-key sk-or-v1-YOUR_KEY
 ```
 
 That's it. The review is written to `paper_review.md` in the current directory.
@@ -35,8 +35,14 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 `uvx` runs coarse in a temporary environment with no permanent install. To install permanently:
 
 ```bash
-uv tool install coarse    # or: pip install coarse
+uv tool install coarse-ink    # or: pip install coarse-ink
 ```
+
+> **Why `coarse-ink` and not `coarse`?** The bare `coarse` name on PyPI is
+> held by an unrelated package, so we ship under `coarse-ink`. The Python
+> import name (`import coarse`) and the `coarse` CLI command are unchanged
+> — installing `coarse-ink` puts both `coarse` and `coarse-ink` on your
+> PATH.
 
 ### Save your API key
 
@@ -54,8 +60,8 @@ PDF, TXT, Markdown, LaTeX, DOCX, HTML, and EPUB. PDFs use Mistral OCR; other for
 Docling (if installed) with lightweight fallbacks. Install optional format support:
 
 ```bash
-pip install coarse[formats]   # DOCX, HTML, EPUB fallbacks
-pip install coarse[docling]   # Docling for PDF/DOCX/HTML/LaTeX
+pip install coarse-ink[formats]   # DOCX, HTML, EPUB fallbacks
+pip install coarse-ink[docling]   # Docling for PDF/DOCX/HTML/LaTeX
 ```
 
 ## How it works
@@ -145,7 +151,7 @@ Make sure your OpenRouter per-key spend limit has headroom above the estimate.
 
 The default spending cap is **$10 per review** (`max_cost_usd` in config). Use `--yes` to skip the
 confirmation prompt. Use `--no-qa` to skip the post-extraction quality check (vision LLM).
-Scanned PDFs are supported via Docling's built-in OCR (`pip install coarse[docling]`).
+Scanned PDFs are supported via Docling's built-in OCR (`pip install coarse-ink[docling]`).
 
 You can also load API keys from any `.env` file with `--env-file path/to/.env`.
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure,
 
 ## Version
 
-1.1.2
+1.1.3
 
 ## License
 

--- a/deploy/CAPACITY.md
+++ b/deploy/CAPACITY.md
@@ -11,7 +11,7 @@ Run this in the **Supabase SQL Editor** (no deploy needed):
 ```sql
 UPDATE system_status
 SET accepting_reviews = false,
-    banner_message = 'We are at capacity right now. Please use the command-line version: pip install coarse',
+    banner_message = 'We are at capacity right now. Please use the command-line version: pip install coarse-ink',
     updated_at = now()
 WHERE id = 1;
 ```
@@ -77,7 +77,7 @@ UPDATE reviews SET paper_markdown = null WHERE completed_at < now() - interval '
 
 **Expand**: Upgrade to Vercel Pro ($20/month) for 1 TB bandwidth and 60-second function timeout.
 
-**Emergency**: Pause submissions via SQL above. The CLI (`pip install coarse`) works independently of the web app.
+**Emergency**: Pause submissions via SQL above. The CLI (`pip install coarse-ink`) works independently of the web app.
 
 ---
 

--- a/deploy/supabase_schema.sql
+++ b/deploy/supabase_schema.sql
@@ -126,7 +126,7 @@ alter publication supabase_realtime add table reviews;
 -- Singleton row: manual kill switch + banner message for the web frontend.
 -- Flip from the Supabase SQL editor:
 --   UPDATE system_status SET accepting_reviews = false,
---     banner_message = 'High traffic — use the CLI: pip install coarse',
+--     banner_message = 'High traffic — use the CLI: pip install coarse-ink',
 --     updated_at = now() WHERE id = 1;
 create table system_status (
   id int primary key default 1 check (id = 1),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "coarse"
+name = "coarse-ink"
 version = "1.1.2"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
@@ -38,11 +38,12 @@ Changelog = "https://github.com/Davidvandijcke/coarse/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 docling = ["docling>=2.0"]
 formats = ["mammoth>=1.6", "markdownify>=0.12", "ebooklib>=0.18"]
-all = ["coarse[docling]", "coarse[formats]"]
+all = ["coarse-ink[docling]", "coarse-ink[formats]"]
 dev = ["pytest>=8.0", "ruff>=0.4"]
 
 [project.scripts]
 coarse = "coarse.cli:app"
+coarse-ink = "coarse.cli:app"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coarse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coarse-ink"
-version = "1.1.2"
+version = "1.1.3"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
 license = "MIT"

--- a/src/coarse/__init__.py
+++ b/src/coarse/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 from coarse.pipeline import review_paper  # noqa: F401

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -479,7 +479,7 @@ def _extract_html_markdownify(path: Path) -> str:
         import markdownify
     except ImportError:
         raise ExtractionError(
-            "HTML extraction requires markdownify: pip install coarse[formats]"
+            "HTML extraction requires markdownify: pip install coarse-ink[formats]"
         )
     html_str = path.read_text(encoding="utf-8")
     return markdownify.markdownify(html_str, heading_style="ATX")
@@ -491,7 +491,7 @@ def _extract_docx_mammoth(path: Path) -> str:
         import mammoth
     except ImportError:
         raise ExtractionError(
-            "DOCX extraction requires mammoth: pip install coarse[formats]"
+            "DOCX extraction requires mammoth: pip install coarse-ink[formats]"
         )
     with open(path, "rb") as f:
         result = mammoth.convert_to_markdown(f)
@@ -506,7 +506,7 @@ def _extract_epub(path: Path) -> str:
         from ebooklib import epub
     except ImportError:
         raise ExtractionError(
-            "EPUB extraction requires ebooklib and markdownify: pip install coarse[formats]"
+            "EPUB extraction requires ebooklib and markdownify: pip install coarse-ink[formats]"
         )
     book = epub.read_epub(str(path))
     chapters = []

--- a/tests/test_readme-+-packaging.py
+++ b/tests/test_readme-+-packaging.py
@@ -32,10 +32,10 @@ def test_readme_exists_and_nonempty():
 
 
 def test_readme_install_commands_present():
-    """README.md contains install commands."""
+    """README.md contains install commands under the `coarse-ink` PyPI name."""
     content = README.read_text(encoding="utf-8")
-    assert "pip install coarse" in content
-    assert "uvx coarse" in content
+    assert "pip install coarse-ink" in content
+    assert "uvx coarse-ink" in content
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +191,13 @@ def test_package_installs_in_fresh_venv(tmp_path):
 
 
 def test_uvx_entry_point():
-    """pyproject.toml [project.scripts] entry `coarse = coarse.cli:app` resolves correctly."""
+    """pyproject.toml [project.scripts] registers both `coarse` and `coarse-ink`.
+
+    Both point at `coarse.cli:app`. The `coarse-ink` entry is what makes
+    `uvx coarse-ink ...` resolve directly (matching the PyPI distribution
+    name); the `coarse` entry preserves the short command on PATH for
+    users who `uv tool install coarse-ink`.
+    """
     import tomllib
 
     with open(PYPROJECT, "rb") as f:
@@ -201,4 +207,8 @@ def test_uvx_entry_point():
     assert "coarse" in scripts, "No 'coarse' entry in [project.scripts]"
     assert scripts["coarse"] == "coarse.cli:app", (
         f"Expected 'coarse.cli:app', got '{scripts['coarse']}'"
+    )
+    assert "coarse-ink" in scripts, "No 'coarse-ink' entry in [project.scripts]"
+    assert scripts["coarse-ink"] == "coarse.cli:app", (
+        f"Expected 'coarse.cli:app', got '{scripts['coarse-ink']}'"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -270,7 +270,7 @@ wheels = [
 ]
 
 [[package]]
-name = "coarse"
+name = "coarse-ink"
 version = "1.1.2"
 source = { editable = "." }
 dependencies = [
@@ -306,8 +306,8 @@ formats = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coarse", extras = ["docling"], marker = "extra == 'all'" },
-    { name = "coarse", extras = ["formats"], marker = "extra == 'all'" },
+    { name = "coarse-ink", extras = ["docling"], marker = "extra == 'all'" },
+    { name = "coarse-ink", extras = ["formats"], marker = "extra == 'all'" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.0" },
     { name = "ebooklib", marker = "extra == 'formats'", specifier = ">=0.18" },
     { name = "instructor", specifier = ">=1.7" },

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "coarse-ink"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },

--- a/web/src/app/api/submit/route.ts
+++ b/web/src/app/api/submit/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
   if (statusRow && !statusRow.accepting_reviews) {
     return NextResponse.json(
       {
-        error: statusRow.banner_message || "Submissions are temporarily paused. Please try again later or use the CLI: pip install coarse",
+        error: statusRow.banner_message || "Submissions are temporarily paused. Please try again later or use the CLI: pip install coarse-ink",
       },
       { status: 503 },
     );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -367,7 +367,7 @@ export default function Home() {
             {" "}
             For faster results, try the CLI:{" "}
             <code style={{ background: "var(--tray)", padding: "0.15em 0.4em", fontSize: "0.95em" }}>
-              pip install coarse
+              pip install coarse-ink
             </code>{" "}
             <a
               href="https://github.com/Davidvandijcke/coarse"


### PR DESCRIPTION
## Summary

Release PR from `dev` → `main`, bundling two merged feature PRs.

### Headline: fixes #17 end-to-end (shipped to PyPI)

#25 landed the `coarse-ink` packaging rename on `dev`. This release PR bumps the version, cuts the tag, and carries it to main.

After merge, I'll:
1. Tag `v1.1.3` on main.
2. Run `uv build` + `uv publish` to put `coarse-ink==1.1.3` on PyPI.
3. Smoke-test `uvx coarse-ink review <paper> --api-key ...` from a clean machine and confirm in the #17 comment thread.

### Also bundled

- **#32** — `.claude/hooks/session-brief.sh` + `.claude/settings.json` wiring. Dev-workflow automation for future Claude Code sessions; not user-facing, no CHANGELOG entry added.
- **Unreleased Added entries that carried over from earlier dev work** (already in the CHANGELOG at merge time):
  - Automated incident posting to X/Twitter (`deploy/incident_monitor.py`).
  - Structured error classification on failed reviews (new `reviews.error_category` column).

## Version gap note

`coarse-ink` on PyPI currently has a single release, `1.1.0`, published manually from the draft rename branch yesterday while the fix was still in #25 (under the old `dev` tip). This release catches up to the in-repo version, so the PyPI history for `coarse-ink` goes `1.1.0 → 1.1.3`, skipping 1.1.1 and 1.1.2. The CHANGELOG header for v1.1.3 calls this out explicitly.

## Verification done locally

- [x] `pytest tests/` → **517 passed, 1 deselected** on this branch
- [x] `scripts/security_scanner.py --strict` → clean
- [x] `scripts/doc-sync-check.sh` → `version 1.1.3 consistent`, `Unreleased` present, no stray model-IDs
- [x] `test_readme_version_matches_pyproject` passes after bumping `README.md:235` `1.1.2 → 1.1.3`

## Test plan for reviewer

- [ ] After merge, confirm `v1.1.3` tag pushed and `main` at the release commit.
- [ ] Run `uv build` and inspect `dist/coarse_ink-1.1.3-*.whl` for both `coarse` and `coarse-ink` scripts in `entry_points.txt`.
- [ ] `uv publish` with the PyPI token.
- [ ] Clean-cache smoke: `UV_CACHE_DIR=/tmp/smoke uvx --refresh coarse-ink review <small-paper> --api-key sk-or-v1-...`.
- [ ] Comment + close on #17 once smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)