### PR TITLE
fix(security): harden webhook auth + sanitize error strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - chore(deps): bump aiohttp→3.13.5, requests→2.33.1, pygments→2.20.0, litellm→1.83.4 to address 15 CVEs (#35)
 - fix(prompts): fence untrusted paper content in PROOF_VERIFY, CONTRIBUTION_EXTRACTION, and PERPLEXITY templates to mitigate prompt injection (#36)
+- fix(deploy): use hmac.compare_digest for webhook token check in modal_worker (#41)
+- fix(deploy): extend _sanitize_error to cover Groq, Perplexity, and Anthropic key prefixes (#41)
+- fix(extraction): scrub bearer tokens and API keys from error messages before raise/log on CLI path (#41)
 
 ### Added
 

--- a/deploy/modal_worker.py
+++ b/deploy/modal_worker.py
@@ -14,6 +14,7 @@ Secrets: Create in Modal dashboard:
 
 from __future__ import annotations
 
+import hmac
 from pathlib import Path
 
 import modal
@@ -89,8 +90,15 @@ def _sanitize_error(msg: str) -> str:
 
     # OpenRouter keys: sk-or-v1-...
     msg = re.sub(r"sk-or-v1-[a-zA-Z0-9]{20,}", "[key]", msg)
+    # Anthropic keys: sk-ant-... (caught by generic sk- below but listed
+    # explicitly so the provider coverage is obvious at a glance).
+    msg = re.sub(r"sk-ant-[a-zA-Z0-9_-]{20,}", "[key]", msg)
     # Standard OpenAI-style keys: sk-...
     msg = re.sub(r"sk-[a-zA-Z0-9-]{20,}", "[key]", msg)
+    # Groq keys: gsk_...
+    msg = re.sub(r"gsk_[a-zA-Z0-9_]{20,}", "[key]", msg)
+    # Perplexity keys: pplx-...
+    msg = re.sub(r"pplx-[a-zA-Z0-9]{20,}", "[key]", msg)
     # Gemini/Google API keys: AIza...
     msg = re.sub(r"AIza[a-zA-Z0-9_-]{30,}", "[key]", msg)
     # JWTs / Supabase service keys: eyJ...
@@ -329,7 +337,9 @@ def run_review(request: Request, req: ReviewRequest):
 
     expected = os.environ.get("MODAL_WEBHOOK_SECRET", "")
     token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
-    if not expected or not token or token != expected:
+    # `hmac.compare_digest` requires same-type non-empty inputs, so keep the
+    # truthiness guard before the constant-time compare.
+    if not expected or not token or not hmac.compare_digest(token, expected):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     do_review.spawn(req.model_dump())

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -24,6 +24,35 @@ logger = logging.getLogger(__name__)
 PAGE_BREAK = "\n\n<!-- PAGE BREAK -->\n\n"
 
 
+# Secret-scrub patterns used on backend failure strings before they reach
+# logger.warning() or the raised ExtractionError. Kept as a small duplicate
+# of deploy/modal_worker.py::_sanitize_error — cross-importing between
+# src/ and deploy/ would be worse than 10 lines of duplication.
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"Bearer\s+\S+", re.IGNORECASE), "Bearer [key]"),
+    (re.compile(r"sk-or-v1-[a-zA-Z0-9]{20,}"), "[key]"),
+    (re.compile(r"sk-ant-[a-zA-Z0-9_-]{20,}"), "[key]"),
+    (re.compile(r"sk-[a-zA-Z0-9-]{20,}"), "[key]"),
+    (re.compile(r"gsk_[a-zA-Z0-9_]{20,}"), "[key]"),
+    (re.compile(r"pplx-[a-zA-Z0-9]{20,}"), "[key]"),
+    (re.compile(r"AIza[a-zA-Z0-9_-]{30,}"), "[key]"),
+    (re.compile(r"eyJ[a-zA-Z0-9_-]{20,}"), "[key]"),
+)
+
+
+def _scrub_secrets(msg: str) -> str:
+    """Strip API keys and bearer tokens from an error string.
+
+    Applied to backend-failure strings before they are logged or embedded in
+    an ExtractionError. Without this, litellm-wrapped exceptions whose
+    stringification embeds request headers can surface Authorization
+    tokens to CLI users' terminals and logs.
+    """
+    for pattern, replacement in _SECRET_PATTERNS:
+        msg = pattern.sub(replacement, msg)
+    return msg
+
+
 def _get_api_error_status(exc: Exception) -> int | None:
     """Extract HTTP status code from an API error, if present."""
     status = getattr(exc, "status_code", None) or getattr(exc, "code", None)
@@ -651,11 +680,12 @@ def extract_text(pdf_path: str | Path, use_cache: bool = True) -> PaperText:
             api_msg = _classify_api_error(exc)
             if api_msg:
                 raise ExtractionError(api_msg) from exc
-            errors.append(f"{name}: {exc}")
-            logger.warning("%s failed: %s", name, exc)
+            scrubbed = _scrub_secrets(str(exc))
+            errors.append(f"{name}: {scrubbed}")
+            logger.warning("%s failed: %s", name, scrubbed)
 
     if full_markdown is None:
-        detail = "; ".join(errors)
+        detail = _scrub_secrets("; ".join(errors))
         raise ExtractionError(f"Cannot convert PDF: all extraction backends failed. {detail}")
 
     # Normalize Mistral OCR artifacts unconditionally

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,4 +1,5 @@
 """Tests for coarse.extraction."""
+
 from __future__ import annotations
 
 import os
@@ -10,8 +11,8 @@ import pytest
 from coarse.extraction import (
     SUPPORTED_EXTENSIONS,
     _estimate_tokens,
-    _extract_latex_regex,
     _response_was_billed,
+    _scrub_secrets,
     compute_garble_ratio,
     extract_file,
     extract_text,
@@ -34,15 +35,19 @@ def _mock_ocr_response(pages_markdown: list[str]):
     """
     content_items = [{"type": "text", "text": md} for md in pages_markdown]
     data = {
-        "choices": [{
-            "message": {
-                "annotations": [{
-                    "type": "file",
-                    "file": {"content": content_items},
-                }],
-                "content": None,
+        "choices": [
+            {
+                "message": {
+                    "annotations": [
+                        {
+                            "type": "file",
+                            "file": {"content": content_items},
+                        }
+                    ],
+                    "content": None,
+                }
             }
-        }]
+        ]
     }
     resp = MagicMock()
     resp.status_code = 200
@@ -147,13 +152,15 @@ def test_fallback_to_docling(minimal_pdf: Path) -> None:
     mock_docling.document_converter.DocumentConverter = mock_converter_cls
 
     # Ensure no OpenRouter key (resolve_api_key) so the OpenRouter backend skips
-    env_clean = {k: v for k, v in os.environ.items()
-                 if k not in ("OPENROUTER_API_KEY",)}
+    env_clean = {k: v for k, v in os.environ.items() if k not in ("OPENROUTER_API_KEY",)}
     with patch.dict(os.environ, env_clean, clear=True):
-        with patch.dict("sys.modules", {
-            "docling": mock_docling,
-            "docling.document_converter": mock_docling.document_converter,
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "docling": mock_docling,
+                "docling.document_converter": mock_docling.document_converter,
+            },
+        ):
             result = extract_text(minimal_pdf, use_cache=False)
 
     assert "Docling Fallback" in result.full_markdown
@@ -164,8 +171,7 @@ def test_all_backends_fail(minimal_pdf: Path) -> None:
     from coarse.types import ExtractionError
 
     # Ensure no OpenRouter key (resolve_api_key) so OpenRouter backend skips
-    env_clean = {k: v for k, v in os.environ.items()
-                 if k not in ("OPENROUTER_API_KEY",)}
+    env_clean = {k: v for k, v in os.environ.items() if k not in ("OPENROUTER_API_KEY",)}
     with patch.dict(os.environ, env_clean, clear=True):
         with patch.dict(
             "sys.modules",
@@ -188,6 +194,7 @@ def _mock_error_response(status: int, body: dict | str):
         resp.json.side_effect = ValueError(f"invalid json: {body}")
     if status >= 400:
         import requests as _r
+
         http_err = _r.HTTPError(f"{status} Error", response=resp)
         resp.raise_for_status.side_effect = http_err
     else:
@@ -202,9 +209,15 @@ def test_openrouter_ocr_http_200_with_error_body(minimal_pdf: Path) -> None:
     The error message is intentionally one that doesn't match any keyword in
     _classify_api_error, so we can see our own ExtractionError text pass through.
     """
-    error_response = _mock_error_response(200, {
-        "error": {"message": "file-parser plugin temporarily unavailable", "code": "plugin_error"},
-    })
+    error_response = _mock_error_response(
+        200,
+        {
+            "error": {
+                "message": "file-parser plugin temporarily unavailable",
+                "code": "plugin_error",
+            },
+        },
+    )
     with patch("requests.post", return_value=error_response):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             with patch.dict(
@@ -221,9 +234,12 @@ def test_openrouter_ocr_http_200_with_error_body(minimal_pdf: Path) -> None:
 def test_openrouter_ocr_classifies_402_as_spend_limit(minimal_pdf: Path) -> None:
     """HTTP 200 with a credits-related error body should be classified into a
     user-friendly spend limit message by the extraction orchestrator."""
-    error_response = _mock_error_response(200, {
-        "error": {"message": "Insufficient credits", "code": 402},
-    })
+    error_response = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Insufficient credits", "code": 402},
+        },
+    )
     with patch("requests.post", return_value=error_response):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             with patch.dict(
@@ -252,14 +268,19 @@ def test_openrouter_ocr_malformed_annotation_falls_back_to_content(
 ) -> None:
     """Malformed annotations (e.g. missing 'file' key) should not crash;
     should fall back to message.content instead."""
-    resp = _mock_error_response(200, {
-        "choices": [{
-            "message": {
-                "annotations": [{"type": "file"}],  # missing 'file' key entirely
-                "content": "Fallback markdown text",
-            }
-        }]
-    })
+    resp = _mock_error_response(
+        200,
+        {
+            "choices": [
+                {
+                    "message": {
+                        "annotations": [{"type": "file"}],  # missing 'file' key entirely
+                        "content": "Fallback markdown text",
+                    }
+                }
+            ]
+        },
+    )
     with patch("requests.post", return_value=resp):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             result = extract_text(minimal_pdf, use_cache=False)
@@ -268,9 +289,9 @@ def test_openrouter_ocr_malformed_annotation_falls_back_to_content(
 
 def test_openrouter_ocr_empty_content_raises(minimal_pdf: Path) -> None:
     """When both annotations and content are empty, raise ExtractionError."""
-    empty_resp = _mock_error_response(200, {
-        "choices": [{"message": {"annotations": [], "content": ""}}]
-    })
+    empty_resp = _mock_error_response(
+        200, {"choices": [{"message": {"annotations": [], "content": ""}}]}
+    )
     with patch("requests.post", return_value=empty_resp):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
             with patch.dict(
@@ -282,7 +303,8 @@ def test_openrouter_ocr_empty_content_raises(minimal_pdf: Path) -> None:
 
 
 def test_openrouter_ocr_retries_on_connection_error(
-    minimal_pdf: Path, mock_ocr_pages,
+    minimal_pdf: Path,
+    mock_ocr_pages,
 ) -> None:
     """Transient connection errors should be retried up to _OCR_MAX_RETRIES."""
     import requests as _r
@@ -323,7 +345,8 @@ def test_openrouter_ocr_gives_up_after_max_retries(minimal_pdf: Path) -> None:
 
 
 def test_openrouter_ocr_retries_on_503(
-    minimal_pdf: Path, mock_ocr_pages,
+    minimal_pdf: Path,
+    mock_ocr_pages,
 ) -> None:
     """HTTP 503 should trigger a retry; subsequent success should be returned."""
     success = _mock_ocr_response(mock_ocr_pages)
@@ -337,14 +360,18 @@ def test_openrouter_ocr_retries_on_503(
 
 
 def test_openrouter_ocr_retries_on_200_with_body_error_504(
-    minimal_pdf: Path, mock_ocr_pages,
+    minimal_pdf: Path,
+    mock_ocr_pages,
 ) -> None:
     """The real production failure mode: HTTP 200 with {error: {code: 504,
     message: "Timed out parsing tmp.pdf"}}. Should be retried just like raw 504."""
     success = _mock_ocr_response(mock_ocr_pages)
-    timeout_body = _mock_error_response(200, {
-        "error": {"message": "Timed out parsing tmp.pdf", "code": 504},
-    })
+    timeout_body = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Timed out parsing tmp.pdf", "code": 504},
+        },
+    )
     # First call returns the 200-with-504 body, second call succeeds
     with patch("requests.post", side_effect=[timeout_body, success]):
         with patch("time.sleep"):
@@ -354,13 +381,17 @@ def test_openrouter_ocr_retries_on_200_with_body_error_504(
 
 
 def test_openrouter_ocr_retries_on_200_with_body_error_502(
-    minimal_pdf: Path, mock_ocr_pages,
+    minimal_pdf: Path,
+    mock_ocr_pages,
 ) -> None:
     """200 with {error: {code: 502}} is also a transient upstream error."""
     success = _mock_ocr_response(mock_ocr_pages)
-    bad_gateway = _mock_error_response(200, {
-        "error": {"message": "Upstream bad gateway", "code": 502},
-    })
+    bad_gateway = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Upstream bad gateway", "code": 502},
+        },
+    )
     with patch("requests.post", side_effect=[bad_gateway, success]):
         with patch("time.sleep"):
             with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
@@ -373,9 +404,12 @@ def test_openrouter_ocr_does_not_retry_on_200_with_body_error_402(
 ) -> None:
     """Non-retryable body codes (402 spend limit, 401 auth) should fail fast —
     no point wasting retries on a billing problem."""
-    spend_limit = _mock_error_response(200, {
-        "error": {"message": "Insufficient credits", "code": 402},
-    })
+    spend_limit = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Insufficient credits", "code": 402},
+        },
+    )
     post_mock = MagicMock(return_value=spend_limit)
     with patch("requests.post", post_mock):
         with patch("time.sleep"):
@@ -401,9 +435,12 @@ def test_openrouter_ocr_retries_on_200_body_504_then_gives_up(
     """
     from coarse.extraction import _OCR_MAX_RETRIES
 
-    timeout_body = _mock_error_response(200, {
-        "error": {"message": "Timed out parsing", "code": 504},
-    })
+    timeout_body = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Timed out parsing", "code": 504},
+        },
+    )
     post_mock = MagicMock(return_value=timeout_body)
     with patch("requests.post", post_mock):
         with patch("time.sleep"):
@@ -419,15 +456,19 @@ def test_openrouter_ocr_retries_on_200_body_504_then_gives_up(
 
 
 def test_pdftext_fallback_runs_when_mistral_ocr_persistently_fails(
-    minimal_pdf: Path, mock_ocr_pages,
+    minimal_pdf: Path,
+    mock_ocr_pages,
 ) -> None:
     """When mistral-ocr exhausts retries with a transient body error, the
     extractor chain should fall through to the pdf-text engine before Docling."""
     from coarse.extraction import _OCR_MAX_RETRIES
 
-    timeout_body = _mock_error_response(200, {
-        "error": {"message": "Timed out parsing", "code": 504},
-    })
+    timeout_body = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Timed out parsing", "code": 504},
+        },
+    )
     pdftext_success = _mock_ocr_response(mock_ocr_pages)
 
     # Return timeout body for all mistral-ocr attempts, then success on the
@@ -448,17 +489,20 @@ def test_pdftext_fallback_runs_when_mistral_ocr_persistently_fails(
 
     assert "# Test Paper" in result.full_markdown
     # First N calls are mistral-ocr retries, last call is pdf-text fallback.
-    assert posted_engines[:_OCR_MAX_RETRIES + 1] == ["mistral-ocr"] * (_OCR_MAX_RETRIES + 1)
+    assert posted_engines[: _OCR_MAX_RETRIES + 1] == ["mistral-ocr"] * (_OCR_MAX_RETRIES + 1)
     assert posted_engines[-1] == "pdf-text"
 
 
 def test_ocr_retry_stops_when_response_is_billed(minimal_pdf: Path) -> None:
     """A 200-with-error-body that ALSO reports non-zero usage must not be
     retried — retrying would double-charge the user for a billed error."""
-    billed_timeout = _mock_error_response(200, {
-        "error": {"message": "Timed out parsing", "code": 504},
-        "usage": {"total_tokens": 123, "total_cost": 0.0042},
-    })
+    billed_timeout = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Timed out parsing", "code": 504},
+            "usage": {"total_tokens": 123, "total_cost": 0.0042},
+        },
+    )
     mistral_post_count = {"n": 0}
     pdftext_post_count = {"n": 0}
 
@@ -531,6 +575,7 @@ def test_response_was_billed_usage_is_not_dict():
 def test_response_was_billed_json_raises():
     def raise_value_error():
         raise ValueError("not json")
+
     assert _response_was_billed(_billed_resp(raise_value_error)) is False
 
 
@@ -568,9 +613,12 @@ def test_ocr_backoff_waits_are_capped_at_max_backoff(minimal_pdf: Path) -> None:
     they all patch time.sleep to a no-op."""
     from coarse.extraction import _OCR_MAX_BACKOFF, _OCR_MAX_RETRIES
 
-    timeout_body = _mock_error_response(200, {
-        "error": {"message": "Timed out parsing", "code": 504},
-    })
+    timeout_body = _mock_error_response(
+        200,
+        {
+            "error": {"message": "Timed out parsing", "code": 504},
+        },
+    )
     sleep_args: list[float] = []
 
     def fake_sleep(seconds):
@@ -594,11 +642,12 @@ def test_ocr_backoff_waits_are_capped_at_max_backoff(minimal_pdf: Path) -> None:
         f"backoff not capped: tail is {per_engine[5:]}"
     )
     # Same pattern repeats for the pdf-text tier.
-    assert sleep_args[_OCR_MAX_RETRIES:2 * _OCR_MAX_RETRIES] == per_engine
+    assert sleep_args[_OCR_MAX_RETRIES : 2 * _OCR_MAX_RETRIES] == per_engine
 
 
 def test_pdftext_is_not_called_when_mistral_ocr_succeeds(
-    minimal_pdf: Path, mock_ocr_pages,
+    minimal_pdf: Path,
+    mock_ocr_pages,
 ) -> None:
     """pdf-text is strictly a fallback — when mistral-ocr succeeds on the
     first try, pdf-text must not be hit at all."""
@@ -779,7 +828,9 @@ def test_extract_file_txt(tmp_path: Path) -> None:
 def test_extract_file_md(tmp_path: Path) -> None:
     """Markdown files preserve headings."""
     md = tmp_path / "paper.md"
-    md.write_text("# Introduction\n\nSome content.\n\n## Methods\n\nMore content.", encoding="utf-8")
+    md.write_text(
+        "# Introduction\n\nSome content.\n\n## Methods\n\nMore content.", encoding="utf-8"
+    )
     result = extract_file(md, use_cache=False)
     assert "# Introduction" in result.full_markdown
     assert "## Methods" in result.full_markdown
@@ -843,12 +894,9 @@ def test_extract_file_caching(tmp_path: Path) -> None:
 
 def test_extract_latex_heading_conversion() -> None:
     """All LaTeX heading levels are correctly converted."""
-    result = _extract_latex_regex.__wrapped__(Path("/dev/null")) if hasattr(
-        _extract_latex_regex, "__wrapped__"
-    ) else None
     # Test the regex directly
-    from coarse.extraction import _LATEX_HEADING_RE, _LATEX_HEADING_LEVEL
-    import re
+
+    from coarse.extraction import _LATEX_HEADING_LEVEL, _LATEX_HEADING_RE
 
     test_cases = [
         ("\\section{Intro}", "# Intro"),
@@ -914,3 +962,64 @@ def test_supported_extensions_includes_all_formats() -> None:
     """SUPPORTED_EXTENSIONS includes all documented formats."""
     for ext in [".pdf", ".txt", ".md", ".tex", ".latex", ".html", ".htm", ".docx", ".epub"]:
         assert ext in SUPPORTED_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Secret scrubbing on the error path (issue #41)
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_secrets_strips_bearer_and_keys() -> None:
+    """_scrub_secrets redacts bearer headers and provider API keys."""
+    # Fake fixture strings only — constructed so each line stays under the
+    # line-length limit and gets its own security scanner suppression.
+    openrouter = "sk-or-v1-abcdef0123456789abcdef0123456789"  # security: ignore
+    anthropic = "sk-ant-abcdef0123456789abcdef"  # security: ignore
+    groq = "gsk_abcdefghijklmnopqrst"  # security: ignore
+    perplexity = "pplx-abcdefghijklmnopqrst"  # security: ignore
+    google = "AIzaSyAbcdefghijklmnopqrstuvwxyz0123456"  # security: ignore
+    jwt = "eyJabcdefghijklmnopqrst"  # security: ignore
+    raw = (
+        f"401 Authorization: Bearer {openrouter} | "
+        f"also saw {anthropic} and {groq} "
+        f"and {perplexity} and {google} "
+        f"and {jwt}"
+    )
+    scrubbed = _scrub_secrets(raw)
+    assert "sk-or-v1-abcdef" not in scrubbed
+    assert "sk-ant-abcdef" not in scrubbed
+    assert "gsk_abcdef" not in scrubbed
+    assert "pplx-abcdef" not in scrubbed
+    assert "AIzaSy" not in scrubbed
+    assert "eyJabcdef" not in scrubbed
+    assert "Bearer sk-or-v1" not in scrubbed
+    assert "[key]" in scrubbed
+
+
+def test_extraction_error_message_is_scrubbed(tmp_path: Path) -> None:
+    """All-backends-failed path scrubs secrets from exception strings."""
+    pdf = tmp_path / "paper.pdf"
+    # Minimal valid PDF magic so extract_text() proceeds past header check.
+    pdf.write_bytes(b"%PDF-1.4\n%fake content\n")
+
+    secret_bearer = "Bearer sk-or-v1-abcdef0123456789abcdef0123456789"  # security: ignore
+
+    def _boom(_path):
+        raise RuntimeError(f"upstream 401 with header {secret_bearer}")
+
+    # Force every backend to fail with the same leaky exception. Patching
+    # _classify_api_error to return None keeps the error path in the
+    # fall-through branch (not the immediate user-actionable raise).
+    with (
+        patch("coarse.extraction._extract_mistral_openrouter", side_effect=_boom),
+        patch("coarse.extraction._extract_pdftext_openrouter", side_effect=_boom),
+        patch("coarse.extraction._extract_docling", side_effect=_boom),
+        patch("coarse.extraction._classify_api_error", return_value=None),
+    ):
+        with pytest.raises(ExtractionError) as exc_info:
+            extract_text(pdf, use_cache=False)
+
+    raised = str(exc_info.value)
+    assert "sk-or-v1-abcdef" not in raised
+    assert secret_bearer not in raised
+    assert "[key]" in raised

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -996,8 +996,12 @@ def test_scrub_secrets_strips_bearer_and_keys() -> None:
     assert "[key]" in scrubbed
 
 
-def test_extraction_error_message_is_scrubbed(tmp_path: Path) -> None:
-    """All-backends-failed path scrubs secrets from exception strings."""
+def test_extraction_error_message_is_scrubbed(tmp_path: Path, caplog) -> None:
+    """All-backends-failed path scrubs secrets from both the raised exception
+    AND the logger.warning side-effect. Without the caplog assertion, a
+    refactor that scrubs only at raise time could regress the log path."""
+    import logging
+
     pdf = tmp_path / "paper.pdf"
     # Minimal valid PDF magic so extract_text() proceeds past header check.
     pdf.write_bytes(b"%PDF-1.4\n%fake content\n")
@@ -1011,6 +1015,7 @@ def test_extraction_error_message_is_scrubbed(tmp_path: Path) -> None:
     # _classify_api_error to return None keeps the error path in the
     # fall-through branch (not the immediate user-actionable raise).
     with (
+        caplog.at_level(logging.WARNING, logger="coarse.extraction"),
         patch("coarse.extraction._extract_mistral_openrouter", side_effect=_boom),
         patch("coarse.extraction._extract_pdftext_openrouter", side_effect=_boom),
         patch("coarse.extraction._extract_docling", side_effect=_boom),
@@ -1023,3 +1028,11 @@ def test_extraction_error_message_is_scrubbed(tmp_path: Path) -> None:
     assert "sk-or-v1-abcdef" not in raised
     assert secret_bearer not in raised
     assert "[key]" in raised
+
+    # Logger.warning path must also be scrubbed — the raised ExtractionError
+    # is one channel, the WARNING log is another, and a regression that only
+    # hardens one of them must fail.
+    log_text = caplog.text
+    assert "sk-or-v1-abcdef" not in log_text
+    assert secret_bearer not in log_text
+    assert "[key]" in log_text

--- a/tests/test_modal_worker.py
+++ b/tests/test_modal_worker.py
@@ -1,0 +1,138 @@
+"""Tests for deploy/modal_worker.py — issue #41 hardening.
+
+deploy/modal_worker.py is not a package; it imports `modal` and
+`fastapi` at module load. Neither is a test dependency of coarse, so we
+stub them in sys.modules before loading the file with importlib.
+
+We only test the pure helpers (_sanitize_error) and assert that
+hmac.compare_digest is wired into run_review at module level — a
+mock-based test of run_review itself would require a full FastAPI
+request object and is out of scope.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MODAL_WORKER = _REPO_ROOT / "deploy" / "modal_worker.py"
+
+
+def _install_stubs() -> None:
+    """Install minimal stand-ins for `modal` and `fastapi` in sys.modules."""
+    if "modal" not in sys.modules:
+        modal_stub = types.ModuleType("modal")
+
+        class _App:
+            def __init__(self, *_a, **_kw):
+                pass
+
+            def function(self, *_a, **_kw):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        class _Image:
+            @staticmethod
+            def debian_slim(*_a, **_kw):
+                return _Image()
+
+            def apt_install(self, *_a, **_kw):
+                return self
+
+            def pip_install(self, *_a, **_kw):
+                return self
+
+            def add_local_dir(self, *_a, **_kw):
+                return self
+
+        class _Secret:
+            @staticmethod
+            def from_name(_name):
+                return object()
+
+        modal_stub.App = _App
+        modal_stub.Image = _Image
+        modal_stub.Secret = _Secret
+
+        def _fastapi_endpoint(*_a, **_kw):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+        modal_stub.fastapi_endpoint = _fastapi_endpoint
+        sys.modules["modal"] = modal_stub
+
+    if "fastapi" not in sys.modules:
+        fastapi_stub = types.ModuleType("fastapi")
+
+        class _HTTPException(Exception):
+            def __init__(self, status_code: int, detail: str = "") -> None:
+                super().__init__(detail)
+                self.status_code = status_code
+                self.detail = detail
+
+        class _Request:  # noqa: D401
+            pass
+
+        fastapi_stub.HTTPException = _HTTPException
+        fastapi_stub.Request = _Request
+        sys.modules["fastapi"] = fastapi_stub
+
+
+def _load_modal_worker():
+    _install_stubs()
+    spec = importlib.util.spec_from_file_location("coarse_deploy_modal_worker", _MODAL_WORKER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def modal_worker():
+    return _load_modal_worker()
+
+
+def test_sanitize_error_scrubs_groq_key(modal_worker) -> None:
+    """Groq keys (gsk_...) must be redacted."""
+    raw = "Groq 401: invalid key gsk_abcdefghijklmnopqrstuvwxyz0123"
+    cleaned = modal_worker._sanitize_error(raw)
+    assert "gsk_abcdef" not in cleaned
+    assert "[key]" in cleaned or "[redacted]" in cleaned
+
+
+def test_sanitize_error_scrubs_perplexity_key(modal_worker) -> None:
+    """Perplexity keys (pplx-...) must be redacted."""
+    raw = "Perplexity 401: pplx-abcdefghijklmnopqrstuvwxyz"
+    cleaned = modal_worker._sanitize_error(raw)
+    assert "pplx-abcdef" not in cleaned
+    assert "[key]" in cleaned or "[redacted]" in cleaned
+
+
+def test_sanitize_error_scrubs_anthropic_key(modal_worker) -> None:
+    """Anthropic keys (sk-ant-...) must be redacted explicitly."""
+    raw = "Anthropic 401: sk-ant-abcdefghijklmnopqrstuvwxyz0123"  # security: ignore
+    cleaned = modal_worker._sanitize_error(raw)
+    assert "sk-ant-abcdef" not in cleaned
+    assert "[key]" in cleaned or "[redacted]" in cleaned
+
+
+def test_run_review_uses_constant_time_compare(modal_worker) -> None:
+    """run_review must route token comparison through hmac.compare_digest."""
+    import hmac as _hmac
+
+    # Module-level `hmac` import is present.
+    assert getattr(modal_worker, "hmac", None) is _hmac
+    # And the run_review source references compare_digest directly.
+    import inspect
+
+    src = inspect.getsource(modal_worker.run_review)
+    assert "hmac.compare_digest" in src

--- a/tests/test_modal_worker.py
+++ b/tests/test_modal_worker.py
@@ -101,38 +101,116 @@ def modal_worker():
     return _load_modal_worker()
 
 
+def test_sanitize_error_scrubs_openrouter_key(modal_worker) -> None:
+    """OpenRouter keys (sk-or-v1-...) must be redacted (regression guard)."""
+    raw = "OpenRouter 401: invalid sk-or-v1-abcdefghijklmnopqrstuvwxyz0123"  # security: ignore
+    cleaned = modal_worker._sanitize_error(raw)
+    assert "sk-or-v1-abcdef" not in cleaned
+    assert "[key]" in cleaned
+    assert "OpenRouter 401" in cleaned  # non-secret context preserved
+
+
 def test_sanitize_error_scrubs_groq_key(modal_worker) -> None:
     """Groq keys (gsk_...) must be redacted."""
-    raw = "Groq 401: invalid key gsk_abcdefghijklmnopqrstuvwxyz0123"
+    raw = "Groq 401: invalid key gsk_abcdefghijklmnopqrstuvwxyz0123"  # security: ignore
     cleaned = modal_worker._sanitize_error(raw)
     assert "gsk_abcdef" not in cleaned
-    assert "[key]" in cleaned or "[redacted]" in cleaned
+    assert "[key]" in cleaned
+    assert "Groq 401" in cleaned
 
 
 def test_sanitize_error_scrubs_perplexity_key(modal_worker) -> None:
     """Perplexity keys (pplx-...) must be redacted."""
-    raw = "Perplexity 401: pplx-abcdefghijklmnopqrstuvwxyz"
+    raw = "Perplexity 401: pplx-abcdefghijklmnopqrstuvwxyz"  # security: ignore
     cleaned = modal_worker._sanitize_error(raw)
     assert "pplx-abcdef" not in cleaned
-    assert "[key]" in cleaned or "[redacted]" in cleaned
+    assert "[key]" in cleaned
+    assert "Perplexity 401" in cleaned
 
 
 def test_sanitize_error_scrubs_anthropic_key(modal_worker) -> None:
-    """Anthropic keys (sk-ant-...) must be redacted explicitly."""
+    """Anthropic keys (sk-ant-...) must be redacted explicitly (before generic sk-)."""
     raw = "Anthropic 401: sk-ant-abcdefghijklmnopqrstuvwxyz0123"  # security: ignore
     cleaned = modal_worker._sanitize_error(raw)
-    assert "sk-ant-abcdef" not in cleaned
-    assert "[key]" in cleaned or "[redacted]" in cleaned
+    # The WHOLE match must be replaced — not left with a dangling `ant-...` tail.
+    assert "sk-ant-" not in cleaned
+    assert "ant-abcdef" not in cleaned
+    assert "[key]" in cleaned
+    assert "Anthropic 401" in cleaned
 
 
-def test_run_review_uses_constant_time_compare(modal_worker) -> None:
-    """run_review must route token comparison through hmac.compare_digest."""
-    import hmac as _hmac
+def _make_req(job_id: str = "j1"):
+    return types.SimpleNamespace(job_id=job_id, model_dump=lambda: {"job_id": job_id})
 
-    # Module-level `hmac` import is present.
-    assert getattr(modal_worker, "hmac", None) is _hmac
-    # And the run_review source references compare_digest directly.
-    import inspect
 
-    src = inspect.getsource(modal_worker.run_review)
-    assert "hmac.compare_digest" in src
+def _make_request(auth_header: str | None):
+    headers: dict[str, str] = {}
+    if auth_header is not None:
+        headers["Authorization"] = auth_header
+    return types.SimpleNamespace(headers=headers)
+
+
+def _fake_hmac(return_value: bool):
+    from unittest.mock import MagicMock
+
+    mock = MagicMock(return_value=return_value)
+    return types.SimpleNamespace(compare_digest=mock), mock
+
+
+def test_run_review_rejects_empty_secret(modal_worker, monkeypatch) -> None:
+    """Empty MODAL_WEBHOOK_SECRET must reject without calling compare_digest."""
+    from fastapi import HTTPException
+
+    monkeypatch.setenv("MODAL_WEBHOOK_SECRET", "")
+    fake, compare_mock = _fake_hmac(return_value=True)
+    monkeypatch.setattr(modal_worker, "hmac", fake)
+
+    with pytest.raises(HTTPException) as exc:
+        modal_worker.run_review(_make_request("Bearer anything"), _make_req())
+    assert exc.value.status_code == 401
+    compare_mock.assert_not_called()
+
+
+def test_run_review_rejects_empty_token(modal_worker, monkeypatch) -> None:
+    """Empty/missing Authorization header must reject without calling compare_digest."""
+    from fastapi import HTTPException
+
+    monkeypatch.setenv("MODAL_WEBHOOK_SECRET", "realsecret")
+    fake, compare_mock = _fake_hmac(return_value=True)
+    monkeypatch.setattr(modal_worker, "hmac", fake)
+
+    with pytest.raises(HTTPException) as exc:
+        modal_worker.run_review(_make_request(None), _make_req())
+    assert exc.value.status_code == 401
+    compare_mock.assert_not_called()
+
+
+def test_run_review_rejects_wrong_token(modal_worker, monkeypatch) -> None:
+    """Non-matching token must reject via hmac.compare_digest returning False."""
+    from fastapi import HTTPException
+
+    monkeypatch.setenv("MODAL_WEBHOOK_SECRET", "realsecret")
+    fake, compare_mock = _fake_hmac(return_value=False)
+    monkeypatch.setattr(modal_worker, "hmac", fake)
+
+    with pytest.raises(HTTPException) as exc:
+        modal_worker.run_review(_make_request("Bearer wrongtoken"), _make_req())
+    assert exc.value.status_code == 401
+    compare_mock.assert_called_once_with("wrongtoken", "realsecret")
+
+
+def test_run_review_accepts_valid_token(modal_worker, monkeypatch) -> None:
+    """Matching token routes through hmac.compare_digest and spawns the worker."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("MODAL_WEBHOOK_SECRET", "realsecret")
+    fake, compare_mock = _fake_hmac(return_value=True)
+    monkeypatch.setattr(modal_worker, "hmac", fake)
+
+    spawn_mock = MagicMock()
+    monkeypatch.setattr(modal_worker, "do_review", types.SimpleNamespace(spawn=spawn_mock))
+
+    result = modal_worker.run_review(_make_request("Bearer realsecret"), _make_req("j42"))
+    assert result == {"status": "accepted", "job_id": "j42"}
+    compare_mock.assert_called_once_with("realsecret", "realsecret")
+    spawn_mock.assert_called_once_with({"job_id": "j42"})


### PR DESCRIPTION
## Summary
Three narrow security fixes from the pre-PR audit:
- Constant-time webhook token compare in `run_review` (`hmac.compare_digest`)
- Extend `_sanitize_error` to scrub Groq (`gsk_`), Perplexity (`pplx-`), and explicit Anthropic (`sk-ant-`) key prefixes
- New `_scrub_secrets` helper in `extraction.py` applied to error messages before `logger.warning` and `ExtractionError` on the CLI path

Closes #41. Task 3(a) — user-key-in-spawn-payload — is explicitly out of scope and tracked separately.

## Test plan
- [x] New tests for scrub helpers across all provider prefixes
- [x] Extraction-error scrub test exercises the backend-failure loop
- [x] `uv run pytest tests/ -v` — all tests pass
- [x] `python3 scripts/security_scanner.py` — clean
- [x] `uv run ruff check` — no new issues in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)