### PR TITLE
fix(ci): cron cutoff timestamp must use Z suffix for PostgREST

### DIFF
--- a/.github/workflows/cleanup_review_secrets.yml
+++ b/.github/workflows/cleanup_review_secrets.yml
@@ -45,7 +45,15 @@ jobs:
                   raw = resp.read()
                   return json.loads(raw) if raw else None
 
-          cutoff = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+          # PostgREST URL-decodes query params, which turns the `+` in `+00:00`
+          # into a space and crashes the timestamp parser with SQLSTATE 22007.
+          # Use the `Z` suffix instead — canonical ISO 8601 UTC, no `+` to
+          # mangle. Matches how cleanup_papers.yml handles its cutoff.
+          cutoff = (
+              (datetime.now(timezone.utc) - timedelta(hours=3))
+              .isoformat()
+              .replace("+00:00", "Z")
+          )
 
           # Count the rows we're about to delete, then delete them. Two calls so
           # we can log the count without relying on the DELETE response shape.


### PR DESCRIPTION
## Summary
Hotfix: every firing of \`cleanup_review_secrets.yml\` since v1.1.6 deployed has failed with PostgreSQL SQLSTATE 22007 because \`datetime.isoformat()\` produces \`+00:00\` and the \`+\` gets URL-decoded to a space by PostgREST's query-string handling.

Concrete error body from run [24289560573](https://github.com/Davidvandijcke/coarse/actions/runs/24289560573):
\`\`\`
HTTP 400 Bad Request
{"code":"22007","message":"invalid input syntax for type timestamp with time zone: \"2026-04-11T16:11:28.371863 00:00\"}
\`\`\`

The sibling \`cleanup_papers.yml\` cron was written correctly and uses \`.replace("+00:00", "Z")\` — I failed to copy that idiom when I wrote the new cron in PR #50. This brings them to parity.

## Why hotfix directly on main
GitHub Actions schedules run from the default branch's workflow file. Merging this into \`dev\` wouldn't take effect until the next release — \`main\` needs the fix to unbreak the TTL safety net immediately.

## Impact window
Every cron firing between the v1.1.6 deploy (2026-04-11 18:54 UTC) and this hotfix landing has been a no-op failure. In practice no orphan rows accumulated during the window — my post-deploy watcher + manual reconciliation of the 2 dropped submissions from issue #63 already cleared them. But if a future burst of Vercel-dropped submissions leaves orphans, they'd sit until this fix lands.

## Test plan
- [x] `yaml` syntax still parses (pre-commit `check yaml` passed)
- [ ] First post-merge cron firing prints `review_secrets: nothing to clean` (or a positive count + deletion). I'll verify after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)