### PR TITLE
fix(llm): strip JSON \u0000 escapes before Pydantic parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Null-byte crashes on Supabase write** — `_sanitized_completion` in `src/coarse/llm.py` stripped literal control characters (`\x00-\x1f`) from raw LLM response text but did not touch the JSON escape sequence `\u0000` (six printable ASCII bytes). When an LLM emitted `\u0000` inside a JSON string field, the escape survived the sanitizer, `json.loads` reconstituted it as a real `\x00` inside the parsed Pydantic field, and the resulting `result_markdown` then crashed the Supabase UPDATE with Postgres 22P05 (`\u0000 cannot be converted to text`), marking the review as failed despite the pipeline having succeeded. Observed in production during the post-launch tweet surge on two gpt-5.4 reviews (`6c41a05e`, `92947b4b`) — extraction produced clean markdown on both PDFs, so the null byte could only have entered through the LLM response path. Fix strips the `\\u0000` escape form before Instructor/Pydantic parses the content. Regression covered by three new tests in `tests/test_llm.py` exercising `_sanitized_completion` directly.
+
 ## v1.1.3 — 2026-04-11
 
 First release under the new `coarse-ink` PyPI name. `uvx coarse-ink review paper.pdf ...` now works end-to-end. The PyPI version history for `coarse-ink` skips 1.1.1 and 1.1.2 — 1.1.0 was published manually from an earlier branch while the rename was still in draft, and this release catches up to the in-repo version. Also ships new incident monitoring and structured error classification for backend observability.

--- a/src/coarse/llm.py
+++ b/src/coarse/llm.py
@@ -62,6 +62,13 @@ for _model_id, _info in _CUSTOM_MODEL_INFO.items():
 
 
 _CTRL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+# JSON \uXXXX escape form of NUL. Needed in addition to _CTRL_CHAR_RE because
+# the regex only sees the raw LLM response text — any \u0000 emitted as a JSON
+# escape is six printable ASCII bytes at that point and survives untouched,
+# then json.loads() decodes it back into a real \x00 inside the parsed field.
+# Postgres text columns reject \x00 (SQLSTATE 22P05), so a single quoted char
+# kills the entire review write. Strip the escape form before parsing.
+_JSON_NUL_ESCAPE_RE = re.compile(r"\\u0000", re.IGNORECASE)
 _DEGENERATE_RE = re.compile(r"(.)\1{50,}")  # 50+ consecutive identical chars
 
 
@@ -125,8 +132,13 @@ def _inject_openrouter_privacy(model: str, kwargs: dict) -> dict:
 def _sanitized_completion(*args, **kwargs):
     """Wrap litellm.completion to strip control characters and detect degenerate output.
 
-    Some models (e.g. MiMo) emit control characters in JSON output that break
-    Pydantic parsing.  Stripping \x00-\x1f (except \t and \n) is safe for JSON.
+    Some models (e.g. MiMo) emit literal control characters in JSON output that
+    break Pydantic parsing; _CTRL_CHAR_RE handles those. Other models (observed
+    on gpt-5.4 quoting source text) emit NUL as the JSON escape sequence
+    ``\\u0000`` instead — six printable bytes that bypass _CTRL_CHAR_RE and then
+    get reconstituted as a real ``\\x00`` by json.loads, which later crashes the
+    Supabase write with Postgres 22P05. _JSON_NUL_ESCAPE_RE closes that gap.
+    Stripping \\x00-\\x1f (except \\t and \\n) is safe for JSON.
     """
     kwargs = _inject_openrouter_privacy(kwargs.get("model", ""), kwargs)
     response = litellm.completion(*args, **kwargs)
@@ -135,6 +147,7 @@ def _sanitized_completion(*args, **kwargs):
         msg = getattr(choice, "message", None)
         if msg and hasattr(msg, "content") and isinstance(msg.content, str):
             msg.content = _CTRL_CHAR_RE.sub("", msg.content)
+            msg.content = _JSON_NUL_ESCAPE_RE.sub("", msg.content)
     return response
 
 

--- a/src/coarse/llm.py
+++ b/src/coarse/llm.py
@@ -62,13 +62,6 @@ for _model_id, _info in _CUSTOM_MODEL_INFO.items():
 
 
 _CTRL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
-# JSON \uXXXX escape form of NUL. Needed in addition to _CTRL_CHAR_RE because
-# the regex only sees the raw LLM response text — any \u0000 emitted as a JSON
-# escape is six printable ASCII bytes at that point and survives untouched,
-# then json.loads() decodes it back into a real \x00 inside the parsed field.
-# Postgres text columns reject \x00 (SQLSTATE 22P05), so a single quoted char
-# kills the entire review write. Strip the escape form before parsing.
-_JSON_NUL_ESCAPE_RE = re.compile(r"\\u0000", re.IGNORECASE)
 _DEGENERATE_RE = re.compile(r"(.)\1{50,}")  # 50+ consecutive identical chars
 
 
@@ -133,12 +126,10 @@ def _sanitized_completion(*args, **kwargs):
     """Wrap litellm.completion to strip control characters and detect degenerate output.
 
     Some models (e.g. MiMo) emit literal control characters in JSON output that
-    break Pydantic parsing; _CTRL_CHAR_RE handles those. Other models (observed
-    on gpt-5.4 quoting source text) emit NUL as the JSON escape sequence
-    ``\\u0000`` instead — six printable bytes that bypass _CTRL_CHAR_RE and then
-    get reconstituted as a real ``\\x00`` by json.loads, which later crashes the
-    Supabase write with Postgres 22P05. _JSON_NUL_ESCAPE_RE closes that gap.
-    Stripping \\x00-\\x1f (except \\t and \\n) is safe for JSON.
+    break Pydantic parsing. Stripping \\x00-\\x1f (except \\t and \\n) is safe
+    for JSON. We also strip the 6-char ``\\u0000`` escape form because it
+    survives _CTRL_CHAR_RE and is reconstituted as a real NUL by json.loads,
+    which later crashes the Supabase write with Postgres 22P05.
     """
     kwargs = _inject_openrouter_privacy(kwargs.get("model", ""), kwargs)
     response = litellm.completion(*args, **kwargs)
@@ -147,7 +138,7 @@ def _sanitized_completion(*args, **kwargs):
         msg = getattr(choice, "message", None)
         if msg and hasattr(msg, "content") and isinstance(msg.content, str):
             msg.content = _CTRL_CHAR_RE.sub("", msg.content)
-            msg.content = _JSON_NUL_ESCAPE_RE.sub("", msg.content)
+            msg.content = msg.content.replace("\\u0000", "")
     return response
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -7,6 +7,7 @@ from coarse.config import CoarseConfig
 from coarse.llm import (
     LLMClient,
     _inject_openrouter_privacy,
+    _sanitized_completion,
     estimate_call_cost,
     estimate_reasoning_overhead_tokens,
     model_cost_per_token,
@@ -415,6 +416,87 @@ def test_estimate_call_cost_reasoning_is_more_expensive_than_regular():
     )
     # Sanity: the overhead should be meaningful (>20% uplift), not a rounding bump
     assert reasoning_cost >= naive_cost * 1.2
+
+
+def _sanitizer_response_with(content: str):
+    """Build a minimal litellm-style response object for _sanitized_completion."""
+    msg = MagicMock()
+    msg.content = content
+    msg.reasoning_content = None
+    choice = MagicMock()
+    choice.message = msg
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+def test_sanitized_completion_strips_literal_control_chars():
+    """Literal \\x00-\\x1f (except tab/newline) in msg.content must be removed."""
+    raw = "before\x00middle\x01tab\there\nnewlineOK\x1fend"
+    response = _sanitizer_response_with(raw)
+
+    with patch("coarse.llm.litellm.completion", return_value=response):
+        result = _sanitized_completion(model="test/mock")
+
+    cleaned = result.choices[0].message.content
+    assert "\x00" not in cleaned
+    assert "\x01" not in cleaned
+    assert "\x1f" not in cleaned
+    assert "\t" in cleaned  # tab preserved
+    assert "\n" in cleaned  # newline preserved
+    assert cleaned == "beforemiddletab\there\nnewlineOKend"
+
+
+def test_sanitized_completion_strips_json_u0000_escape_before_parse():
+    """Regression for production bug: gpt-5.4 emitted JSON with \\u0000 escape
+    sequences inside string fields. _CTRL_CHAR_RE only matches literal control
+    chars, so the 6-byte \\u0000 escape passed through untouched, and json.loads
+    then reconstituted it as a real \\x00 inside the parsed Pydantic field.
+    That NUL byte then crashed the Supabase write with Postgres 22P05.
+
+    The fix strips the escape form before Instructor/Pydantic sees the content.
+    """
+    import json
+
+    # Six printable ASCII bytes, NOT a literal NUL. Must use a raw-ish build
+    # so Python's string literal parser doesn't fold \u0000 into \x00.
+    raw_json = '{"quote": "text ' + "\\u0000" + ' more", "keep": "tab\\tend"}'
+    # Sanity-check the test fixture itself:
+    assert "\x00" not in raw_json  # no literal NUL yet
+    assert "\\u0000" in raw_json  # escape sequence is present as 6 chars
+
+    response = _sanitizer_response_with(raw_json)
+    with patch("coarse.llm.litellm.completion", return_value=response):
+        result = _sanitized_completion(model="test/mock")
+
+    cleaned = result.choices[0].message.content
+    parsed = json.loads(cleaned)
+
+    # The fix: no \x00 should survive the json.loads round-trip.
+    assert "\x00" not in parsed["quote"], f"NUL byte leaked into parsed field: {parsed['quote']!r}"
+    assert parsed["quote"] == "text  more"  # space preserved either side
+    # Legit escape sequences (\t) must still round-trip correctly.
+    assert parsed["keep"] == "tab\tend"
+
+
+def test_sanitized_completion_is_case_insensitive_for_u_escape():
+    """JSON allows either case for the hex digits in \\uXXXX escapes."""
+    import json
+
+    variants = [
+        '{"x": "a' + "\\u0000" + 'b"}',
+        '{"x": "a' + "\\U0000" + 'b"}',  # uppercase U (not strictly valid JSON, but defensive)
+        '{"x": "a' + "\\u0000".upper() + 'b"}',
+    ]
+    for raw in variants:
+        response = _sanitizer_response_with(raw)
+        with patch("coarse.llm.litellm.completion", return_value=response):
+            result = _sanitized_completion(model="test/mock")
+        cleaned = result.choices[0].message.content
+        # At minimum the standard lowercase form must be stripped and parseable.
+        if "\\u0000" in raw:
+            parsed = json.loads(cleaned)
+            assert "\x00" not in parsed["x"]
 
 
 def test_complete_instructor_validation_error(mock_instructor_client):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -479,24 +479,31 @@ def test_sanitized_completion_strips_json_u0000_escape_before_parse():
     assert parsed["keep"] == "tab\tend"
 
 
-def test_sanitized_completion_is_case_insensitive_for_u_escape():
-    """JSON allows either case for the hex digits in \\uXXXX escapes."""
+def test_sanitized_completion_strips_multiple_u0000_escapes():
+    """Pin global replacement: every \\u0000 occurrence must be stripped,
+    not just the first. Guards against a future switch to `.replace(..., 1)`.
+    """
     import json
 
-    variants = [
-        '{"x": "a' + "\\u0000" + 'b"}',
-        '{"x": "a' + "\\U0000" + 'b"}',  # uppercase U (not strictly valid JSON, but defensive)
-        '{"x": "a' + "\\u0000".upper() + 'b"}',
-    ]
-    for raw in variants:
-        response = _sanitizer_response_with(raw)
-        with patch("coarse.llm.litellm.completion", return_value=response):
-            result = _sanitized_completion(model="test/mock")
-        cleaned = result.choices[0].message.content
-        # At minimum the standard lowercase form must be stripped and parseable.
-        if "\\u0000" in raw:
-            parsed = json.loads(cleaned)
-            assert "\x00" not in parsed["x"]
+    raw = '{"q": "a' + "\\u0000" + "b" + "\\u0000" + "c" + "\\u0000" + 'd"}'
+    response = _sanitizer_response_with(raw)
+    with patch("coarse.llm.litellm.completion", return_value=response):
+        result = _sanitized_completion(model="test/mock")
+
+    parsed = json.loads(result.choices[0].message.content)
+    assert "\x00" not in parsed["q"]
+    assert parsed["q"] == "abcd"
+
+
+def test_sanitized_completion_handles_none_content():
+    """The `isinstance(msg.content, str)` guard must no-op on None content
+    without raising. Some providers (e.g. reasoning-only responses) return
+    a message with content=None.
+    """
+    response = _sanitizer_response_with(None)
+    with patch("coarse.llm.litellm.completion", return_value=response):
+        result = _sanitized_completion(model="test/mock")
+    assert result.choices[0].message.content is None
 
 
 def test_complete_instructor_validation_error(mock_instructor_client):


### PR DESCRIPTION
## Summary

- `_sanitized_completion` in `src/coarse/llm.py` stripped literal control chars from raw LLM response text but not the 6-byte JSON escape sequence `\u0000`. When an LLM emitted `\u0000` inside a JSON string field, `json.loads` reconstituted it as a real `\x00` inside the parsed Pydantic field, which then crashed the Supabase UPDATE with Postgres 22P05 (`\u0000 cannot be converted to text`), marking the review as `failed` **after** the pipeline had already succeeded.
- Fix adds a single `.replace("\\u0000", "")` to the existing per-choice loop in `_sanitized_completion`.
- Regression covered by 3 new tests exercising `_sanitized_completion` directly with a mocked `litellm.completion`.

## Context — why it surfaced now

Observed on two gpt-5.4 reviews during the post-launch tweet surge (140k views, 163 reviews/24h, baseline was ~50/mo). Failed review IDs: `6c41a05e-b22e-4a87-a5ca-9eb1dbb0c8cf` and `92947b4b-b96a-446e-8699-776671114e66`.

I downloaded both failing PDFs from Supabase Storage and re-ran `extract_text()` on each — both produced clean markdown (0 null bytes, garble_ratio 0.0), ruling out the extraction path as the source. The null byte could only have entered through the LLM response path, where the sanitizer had a provable gap: `_CTRL_CHAR_RE` only matches literal `\x00-\x1f` in the raw response text, so the printable 6-byte `\u0000` escape sequence passed through untouched. Validated end-to-end in a unit test that simulates the exact `sanitizer → json.loads` pipeline.

## Test plan

- [x] `uv run pytest tests/test_llm.py -v -k sanitized_completion` — 4 tests pass
- [x] `uv run pytest tests/ -q` — 529 tests pass, no regressions
- [x] `uv run ruff check src/coarse/llm.py tests/test_llm.py` — clean
- [x] `python3 scripts/security_scanner.py` — clean
- [x] `bash scripts/doc-sync-check.sh` — clean
- [x] Revert-check: reverting the one-line fix makes the regression test fail with a useful assertion message (verified manually)
- [ ] Post-merge: watch Modal logs for the next 24h and confirm no new `22P05` errors. Any future null-byte failure would indicate a different path and warrant a defense-in-depth strip at the `modal_worker.py` write site.

## Out of scope for this PR (follow-ups)

- `msg.reasoning_content` is not sanitized. Reasoning models could in principle produce `\u0000` in the reasoning field; not touched here because the field isn't currently written to Supabase, but worth a follow-up if it ever is.
- `extraction.py` uses raw `requests.post` for the OpenRouter file-parser plugin and bypasses `_sanitized_completion` entirely. Empirically clean on the two failing PDFs, but not provably clean in general.

🤖 Generated with [Claude Code](https://claude.com/claude-code)