### PR TITLE
fix(extraction): fall back after openrouter OCR denials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- **Extraction now logs real OpenRouter denial details and falls back after paid OCR denials (#71)** — the PDF extractor no longer hard-fails immediately when the first `mistral-ocr` file-parser call comes back as a user-actionable OpenRouter denial. It now records a scrubbed one-line summary of the provider response body (status, message, code, metadata when present) so operators can distinguish `402 Payment Required` / spend-limit failures from `403 Forbidden` privacy-or-terms failures in Modal logs, and it allows the extraction chain to continue from paid `mistral-ocr` to free `pdf-text` / `cloudflare-ai` and then Docling for recoverable OpenRouter `402` / `403` denials. `401` auth failures still fail fast. New tests pin both production-shaped cases: `402` and `403` on the first extraction call now skip retries on that backend, log the scrubbed reason, and successfully fall through to the next extractor when available.
+
 - **Author steering notes now reach all downstream review passes** — `author_notes` is now forwarded beyond the original overview/section/editorial path into `completeness`, `proof_verify`, `cross_section`, and the legacy `crossref`/`critique` fallback so later passes cannot silently drop the requested focus. The shared `author_notes_block()` prompt wrapper was also strengthened to tell agents how to prioritize valid note-aligned comments, while still preserving the rubric, quote rules, and prompt-injection boundary.
 
 ### Fixed

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -123,6 +123,81 @@ def _classify_api_error(exc: Exception) -> str | None:
     return None
 
 
+def _describe_api_error(exc: Exception) -> str | None:
+    """Return a scrubbed one-line summary of the provider response, if any."""
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return None
+
+    parts: list[str] = []
+    status = getattr(resp, "status_code", None)
+    if isinstance(status, int):
+        parts.append(f"status={status}")
+
+    try:
+        body = resp.json()
+    except Exception:
+        body = None
+
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict):
+            message = err.get("message")
+            code = err.get("code")
+            metadata = err.get("metadata")
+            if message:
+                parts.append(f"message={message}")
+            if code is not None:
+                parts.append(f"code={code}")
+            if metadata:
+                parts.append(f"metadata={metadata}")
+        elif err is not None:
+            parts.append(f"error={err}")
+        elif body:
+            parts.append(f"body={body}")
+    elif body is not None:
+        parts.append(f"body={body}")
+    else:
+        text = getattr(resp, "text", None)
+        if text:
+            parts.append(f"body={text}")
+
+    if not parts:
+        return None
+    return _scrub_secrets("; ".join(str(part) for part in parts))[:500]
+
+
+def _can_fall_through_api_error(
+    extractor_name: str,
+    exc: Exception,
+    api_msg: str | None = None,
+) -> bool:
+    """Return True when a user-actionable API error should still try fallback.
+
+    Extraction has a meaningful fallback chain: a paid/provider-specific
+    OpenRouter failure on one PDF engine can still succeed on a cheaper or
+    fully offline backend. Keep 401 as fail-fast, but let 402/403 on
+    OpenRouter extraction engines fall through.
+    """
+    if "OpenRouter" not in extractor_name:
+        return False
+
+    status = _get_api_error_status(exc)
+    if status in {402, 403}:
+        return True
+
+    return api_msg in {
+        "API key spend limit reached. Add credits or raise your limit in your provider dashboard.",
+        (
+            "OpenRouter denied the PDF extraction request (HTTP 403). This usually means "
+            "your OpenRouter account has no credits, your privacy settings block the "
+            "provider we use for extraction, or you haven't accepted that provider's "
+            "terms. Add credits at https://openrouter.ai/credits and review your privacy "
+            "settings at https://openrouter.ai/settings/privacy, then start a new review."
+        ),
+    }
+
+
 SUPPORTED_EXTENSIONS = frozenset(
     {
         ".pdf",
@@ -685,16 +760,33 @@ def extract_text(pdf_path: str | Path, use_cache: bool = True) -> PaperText:
     ]
     full_markdown = None
     errors: list[str] = []
-    for name, fn in extractors:
+    for idx, (name, fn) in enumerate(extractors):
         try:
             full_markdown = fn(path)
             logger.info("Extracted via %s (%d chars)", name, len(full_markdown))
             break
         except Exception as exc:
-            # Surface user-actionable API errors immediately — don't mask
-            # them by falling through to the next backend.
             api_msg = _classify_api_error(exc)
             if api_msg:
+                summary = _describe_api_error(exc)
+                has_fallback = idx < len(extractors) - 1
+                if has_fallback and _can_fall_through_api_error(name, exc, api_msg):
+                    errors.append(f"{name}: {api_msg}")
+                    if summary:
+                        logger.warning(
+                            "%s returned a recoverable API denial; trying fallback backend. %s",
+                            name,
+                            summary,
+                        )
+                    else:
+                        logger.warning(
+                            "%s returned a recoverable API denial; trying fallback backend: %s",
+                            name,
+                            api_msg,
+                        )
+                    continue
+                if summary:
+                    logger.warning("%s failed with API error: %s", name, summary)
                 raise ExtractionError(api_msg) from exc
             scrubbed = _scrub_secrets(str(exc))
             errors.append(f"{name}: {scrubbed}")

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -457,8 +458,11 @@ def test_openrouter_ocr_retries_on_200_with_body_error_502(
 def test_openrouter_ocr_does_not_retry_on_200_with_body_error_402(
     minimal_pdf: Path,
 ) -> None:
-    """Non-retryable body codes (402 spend limit, 401 auth) should fail fast —
-    no point wasting retries on a billing problem."""
+    """Non-retryable 402 body codes should not retry the same backend.
+
+    We still allow the extractor chain to try the next backend, but each
+    OpenRouter engine should only be attempted once for a hard billing error.
+    """
     spend_limit = _mock_error_response(
         200,
         {
@@ -475,8 +479,60 @@ def test_openrouter_ocr_does_not_retry_on_200_with_body_error_402(
                 ):
                     with pytest.raises(ExtractionError):
                         extract_text(minimal_pdf, use_cache=False)
-    # Exactly one call — no retry on 402
-    assert post_mock.call_count == 1
+    # Exactly one call per OpenRouter backend — no retries on 402.
+    assert post_mock.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("status", "body"),
+    [
+        (
+            402,
+            {"error": {"message": "Insufficient credits", "code": 402}},
+        ),
+        (
+            403,
+            {
+                "error": {
+                    "message": "Provider blocked by privacy settings",
+                    "code": "provider_forbidden",
+                    "metadata": {"provider": "mistral"},
+                }
+            },
+        ),
+    ],
+)
+def test_openrouter_ocr_falls_back_after_mistral_api_denial(
+    minimal_pdf: Path,
+    mock_ocr_pages,
+    caplog,
+    status: int,
+    body: dict,
+) -> None:
+    """402/403 on paid Mistral OCR should still try cheaper/offline fallback."""
+    first = _mock_error_response(status, body)
+    second = _mock_ocr_response(mock_ocr_pages)
+    posted_engines: list[str] = []
+
+    def spy_post(url, headers, json, timeout):  # noqa: A002
+        plugins = json.get("plugins") or []
+        engine = plugins[0].get("pdf", {}).get("engine") if plugins else None
+        posted_engines.append(engine)
+        return [first, second][len(posted_engines) - 1]
+
+    with caplog.at_level(logging.WARNING):
+        with patch("requests.post", side_effect=spy_post):
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}):
+                result = extract_text(minimal_pdf, use_cache=False)
+
+    assert "# Test Paper" in result.full_markdown
+    assert posted_engines == ["mistral-ocr", "pdf-text"]
+    assert "recoverable API denial" in caplog.text
+    if status == 402:
+        assert "Insufficient credits" in caplog.text
+    else:
+        assert "Provider blocked by privacy settings" in caplog.text
+        assert "provider_forbidden" in caplog.text
 
 
 def test_openrouter_ocr_retries_on_200_body_504_then_gives_up(


### PR DESCRIPTION
## Summary
- log scrubbed OpenRouter extraction denial details for operator diagnosis
- continue from paid `mistral-ocr` to `pdf-text`/Docling on recoverable 402/403 denials
- add regression tests for 402 and 403 fallback behavior

## Verification
- `bash scripts/doc-sync-check.sh`
- `python3 scripts/security_scanner.py`
- `uv run pytest tests/test_extraction.py -q`
- `uv run pytest tests/ -v`
- `uv run ruff check src/coarse/extraction.py tests/test_extraction.py`

## Notes
- `make check` is currently blocked by pre-existing lint issues in untouched test files (`tests/test_extraction_qa.py`, `tests/test_quality-eval.py`, `tests/test_quote_verify.py`, `tests/test_synthesis.py`). Full test suite still passes.