### PR TITLE
feat(web): refresh landing-page model picker and default to Opus 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- **Landing-page model picker refreshed** — `web/src/components/ModelPicker.tsx` now defaults to `anthropic/claude-opus-4.6` as the pre-selected model and adds `openai/gpt-5.4` and `google/gemini-3.1-pro-preview` as featured options. `qwen/qwen3.5-plus-02-15` was bumped to `qwen/qwen3.6-plus` to reflect the new release on OpenRouter. All four IDs were verified against OpenRouter's live catalog before landing.
+
 ### Fixed
 
 - **Null-byte crashes on Supabase write** — `_sanitized_completion` in `src/coarse/llm.py` stripped literal control characters (`\x00-\x1f`) from raw LLM response text but did not touch the JSON escape sequence `\u0000` (six printable ASCII bytes). When an LLM emitted `\u0000` inside a JSON string field, the escape survived the sanitizer, `json.loads` reconstituted it as a real `\x00` inside the parsed Pydantic field, and the resulting `result_markdown` then crashed the Supabase UPDATE with Postgres 22P05 (`\u0000 cannot be converted to text`), marking the review as failed despite the pipeline having succeeded. Observed in production during the post-launch tweet surge on two gpt-5.4 reviews (`6c41a05e`, `92947b4b`) — extraction produced clean markdown on both PDFs, so the null byte could only have entered through the LLM response path. Fix strips the `\\u0000` escape form before Instructor/Pydantic parses the content. Regression covered by three new tests in `tests/test_llm.py` exercising `_sanitized_completion` directly.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -163,7 +163,7 @@ export default function Home() {
   const [file, setFile] = useState<File | null>(null);
   const [email, setEmail] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [model, setModel] = useState("anthropic/claude-sonnet-4.6");
+  const [model, setModel] = useState("anthropic/claude-opus-4.6");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lookupKey, setLookupKey] = useState("");

--- a/web/src/components/ModelPicker.tsx
+++ b/web/src/components/ModelPicker.tsx
@@ -4,10 +4,13 @@ import { useState, useEffect, useRef, useCallback } from "react";
 
 /* ── Default model options ─────────────────────────────────── */
 const DEFAULT_MODELS = [
+  { id: "anthropic/claude-opus-4.6", label: "Opus 4.6", provider: "Anthropic" },
   { id: "anthropic/claude-sonnet-4.6", label: "Sonnet 4.6", provider: "Anthropic" },
+  { id: "openai/gpt-5.4", label: "GPT-5.4", provider: "OpenAI" },
   { id: "openai/gpt-5-mini", label: "GPT-5 Mini", provider: "OpenAI" },
+  { id: "google/gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", provider: "Google" },
   { id: "google/gemini-3-flash-preview", label: "Gemini 3 Flash", provider: "Google" },
-  { id: "qwen/qwen3.5-plus-02-15", label: "Qwen 3.5 Plus", provider: "Qwen" },
+  { id: "qwen/qwen3.6-plus", label: "Qwen 3.6 Plus", provider: "Qwen" },
   { id: "moonshotai/kimi-k2.5", label: "Kimi K2.5", provider: "Moonshot" },
   { id: "deepseek/deepseek-v3.2", label: "DeepSeek V3.2", provider: "DeepSeek" },
   { id: "x-ai/grok-4.1-fast", label: "Grok 4.1 Fast", provider: "xAI" },


### PR DESCRIPTION
## Summary

- Add Claude Opus 4.6, GPT-5.4, and Gemini 3.1 Pro as featured tiles in `ModelPicker`; bump Qwen 3.5 Plus to Qwen 3.6 Plus.
- Switch the landing page's pre-selected model from `anthropic/claude-sonnet-4.6` to `anthropic/claude-opus-4.6`.
- All four IDs were verified against the live OpenRouter catalog with the `latest-models` skill before landing.

## Cost note for reviewers

Opus 4.6 is ~10× the per-token price of Sonnet 4.6 ($5/$25 vs $3/$15 per 1M tok), so the out-of-the-box cost estimate on the landing page will jump for a typical review. The in-page cost estimator already surfaces this before submission, so users see the impact before consenting — but worth a conscious decision on whether Opus should be the default vs. a featured upsell.

## Test plan

- [ ] Visit the landing page and confirm Opus 4.6 appears first and is pre-selected.
- [ ] Confirm GPT-5.4, Gemini 3.1 Pro, and Qwen 3.6 Plus render as tiles.
- [ ] Upload a small PDF and verify the cost estimator populates correctly for each of the four new/updated tiles (pricing pulled live from OpenRouter).
- [ ] Verify the old `qwen/qwen3.5-plus-02-15` ID no longer appears anywhere in `web/src/components/ModelPicker.tsx`.