### PR TITLE
fix(web): legible placeholder for author-notes textarea

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -114,6 +114,34 @@ body::after {
 .field-line-mono::placeholder { color: var(--tray); }
 .field-line-mono:focus { border-bottom-color: var(--yellow-chalk); }
 
+/* Multi-line variant for the author-notes textarea. The single-line
+   .field-line inputs hide placeholders in var(--tray) against a
+   transparent background, which works for short labels but makes a
+   long multi-line placeholder illegible. The textarea sits on
+   var(--board-surface) with a visible box border, and the placeholder
+   picks up var(--dust) for readable contrast. */
+.field-line-textarea {
+  width: 100%;
+  resize: vertical;
+  outline: none;
+  color: var(--chalk);
+  background: var(--board-surface);
+  border: 1px solid var(--tray);
+  border-radius: 2px;
+  font-family: Georgia, serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: 0.6rem 0.75rem;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+.field-line-textarea::placeholder {
+  color: var(--dust);
+  opacity: 1;  /* Firefox defaults to 0.54 — set to 1 so --dust isn't halved */
+  font-style: italic;
+}
+.field-line-textarea:focus { border-color: var(--yellow-chalk); }
+
 /* ── Chalk tab selectors ─────────────────────────────────── */
 .chalk-tab {
   font-family: var(--font-chalk);

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -768,20 +768,7 @@ export default function Home() {
                 rows={3}
                 maxLength={2000}
                 aria-label="Optional notes to steer the reviewer"
-                className="field-line"
-                style={{
-                  width: "100%",
-                  resize: "vertical",
-                  fontFamily: "Georgia, serif",
-                  fontSize: "1rem",
-                  lineHeight: 1.5,
-                  padding: "0.6rem 0.75rem",
-                  background: "var(--board-surface)",
-                  color: "var(--chalk)",
-                  border: "1px solid var(--tray)",
-                  borderRadius: "2px",
-                  boxSizing: "border-box",
-                }}
+                className="field-line-textarea"
               />
               <p
                 style={{


### PR DESCRIPTION
Follow-up to #67.

## Problem

The textarea I added in #67 used \`className=\"field-line\"\` plus a block of inline styles. The \`.field-line\` CSS class's \`::placeholder\` rule uses \`var(--tray)\` (#2A3138) — fine for short one-line inputs where the hint is redundant and the border alone tells users what to type, but the author-notes textarea has a multi-line placeholder that users **actually need to read**, and it rendered as dark-grey-on-dark-grey against \`var(--board-surface)\` (#242D33).

## Fix

New \`.field-line-textarea\` class in \`globals.css\`:
- \`::placeholder { color: var(--dust); opacity: 1 }\` — \`var(--dust)\` is #6B6862, readable against the board surface. \`opacity: 1\` because Firefox defaults to 0.54 and would halve the already-muted color.
- \`font-style: italic\` on the placeholder so it's visually distinct from real input.
- Box layout (width, resize, border, padding, etc.) migrates from the page.tsx inline-style block into the class, matching the existing \`field-line\` pattern.

Also addresses one of the MEDIUM findings from \`/pre-pr\` on #67: the \`field-line\` class was set on an element whose inline styles overrode most of what the class provided. Now there's one class, one source of truth, no inline duplication.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`next build\` clean (all 15 routes)
- [ ] Manual: load coarse.ink submit page (preview deploy), confirm the placeholder text inside the textarea is legible and distinct from real user input

🤖 Generated with [Claude Code](https://claude.com/claude-code)