### PR TITLE
fix(web): harden client key storage and modal webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **Quote verification now corrects quotes before downstream review handoffs without dropping recall** — the pipeline now programmatically verifies or repairs quotes between section/proof/cross-section/editorial stages so later agents reason over grounded text, but intermediate handoffs use non-dropping verification (`[approximate]` fallback) to preserve review coverage when extraction is noisy. The final output gate remains strict. This review-driven cleanup also removes the dead assumption-checker path and normalizes the recently changed module test files to the `tests/test_{module}.py` convention.
+- **The web app now keeps OpenRouter OAuth keys in tab-only storage and validates Modal webhooks before sending secrets (#95)** — the browser now reads any legacy `localStorage` key once, migrates it into `sessionStorage`, and deletes the persistent copy so a reusable bearer credential is no longer left in local storage. The submit route also rejects invalid `MODAL_FUNCTION_URL` / empty `MODAL_WEBHOOK_SECRET` configurations up front, requires `https` for real deployments, and adds a timeout to the secret-bearing Modal trigger call.
 
 ## v1.2.2 — 2026-04-12
 

--- a/web/src/app/api/submit/route.ts
+++ b/web/src/app/api/submit/route.ts
@@ -5,9 +5,45 @@ import { checkRateLimit } from "@/lib/rateLimit";
 import { isEmailCapacityReached } from "@/lib/emailCapacity";
 
 export const maxDuration = 30;
+const MODAL_TRIGGER_TIMEOUT_MS = 10_000;
+const MODAL_WEBHOOK_HOST_SUFFIX = "--coarse-review-run-review.modal.run";
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function isLocalhost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}
+
+function getModalWebhookConfig(): { url: string; secret: string } | null {
+  const rawUrl = process.env.MODAL_FUNCTION_URL?.trim();
+  if (!rawUrl) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("MODAL_FUNCTION_URL must be a valid absolute URL");
+  }
+
+  const secret = process.env.MODAL_WEBHOOK_SECRET?.trim() ?? "";
+  if (!secret) {
+    throw new Error("MODAL_WEBHOOK_SECRET must be set when MODAL_FUNCTION_URL is configured");
+  }
+
+  if (parsed.protocol === "https:") {
+    if (!parsed.hostname.endsWith(MODAL_WEBHOOK_HOST_SUFFIX)) {
+      throw new Error(`MODAL_FUNCTION_URL must target *${MODAL_WEBHOOK_HOST_SUFFIX}`);
+    }
+    return { url: parsed.toString(), secret };
+  }
+
+  if (parsed.protocol === "http:" && process.env.NODE_ENV !== "production" && isLocalhost(parsed.hostname)) {
+    return { url: parsed.toString(), secret };
+  }
+
+  throw new Error("MODAL_FUNCTION_URL must use https (except http://localhost in development)");
 }
 
 function getMailer() {
@@ -29,6 +65,14 @@ export async function POST(request: NextRequest) {
       { error: "Server not configured — set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY in .env.local" },
       { status: 503 }
     );
+  }
+
+  let modalWebhookConfig: { url: string; secret: string } | null = null;
+  try {
+    modalWebhookConfig = getModalWebhookConfig();
+  } catch (error) {
+    console.error("Invalid Modal webhook configuration", error);
+    return NextResponse.json({ error: "Server not configured to start review workers" }, { status: 503 });
   }
 
   const supabaseAdmin = createClient(supabaseUrl, supabaseKey);
@@ -186,14 +230,16 @@ export async function POST(request: NextRequest) {
   // Trigger Modal worker (fire-and-forget — the worker updates Supabase directly).
   // NOTE: user_api_key is intentionally NOT in the body. The worker resolves it
   // from review_secrets. This keeps the key out of Modal's spawn() payload.
-  const modalUrl = process.env.MODAL_FUNCTION_URL;
-  if (modalUrl) {
-    fetch(modalUrl, {
+  if (modalWebhookConfig) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), MODAL_TRIGGER_TIMEOUT_MS);
+    fetch(modalWebhookConfig.url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.MODAL_WEBHOOK_SECRET ?? ""}`,
+        Authorization: `Bearer ${modalWebhookConfig.secret}`,
       },
+      signal: controller.signal,
       body: JSON.stringify({
         job_id: id,
         pdf_storage_path: storagePath,
@@ -223,6 +269,10 @@ export async function POST(request: NextRequest) {
         }
       })
       .catch(async (fetchErr) => {
+        if (fetchErr instanceof Error && fetchErr.name === "AbortError") {
+          console.warn(`[${id}] Modal webhook timed out after ${MODAL_TRIGGER_TIMEOUT_MS}ms; delivery status unknown`);
+          return;
+        }
         // Modal fetch itself rejected — same cleanup as the !res.ok branch.
         try {
           await supabaseAdmin.from("review_secrets").delete().eq("review_id", id);
@@ -236,6 +286,9 @@ export async function POST(request: NextRequest) {
             cleanupErr,
           });
         }
+      })
+      .finally(() => {
+        clearTimeout(timeoutId);
       });
   }
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -167,6 +167,7 @@ export default function Home() {
   const [authorNotes, setAuthorNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [keyNotice, setKeyNotice] = useState<string | null>(null);
   const [lookupKey, setLookupKey] = useState("");
   const [costEstimate, setCostEstimate] = useState<number | null>(null);
   const [costLoading, setCostLoading] = useState(false);
@@ -182,11 +183,17 @@ export default function Home() {
     fetch("/api/status").then(r => r.json()).then(setSystemStatus).catch(() => {});
   }, []);
 
-  // Hydrate OpenRouter key from localStorage and handle OAuth callback (?code=...)
+  // Hydrate a tab-scoped OpenRouter key and handle OAuth callback (?code=...).
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
-    const stored = loadStoredKey();
+    const { key: stored, migratedFromLocalStorage } = loadStoredKey();
+
+    if (migratedFromLocalStorage) {
+      setKeyNotice(
+        "Moved your saved OpenRouter key into tab-only storage. It will clear when you close this tab.",
+      );
+    }
 
     if (!code) {
       if (stored) setApiKey(stored);
@@ -201,11 +208,12 @@ export default function Home() {
     completeLogin(code)
       .then((key) => {
         setApiKey(key);
+        setKeyNotice(null);
         try {
           saveStoredKey(key);
         } catch {
           setError(
-            "Logged in, but couldn't save the key to your browser. You'll need to log in again next visit.",
+            "Logged in, but couldn't keep the key in this tab. You'll need to paste it again if this page reloads.",
           );
         }
       })
@@ -715,6 +723,7 @@ export default function Home() {
                     onLogout={() => {
                       clearStoredKey();
                       setApiKey("");
+                      setKeyNotice(null);
                     }}
                   />
                 </div>
@@ -747,8 +756,20 @@ export default function Home() {
                     marginTop: "0.4rem",
                   }}
                 >
-                  Stored on your device only. Never saved on our servers.
+                  OAuth keys stay in this tab only and clear when you close it. Never saved on our servers.
                 </p>
+                {keyNotice && (
+                  <p
+                    style={{
+                      fontFamily: "var(--font-chalk)",
+                      fontSize: "1rem",
+                      color: "var(--blue-chalk)",
+                      marginTop: "0.35rem",
+                    }}
+                  >
+                    {keyNotice}
+                  </p>
+                )}
               </div>
             </div>
 

--- a/web/src/lib/openrouterAuth.ts
+++ b/web/src/lib/openrouterAuth.ts
@@ -6,8 +6,28 @@ const KEY_EXCHANGE_URL = "https://openrouter.ai/api/v1/auth/keys";
 const VERIFIER_STORAGE_KEY = "coarse.or_verifier";
 const API_KEY_STORAGE_KEY = "coarse.or_key";
 
+export type StoredKeyResult = {
+  key: string | null;
+  migratedFromLocalStorage: boolean;
+};
+
 function isBrowser(): boolean {
   return typeof window !== "undefined";
+}
+
+function getStorage(kind: "localStorage" | "sessionStorage"): Storage | null {
+  if (!isBrowser()) return null;
+  try {
+    return window[kind];
+  } catch {
+    return null;
+  }
+}
+
+function normalizeStoredKey(value: string | null): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function base64UrlEncode(bytes: Uint8Array): string {
@@ -35,9 +55,11 @@ export async function beginLogin(callbackUrl: string): Promise<void> {
   if (!window.crypto || !window.crypto.subtle) {
     throw new Error("Web Crypto API not available (needs HTTPS or localhost)");
   }
-  window.sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
+  const sessionStorage = getStorage("sessionStorage");
+  if (!sessionStorage) throw new Error("Session storage unavailable");
+  sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
   const { verifier, challenge } = await generatePkcePair();
-  window.sessionStorage.setItem(VERIFIER_STORAGE_KEY, verifier);
+  sessionStorage.setItem(VERIFIER_STORAGE_KEY, verifier);
   const url =
     `${AUTH_URL}?callback_url=${encodeURIComponent(callbackUrl)}` +
     `&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256`;
@@ -46,7 +68,9 @@ export async function beginLogin(callbackUrl: string): Promise<void> {
 
 export async function completeLogin(code: string): Promise<string> {
   if (!isBrowser()) throw new Error("completeLogin called outside the browser");
-  const verifier = window.sessionStorage.getItem(VERIFIER_STORAGE_KEY);
+  const sessionStorage = getStorage("sessionStorage");
+  if (!sessionStorage) throw new Error("Session storage unavailable");
+  const verifier = sessionStorage.getItem(VERIFIER_STORAGE_KEY);
   if (!verifier) throw new Error("Missing PKCE verifier");
   const res = await fetch(KEY_EXCHANGE_URL, {
     method: "POST",
@@ -59,26 +83,50 @@ export async function completeLogin(code: string): Promise<string> {
   const data = (await res.json()) as { key?: string };
   const key = (data.key ?? "").trim();
   if (!key) throw new Error("OpenRouter response missing key");
-  window.sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
+  sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
   return key;
 }
 
-export function loadStoredKey(): string | null {
-  if (!isBrowser()) return null;
-  const stored = window.localStorage.getItem(API_KEY_STORAGE_KEY);
-  if (stored === null) return null;
-  const trimmed = stored.trim();
-  return trimmed.length > 0 ? trimmed : null;
+export function loadStoredKey(): StoredKeyResult {
+  const sessionStorage = getStorage("sessionStorage");
+  const localStorage = getStorage("localStorage");
+
+  const sessionKey = normalizeStoredKey(sessionStorage?.getItem(API_KEY_STORAGE_KEY) ?? null);
+  if (sessionKey) {
+    return { key: sessionKey, migratedFromLocalStorage: false };
+  }
+
+  const legacyKey = normalizeStoredKey(localStorage?.getItem(API_KEY_STORAGE_KEY) ?? null);
+  if (!legacyKey) {
+    localStorage?.removeItem(API_KEY_STORAGE_KEY);
+    return { key: null, migratedFromLocalStorage: false };
+  }
+
+  if (sessionStorage) {
+    try {
+      sessionStorage.setItem(API_KEY_STORAGE_KEY, legacyKey);
+    } catch {
+      localStorage?.removeItem(API_KEY_STORAGE_KEY);
+      return { key: legacyKey, migratedFromLocalStorage: false };
+    }
+    localStorage?.removeItem(API_KEY_STORAGE_KEY);
+    return { key: legacyKey, migratedFromLocalStorage: true };
+  }
+
+  localStorage?.removeItem(API_KEY_STORAGE_KEY);
+  return { key: legacyKey, migratedFromLocalStorage: false };
 }
 
 export function saveStoredKey(key: string): void {
-  if (!isBrowser()) return;
   const trimmed = key.trim();
   if (!trimmed) return;
-  window.localStorage.setItem(API_KEY_STORAGE_KEY, trimmed);
+  const sessionStorage = getStorage("sessionStorage");
+  if (!sessionStorage) throw new Error("Session storage unavailable");
+  sessionStorage.setItem(API_KEY_STORAGE_KEY, trimmed);
+  getStorage("localStorage")?.removeItem(API_KEY_STORAGE_KEY);
 }
 
 export function clearStoredKey(): void {
-  if (!isBrowser()) return;
-  window.localStorage.removeItem(API_KEY_STORAGE_KEY);
+  getStorage("sessionStorage")?.removeItem(API_KEY_STORAGE_KEY);
+  getStorage("localStorage")?.removeItem(API_KEY_STORAGE_KEY);
 }


### PR DESCRIPTION
## Summary
- migrate OpenRouter OAuth keys from legacy localStorage into tab-only session storage and clear persistent copies
- update the submit page copy to explain the new browser-key behavior and show a one-time migration notice
- validate the Modal webhook target/secret before submission, restrict the production host to the expected worker endpoint, and add a timeout to the outbound trigger without falsely failing late-delivered jobs

## Validation
- python3 scripts/security_scanner.py --strict --json
- bash scripts/doc-sync-check.sh
- cd web && npm ci
- cd web && npm run build
- cd web && npm run lint *(interactive in this repo: Next 15 prompts to create an ESLint config instead of running non-interactively)*