### PR TITLE
docs: realign architecture docs with runtime (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 - **Pipeline cost heuristics now come from a shared stage manifest** — the review section cap, stage output budgets, math/cross-section heuristics, and web cost-estimator constants now live in `src/coarse/pipeline_spec.py`, with a generated JSON export consumed by the frontend. This removes the hand-maintained drift between `pipeline.py`, `cost.py`, and `web/src/lib/estimateCost.ts`.
 
+### Changed
+
+- **Architecture docs now match the runtime pipeline** — README, CONTRIBUTING, and CLAUDE now describe the single overview pass, completeness stage, cross-section/editorial flow, and legacy `crossref`/`critique` fallback that the code actually runs. The changelog entry that prematurely claimed `StageRouter`/`STAGE_MODELS` shipped was also corrected, and `scripts/doc-sync-check.sh` now blocks stale architecture phrases from creeping back in.
+
 ## v1.2.2 — 2026-04-12
 
 Patch release. Clears the false "system busy (N/20 slots in use)" banner that the landing page was showing even when Modal was idle, and bundles the unreleased `dev` work (GPT-5.4 compare-panel + author-steering fallthroughs) that had accumulated since v1.2.1.
@@ -95,7 +99,7 @@ Minor release. Headline is the new **optional author-steering notes** field on t
 
 ## v1.1.6 — 2026-04-11
 
-Security and routing release. Headline fix is the user-OpenRouter-key ferry (#50): the user's API key no longer rides through Modal's `spawn()` managed-queue payload. Also ships the per-stage model routing feature (`StageRouter` + `STAGE_MODELS` + `--stage-override`) — the three "Added" entries below were retroactively documented under v1.1.4 on `dev` but never actually landed in the tagged v1.1.4 or v1.1.5 releases; they ship for real in v1.1.6. Rounds out with a cheap-tier glm-5.1 thinking-mode fix found in end-to-end testing and a double-click race fix in the `/api/submit` route.
+Security release. Headline fix is the user-OpenRouter-key ferry (#50): the user's API key no longer rides through Modal's `spawn()` managed-queue payload. The three routing entries below were documented in error during the v1.1.4/v1.1.5 cycle and did not ship in v1.1.6; the runtime still used a single shared `LLMClient` threaded through `pipeline.py`. They are retained here as historical notes so the release log stays auditable. The release also includes a cheap-tier glm-5.1 thinking-mode fix found in end-to-end testing and a double-click race fix in the `/api/submit` route.
 
 ### Security
 
@@ -104,13 +108,13 @@ Security and routing release. Headline fix is the user-OpenRouter-key ferry (#50
 
 ### Added
 
-- **Per-stage model routing (`--stage-override`, `STAGE_MODELS`)** — the review pipeline now resolves an LLM client per stage instead of threading a single client through every agent. Stages classified as "cheap-safe" (`metadata`, `math_detection`, `contribution_extraction`, `calibration`) are pinned to a new `CHEAP_STAGE_MODEL = "z-ai/glm-5.1"` regardless of what `--model` the user passes, while reasoning-heavy stages (`overview`, `completeness`, `section`, `cross_section`, `verify`, `editorial`) use `--model` as-is. The routing map lives in `src/coarse/models.py::STAGE_MODELS`; the resolver is `src/coarse/routing.py::StageRouter`; the CLI gets a repeatable `--stage-override name=model` flag for ad-hoc per-stage overrides. Worked example: running `coarse-ink review paper.pdf --model anthropic/claude-opus-4.6` previously paid opus rates (~$15/$75 per 1M tok) on the trivial 500-token `metadata` call and the 2000-token `math_detection` call; now those route to glm-5.1 on US-HQ providers while overview/section/editorial continue to use opus. Estimated savings ≈$0.30-0.40 per review. Theory-driven classification (gh #46), not empirically validated — per-stage regressions are recoverable via `--stage-override`.
-- **US-HQ provider allowlist for cheap-tier routing (`CHEAP_STAGE_PROVIDERS`)** — the glm-5.1 cheap tier is restricted to `("DeepInfra", "Parasail", "Fireworks")` via OpenRouter's `provider.only` preference so request data stays on US servers even though the model weights are from a Chinese company. Layered on top of the existing `data_collection=deny` injection: both are active. Enforced through a new `LLMClient(provider_allowlist=...)` kwarg and `_apply_provider_prefs` helper that merge the allowlist into `extra_body.provider.only` on every call. Z.AI's own hosting (HQ=SG) and Alibaba (the only qwen endpoint, HQ=SG+CN) are explicitly excluded.
-- **Cheap-tier kimi-k2.5 fallback (`CHEAP_STAGE_FALLBACK_MODEL`)** — if the glm-5.1 call fails (provider outage, transient OpenRouter error), the `StageRouter`-built cheap client transparently retries on `moonshotai/kimi-k2.5` with the same `CHEAP_STAGE_PROVIDERS` US-HQ allowlist. Each underlying model gets its own instructor mode (JSON for glm, MD_JSON for kimi — required because kimi is in `MARKDOWN_JSON_PREFIXES`), so the fallback is client-level rather than OpenRouter's server-side `models` preference. Wired through a new `LLMClient(fallback_client=...)` kwarg that catches exceptions in `complete()` / `complete_text()` and delegates to the fallback's method with the same kwargs. Both primary and fallback clients are cached in the router so their cumulative costs both flow into `router.cost_usd`.
+- **Historical note: per-stage model routing docs were premature** — this feature set (`--stage-override`, `STAGE_MODELS`, `StageRouter`) was described in release notes before the implementation existed. It did not ship in v1.1.6; the actual runtime still used one shared `LLMClient` in `pipeline.py`. Any future implementation should land in code first, then be documented.
+- **Historical note: cheap-tier provider allowlist docs were premature** — the documented `CHEAP_STAGE_PROVIDERS` allowlist and related provider-routing helpers were not present in the released code for v1.1.6.
+- **Historical note: cheap-tier kimi fallback docs were premature** — the documented `CHEAP_STAGE_FALLBACK_MODEL` / router-level fallback path was not present in the released code for v1.1.6.
 
 ### Fixed
 
-- **Cheap-tier glm-5.1 no longer truncates on invisible thinking overhead** — end-to-end test of the per-stage routing on a 20k+ token paper surfaced a systematic `instructor.core.exceptions.IncompleteOutputException` on every glm-5.1 cheap-tier structured-output call. Root cause: glm-5.1 via OpenRouter defaults to thinking-on, and the invisible reasoning preamble consumes `max_tokens` before any JSON emits. Structured-output calls with `max_tokens <= 2048` (metadata 256, math_detection 1024, calibration 2048, contribution_extraction 2048) never reached the JSON phase. Fix applies OpenRouter's documented `{"reasoning": {"effort": "none"}}` to both the glm-5.1 primary and the kimi-k2.5 fallback via a new `LLMClient(default_extra_body=...)` kwarg that merges per-call `extra_body` with `setdefault` so caller-supplied fields still win. `StageRouter._build_client` applies `_CHEAP_STAGE_EXTRA_BODY = {"reasoning": {"effort": "none"}}` to both the cheap primary and fallback. Pre-fix every cheap-tier call silently failed over to the kimi fallback; post-fix both paths clean-exit. Three new tests in `tests/test_llm.py` and `tests/test_routing.py`.
+- **Historical note: cheap-tier glm-5.1 routing fix docs were premature** — this note referred to the same unshipped stage-routing implementation above and did not correspond to code in the v1.1.6 release artifact.
 
 ## v1.1.5 — 2026-04-11
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,15 @@ paper (PDF, TXT, MD, TeX, DOCX, HTML, EPUB)
     → [structure.py]     Parse headings + LLM → PaperStructure (sections, math detection, domain)
     → [calibrate_domain] Domain-specific review criteria (parallel with literature)
     → [literature.py]    Perplexity Sonar Pro search, arXiv fallback (parallel with calibration)
-    → [overview panel]   3-judge panel → synthesized OverviewFeedback (4-6 macro issues)
+    → [overview.py]      Single overview agent → OverviewFeedback (macro issues)
+    → [completeness.py]  Structural-gap pass merged into overview
     → [section agents]   LLM → 15-25 detailed comments (1 per section, parallel)
     → [verify agent]     Adversarial proof verification (math sections only, chained)
-    → [crossref agent]   LLM → deduplicate, validate quotes, consistency
+    → [cross_section.py] Results ↔ discussion synthesis (conditional)
+    → [editorial.py]     Primary filtering pass → dedup, contradiction, quality, ordering
+    → [crossref.py]      Legacy fallback if editorial fails
+    → [critique.py]      Legacy fallback if editorial fails
     → [quote_verify.py]  Programmatic → exact/normalized/table-aware quote verification
-    → [critique agent]   LLM → self-critique quality gate, revise weak comments
     → [quote_repair.py]  LLM → batched near-miss quote-anchor repair (bounded contexts only)
     → [quote_verify.py]  Programmatic → re-verify repaired quotes before synthesis
     → [synthesis.py]     Deterministic → paper_review.md (refine.ink format)
@@ -68,7 +71,7 @@ src/coarse/
 └── agents/
     ├── __init__.py
     ├── base.py              # ReviewAgent ABC + _build_messages helper + prompt caching
-    ├── overview.py          # 3-judge panel overview (macro-level feedback, 4-6 issues)
+    ├── overview.py          # Single-pass macro-level overview feedback
     ├── section.py           # Per-section detailed review
     ├── completeness.py      # Flags structural gaps and missing content
     ├── cross_section.py     # Cross-section synthesis: discussion claims vs formal results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,11 +44,14 @@ src/coarse/
 ├── quality.py          # Quality eval against reference review (dev only)
 └── agents/
     ├── base.py             # ReviewAgent ABC + prompt caching support
-    ├── overview.py         # 3-judge panel overview (macro-level feedback)
+    ├── overview.py         # Single-pass overview feedback
     ├── section.py          # Per-section detailed review
-    ├── crossref.py         # Cross-reference deduplication
-    ├── critique.py         # Self-critique quality gate
+    ├── completeness.py     # Structural-gap assessment merged into overview
+    ├── editorial.py        # Primary filtering pass for detailed comments
+    ├── crossref.py         # Legacy cross-reference fallback
+    ├── critique.py         # Legacy critique fallback
     ├── verify.py           # Adversarial proof verification for math sections
+    ├── cross_section.py    # Results vs discussion synthesis
     └── literature.py       # Literature search (Perplexity Sonar Pro, arXiv fallback)
 ```
 
@@ -62,14 +65,16 @@ paper.pdf (or .txt, .md, .tex, .docx, .html, .epub)
   -> calibrate_domain \
                        |  Parallel: domain-specific criteria + literature search
   -> search_literature /  (Perplexity Sonar Pro, arXiv fallback)
-  -> overview panel       3-judge panel with different personas -> synthesized OverviewFeedback
+  -> overview.py          Single overview agent -> OverviewFeedback
+  -> completeness.py      Structural-gap pass merged into overview
   -> section agents   \
                        |  Parallel: detailed comments + adversarial proof verification
   -> proof verify      /  (math sections only)
-  -> crossref agent      Deduplicate, validate quotes, consistency
+  -> cross_section.py     Results vs discussion synthesis (conditional)
+  -> editorial.py         Primary dedup/consistency/quality filter
+  -> crossref agent       Legacy fallback if editorial fails
   -> quote_verify.py     Programmatic fuzzy-match quotes against text
-  -> critique agent      Self-critique quality gate, revise weak comments
-  -> quote_verify.py     Re-verify (critique can re-garble quotes via JSON)
+  -> critique agent      Legacy fallback if editorial fails
   -> synthesis.py        Deterministic render -> paper_review.md
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,8 @@ paper.pdf (or .txt, .md, .tex, .docx, .html, .epub)
   -> cross_section.py     Results vs discussion synthesis (conditional)
   -> editorial.py         Primary dedup/consistency/quality filter
   -> crossref agent       Legacy fallback if editorial fails
-  -> quote_verify.py     Programmatic fuzzy-match quotes against text
   -> critique agent      Legacy fallback if editorial fails
+  -> quote_verify.py      Programmatic fuzzy-match quotes against text
   -> synthesis.py        Deterministic render -> paper_review.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,23 +72,25 @@ paper.pdf (or .txt, .md, .tex, .docx, .html, .epub)
   -> Vision LLM spot-check               Optional QA (auto-triggers on garbled text)
   -> Structure analysis                   Parse sections, detect math content, classify domain
   -> Domain calibration + lit search      Parallel: domain-specific criteria + Perplexity Sonar Pro
-  -> 3-judge overview panel               Three personas review full paper, then synthesize
+  -> Overview agent                       Single macro-level review pass
+  -> Completeness agent                   Structural-gap pass merged into overview
   -> Section agents + proof verification  Parallel: 15-25 detailed comments; math sections get adversarial proof check
-  -> Cross-reference agent                Deduplicate, validate consistency
+  -> Cross-section synthesis              Results vs discussion consistency check
+  -> Editorial filter                     Primary deduplication, contradiction, and quality pass
   -> Quote verification                   Fuzzy-match quotes against paper text (stricter for math)
-  -> Self-critique agent                  Quality gate, revise weak comments
-  -> Quote re-verification               Fix any quotes garbled during critique
+  -> Legacy crossref/critique fallback    Only used if the editorial pass fails
   -> Synthesis                            Render final paper_review.md
 ```
 
 The pipeline extracts text, classifies the paper's domain and structure, then generates
 domain-specific review criteria and searches for related literature (via
-[Perplexity Sonar Pro](https://docs.perplexity.ai/), with arXiv fallback). A 3-judge
-overview panel produces macro-level feedback from different perspectives, which is then
-synthesized into a unified assessment. Section agents run in parallel, with an adversarial
-proof verification pass for math-heavy sections. A cross-reference pass deduplicates comments
-and a self-critique agent acts as a quality gate. All quotes are programmatically verified
-against the source text, with stricter thresholds for math content.
+[Perplexity Sonar Pro](https://docs.perplexity.ai/), with arXiv fallback). A single
+overview pass produces macro-level feedback, completeness can add structural gaps, and
+section agents run in parallel with adversarial proof verification for math-heavy sections.
+A conditional cross-section pass checks whether discussion claims are supported by formal
+results, and an editorial pass is the primary deduplication and quality gate. All quotes
+are programmatically verified against the source text, with stricter thresholds for math
+content.
 
 ## Model selection
 
@@ -144,9 +146,9 @@ coarse estimates cost before running and asks for confirmation. The estimate inc
 | Short (< 20pp)  | $0.25 - $0.50 |
 | Long (30+ pp)   | $0.50 - $1    |
 
-**Actual costs can run up to ~2× the estimate** on complex papers depending on
-model reasoning depth, critique agent rewrites, and proof-verification chains
-for math-heavy sections. The 15% buffer is a first approximation, not a ceiling.
+**Actual costs can run materially above the estimate** on complex papers depending on
+model reasoning depth, editorial filtering behavior, and proof-verification chains
+for math-heavy sections. The built-in buffer is conservative, not a ceiling.
 Make sure your OpenRouter per-key spend limit has headroom above the estimate.
 
 The default spending cap is **$10 per review** (`max_cost_usd` in config). Use `--yes` to skip the

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ paper.pdf (or .txt, .md, .tex, .docx, .html, .epub)
   -> Section agents + proof verification  Parallel: 15-25 detailed comments; math sections get adversarial proof check
   -> Cross-section synthesis              Results vs discussion consistency check
   -> Editorial filter                     Primary deduplication, contradiction, and quality pass
-  -> Quote verification                   Fuzzy-match quotes against paper text (stricter for math)
   -> Legacy crossref/critique fallback    Only used if the editorial pass fails
+  -> Quote verification                   Fuzzy-match quotes against paper text (stricter for math)
   -> Synthesis                            Render final paper_review.md
 ```
 
@@ -118,7 +118,7 @@ step-by-step setup instructions, see the [API key guide](https://coarse.vercel.a
 > **Set your OpenRouter per-key spend limit to at least $10** (ideally matching
 > the `max_cost_usd` default of `$10`). If the limit is hit mid-review the run
 > will fail and you'll need to raise the limit and resubmit. Cost estimates
-> shown before each review are approximate (~15% buffer) — they're a guide,
+> shown before each review are approximate (~30% buffer) — they're a guide,
 > not a hard ceiling, so leave yourself headroom.
 
 For direct provider access to chat models (lower latency, separate billing),
@@ -139,7 +139,7 @@ you can set the provider-specific key instead:
 ## Cost
 
 coarse estimates cost before running and asks for confirmation. The estimate includes a
-15% buffer to account for variance.
+30% buffer to account for variance.
 
 | Paper length    | Typical cost  |
 |-----------------|---------------|

--- a/scripts/doc-sync-check.sh
+++ b/scripts/doc-sync-check.sh
@@ -64,11 +64,13 @@ fi
 # 4) No new model-ID literals in the diff outside src/coarse/models.py
 base="${DOC_SYNC_BASE:-dev}"
 if git rev-parse --verify "$base" >/dev/null 2>&1; then
-    diff_files=$(git diff --name-only "${base}...HEAD" 2>/dev/null \
-        | grep -E '^src/coarse/.*\.py$' \
-        | grep -v '^src/coarse/models\.py$' || true)
-    if [ -n "$diff_files" ]; then
-        offenders=$(git diff "${base}...HEAD" -- $diff_files \
+    mapfile -t diff_files < <(
+        git diff --name-only "${base}...HEAD" 2>/dev/null \
+            | grep -E '^src/coarse/.*\.py$' \
+            | grep -v '^src/coarse/models\.py$' || true
+    )
+    if [ "${#diff_files[@]}" -gt 0 ]; then
+        offenders=$(git diff "${base}...HEAD" -- "${diff_files[@]}" \
             | grep -E '^\+' \
             | grep -v '^+++' \
             | grep -Ev '^\+ *#|^\+ *"""|^\+ *\x27\x27\x27' \
@@ -92,11 +94,11 @@ fi
 stale_hits=$(rg -n \
     -e '3-judge overview panel' \
     -e 'overview panel +3-judge' \
+    -e 'crossref \+ critique.*primary path' \
+    -e 'ships the per-stage model routing feature' \
     -e 'crossref agent.*Deduplicate, validate quotes, consistency' \
     -e 'critique agent.*Self-critique quality gate' \
-    -e 'StageRouter' \
-    -e 'STAGE_MODELS' \
-    CLAUDE.md README.md CONTRIBUTING.md 2>/dev/null || true)
+    CLAUDE.md README.md CONTRIBUTING.md CHANGELOG.md 2>/dev/null || true)
 if [ -n "$stale_hits" ]; then
     fail "stale architecture wording found in canonical docs:"
     echo "$stale_hits" | sed 's/^/       /' >&2

--- a/scripts/doc-sync-check.sh
+++ b/scripts/doc-sync-check.sh
@@ -64,11 +64,14 @@ fi
 # 4) No new model-ID literals in the diff outside src/coarse/models.py
 base="${DOC_SYNC_BASE:-dev}"
 if git rev-parse --verify "$base" >/dev/null 2>&1; then
-    mapfile -t diff_files < <(
-        git diff --name-only "${base}...HEAD" 2>/dev/null \
-            | grep -E '^src/coarse/.*\.py$' \
-            | grep -v '^src/coarse/models\.py$' || true
-    )
+    diff_files=()
+    while IFS= read -r file; do
+        diff_files+=("$file")
+    done <<EOF
+$(git diff --name-only "${base}...HEAD" 2>/dev/null \
+    | grep -E '^src/coarse/.*\.py$' \
+    | grep -v '^src/coarse/models\.py$' || true)
+EOF
     if [ "${#diff_files[@]}" -gt 0 ]; then
         offenders=$(git diff "${base}...HEAD" -- "${diff_files[@]}" \
             | grep -E '^\+' \

--- a/scripts/doc-sync-check.sh
+++ b/scripts/doc-sync-check.sh
@@ -88,6 +88,22 @@ else
     note "[WARN] base branch '$base' not found; skipping diff checks"
 fi
 
+# 5) Current architecture docs must match runtime shape
+stale_hits=$(rg -n \
+    -e '3-judge overview panel' \
+    -e 'overview panel +3-judge' \
+    -e 'crossref agent.*Deduplicate, validate quotes, consistency' \
+    -e 'critique agent.*Self-critique quality gate' \
+    -e 'StageRouter' \
+    -e 'STAGE_MODELS' \
+    CLAUDE.md README.md CONTRIBUTING.md 2>/dev/null || true)
+if [ -n "$stale_hits" ]; then
+    fail "stale architecture wording found in canonical docs:"
+    echo "$stale_hits" | sed 's/^/       /' >&2
+else
+    note "[OK] canonical docs match current runtime architecture"
+fi
+
 echo ""
 if [ "$FAIL" -eq 0 ]; then
     echo "doc-sync: OK"

--- a/scripts/doc-sync-check.sh
+++ b/scripts/doc-sync-check.sh
@@ -66,6 +66,7 @@ base="${DOC_SYNC_BASE:-dev}"
 if git rev-parse --verify "$base" >/dev/null 2>&1; then
     diff_files=()
     while IFS= read -r file; do
+        [ -n "$file" ] || continue
         diff_files+=("$file")
     done <<EOF
 $(git diff --name-only "${base}...HEAD" 2>/dev/null \
@@ -94,14 +95,29 @@ else
 fi
 
 # 5) Current architecture docs must match runtime shape
-stale_hits=$(rg -n \
+doc_hits=$(rg -n \
     -e '3-judge overview panel' \
     -e 'overview panel +3-judge' \
     -e 'crossref \+ critique.*primary path' \
     -e 'ships the per-stage model routing feature' \
     -e 'crossref agent.*Deduplicate, validate quotes, consistency' \
     -e 'critique agent.*Self-critique quality gate' \
-    CLAUDE.md README.md CONTRIBUTING.md CHANGELOG.md 2>/dev/null || true)
+    CLAUDE.md README.md CONTRIBUTING.md 2>/dev/null || true)
+changelog_hits=""
+if git rev-parse --verify "$base" >/dev/null 2>&1; then
+    changelog_hits=$(git diff "${base}...HEAD" -- CHANGELOG.md 2>/dev/null \
+        | grep -E '^\+' \
+        | grep -v '^+++' \
+        | rg -n \
+            -e '3-judge overview panel' \
+            -e 'overview panel +3-judge' \
+            -e 'crossref \+ critique.*primary path' \
+            -e 'ships the per-stage model routing feature' \
+            -e 'crossref agent.*Deduplicate, validate quotes, consistency' \
+            -e 'critique agent.*Self-critique quality gate' \
+            || true)
+fi
+stale_hits=$(printf '%s\n%s\n' "$doc_hits" "$changelog_hits" | sed '/^$/d')
 if [ -n "$stale_hits" ]; then
     fail "stale architecture wording found in canonical docs:"
     echo "$stale_hits" | sed 's/^/       /' >&2


### PR DESCRIPTION
Summary:
- align README, CONTRIBUTING, and CLAUDE with the actual runtime pipeline
- correct the premature StageRouter/STAGE_MODELS release-note claims
- harden doc-sync against stale architecture wording and shell path splitting

Test plan:
- python3 scripts/security_scanner.py
- bash scripts/doc-sync-check.sh
- uv run pytest tests/ -v
