### PR TITLE
refactor: introduce canonical pipeline stage spec (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Extraction now logs real OpenRouter denial details and falls back after paid OCR denials (#71)** — the PDF extractor no longer hard-fails immediately when the first `mistral-ocr` file-parser call comes back as a user-actionable OpenRouter denial. It now records a scrubbed one-line summary of the provider response body (status, message, code, metadata when present) so operators can distinguish `402 Payment Required` / spend-limit failures from `403 Forbidden` privacy-or-terms failures in Modal logs, and it allows the extraction chain to continue from paid `mistral-ocr` to free `pdf-text` / `cloudflare-ai` and then Docling for recoverable OpenRouter `402` / `403` denials. `401` auth failures still fail fast. New tests pin both production-shaped cases: `402` and `403` on the first extraction call now skip retries on that backend, log the scrubbed reason, and successfully fall through to the next extractor when available.
 
+### Changed
+
+- **Pipeline cost heuristics now come from a shared stage manifest** — the review section cap, stage output budgets, math/cross-section heuristics, and web cost-estimator constants now live in `src/coarse/pipeline_spec.py`, with a generated JSON export consumed by the frontend. This removes the hand-maintained drift between `pipeline.py`, `cost.py`, and `web/src/lib/estimateCost.ts`.
+
 ## v1.2.2 — 2026-04-12
 
 Patch release. Clears the false "system busy (N/20 slots in use)" banner that the landing page was showing even when Modal was idle, and bundles the unreleased `dev` work (GPT-5.4 compare-panel + author-steering fallthroughs) that had accumulated since v1.2.1.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ src/coarse/
 ├── cli.py                   # Typer CLI, progress display (rich)
 ├── config.py                # ~/.coarse/config.toml, API key management
 ├── cost.py                  # Cost estimation + user approval gate
+├── pipeline_spec.py         # Shared stage manifest for runtime + cost estimators
 ├── extraction.py            # PDF/TXT/MD/TeX/DOCX/HTML/EPUB → PaperText
 ├── extraction_qa.py         # Post-extraction QA via vision LLM (Gemini Flash)
 ├── structure.py             # PaperText → PaperStructure (heading parse + math detection + LLM metadata)

--- a/scripts/export_pipeline_spec.py
+++ b/scripts/export_pipeline_spec.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Export the canonical pipeline spec for the web estimator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from coarse.pipeline_spec import export_web_spec
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    out_path = repo_root / "web" / "src" / "data" / "pipelineSpec.json"
+    out_path.write_text(json.dumps(export_web_spec(), indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/coarse/cost.py
+++ b/src/coarse/cost.py
@@ -18,9 +18,12 @@ from coarse.pipeline_spec import (
     AVG_COMMENTS_PER_SECTION,
     COST_BUFFER,
     EDITORIAL_OVERHEAD,
+    EXTRACTION_QA_IMAGE_OVERHEAD,
+    FIXED_STAGE_INPUT_TOKENS,
     LITERATURE_FLAT_COST,
     OCR_COST_PER_PAGE,
     OVERVIEW_CONTEXT_OVERHEAD,
+    OVERVIEW_INPUT_OVERHEAD,
     SECTION_PROMPT_OVERHEAD,
     STAGE_OUTPUT_TOKENS,
     TOKENS_PER_COMMENT,
@@ -139,20 +142,36 @@ def build_cost_estimate(
             stages,
             "extraction_qa",
             config.vision_model,
-            total_tokens + 5000,
+            total_tokens + EXTRACTION_QA_IMAGE_OVERHEAD,
             STAGE_OUTPUT_TOKENS["extraction_qa"],
         )
 
     # Structure analysis (metadata + math detection) — both cheap.
-    _append_model_stage(stages, "metadata", model, 500, STAGE_OUTPUT_TOKENS["metadata"])
     _append_model_stage(
-        stages, "math_detection", model, 2000, STAGE_OUTPUT_TOKENS["math_detection"]
+        stages,
+        "metadata",
+        model,
+        FIXED_STAGE_INPUT_TOKENS["metadata"],
+        STAGE_OUTPUT_TOKENS["metadata"],
+    )
+    _append_model_stage(
+        stages,
+        "math_detection",
+        model,
+        FIXED_STAGE_INPUT_TOKENS["math_detection"],
+        STAGE_OUTPUT_TOKENS["math_detection"],
     )
 
     # Parallel trio: calibration, literature search, contribution
     # extraction. All use the default model except Perplexity literature
     # search, which is flat-fee.
-    _append_model_stage(stages, "calibration", model, 1500, STAGE_OUTPUT_TOKENS["calibration"])
+    _append_model_stage(
+        stages,
+        "calibration",
+        model,
+        FIXED_STAGE_INPUT_TOKENS["calibration"],
+        STAGE_OUTPUT_TOKENS["calibration"],
+    )
 
     if has_provider_key("openrouter", config):
         stages.append(
@@ -171,14 +190,14 @@ def build_cost_estimate(
             stages,
             "literature_query_gen",
             model,
-            1500,
+            FIXED_STAGE_INPUT_TOKENS["literature_query_gen"],
             STAGE_OUTPUT_TOKENS["literature_query_gen"],
         )
         _append_model_stage(
             stages,
             "literature_ranking",
             model,
-            4000,
+            FIXED_STAGE_INPUT_TOKENS["literature_ranking"],
             STAGE_OUTPUT_TOKENS["literature_ranking"],
         )
 
@@ -186,7 +205,7 @@ def build_cost_estimate(
         stages,
         "contribution_extraction",
         model,
-        3000,
+        FIXED_STAGE_INPUT_TOKENS["contribution_extraction"],
         STAGE_OUTPUT_TOKENS["contribution_extraction"],
     )
 
@@ -194,7 +213,11 @@ def build_cost_estimate(
     # `OverviewAgent.run()` at src/coarse/agents/overview.py:80 makes
     # one `client.complete(..., max_tokens=8192)` call and returns.
     _append_model_stage(
-        stages, "overview", model, total_tokens + 3000, STAGE_OUTPUT_TOKENS["overview"]
+        stages,
+        "overview",
+        model,
+        total_tokens + OVERVIEW_INPUT_OVERHEAD,
+        STAGE_OUTPUT_TOKENS["overview"],
     )
 
     # Completeness agent. Reads the full paper via `_build_sections_text`

--- a/src/coarse/cost.py
+++ b/src/coarse/cost.py
@@ -1,12 +1,8 @@
 """Cost estimation and user approval gate for coarse.
 
 No LLM calls here — purely heuristic token budgets + pricing lookup.
-
-The stage list in `build_cost_estimate()` is a best-effort mirror of
-`review_paper()` in `pipeline.py`. It is NOT automatically kept in sync —
-when an agent is added, removed, or its `max_tokens` budget changes, the
-matching stage here has to be updated by hand. Audit this file against
-`pipeline.py` and `src/coarse/agents/*.py` on every pipeline refactor.
+Stage heuristics are sourced from `coarse.pipeline_spec`, which is also used
+to generate the web estimator's shared constants.
 """
 
 from __future__ import annotations
@@ -18,69 +14,23 @@ from rich.table import Table
 from coarse.config import CoarseConfig, has_provider_key
 from coarse.llm import estimate_call_cost, estimate_reasoning_overhead_tokens
 from coarse.models import LITERATURE_SEARCH_MODEL, OCR_MODEL, is_reasoning_model
+from coarse.pipeline_spec import (
+    AVG_COMMENTS_PER_SECTION,
+    COST_BUFFER,
+    EDITORIAL_OVERHEAD,
+    LITERATURE_FLAT_COST,
+    OCR_COST_PER_PAGE,
+    OVERVIEW_CONTEXT_OVERHEAD,
+    SECTION_PROMPT_OVERHEAD,
+    STAGE_OUTPUT_TOKENS,
+    TOKENS_PER_COMMENT,
+    TOKENS_PER_PAGE,
+    clamp_section_count,
+    estimate_cross_section_count,
+    estimate_math_section_count,
+    estimate_section_count,
+)
 from coarse.types import CostEstimate, CostStage, PaperText
-
-# ---------------------------------------------------------------------------
-# Heuristic pricing constants (verified 2026-04-11, aligned with pipeline.py
-# and src/coarse/agents/*.py). Constants are sized to match the real
-# `max_tokens` each agent passes — not a guess at average visible output.
-# Instructor retries, long outputs, and conditional stages that didn't fire
-# are absorbed by `_COST_BUFFER`.
-# ---------------------------------------------------------------------------
-
-# Section sizing. `_MAX_REVIEWABLE_SECTIONS` mirrors the `reviewable_sections[:25]`
-# slice in `pipeline.py::review_paper()` — both must match.
-_TOKENS_PER_SECTION = 1200
-_MAX_REVIEWABLE_SECTIONS = 25
-_MIN_SECTIONS = 4
-
-# Per-section prompt overhead: system + overview + calibration + notation
-# + abstract + (sometimes lit context). Measured on a typical run, not the
-# ~5k the previous version assumed.
-_SECTION_PROMPT_OVERHEAD = 8000
-
-# PDF extraction (Mistral OCR via OpenRouter file-parser, $2 / 1000 pages)
-_TOKENS_PER_PAGE = 250
-_OCR_COST_PER_PAGE = 0.002
-
-# Conditional-stage heuristics — the cost gate runs before structure
-# analysis so we don't yet know how many math sections exist or whether
-# the results/discussion split justifies cross-section synthesis. Math-
-# heavy papers will under-estimate relative to these defaults; the 1.30x
-# buffer has to carry the slack.
-_MATH_SECTION_FRACTION = 0.2  # fraction of sections assumed to have math content
-_CROSS_SECTION_MIN_SECTIONS = 6  # below this, assume no cross-section synthesis
-_EXPECTED_CROSS_SECTION_CALLS = 1  # expected-value midpoint; up to 3 fire in practice
-
-# Editorial agent (single merged pass that replaced the legacy
-# crossref+critique chain — see src/coarse/agents/editorial.py). The
-# agent also reads the full paper text for quote/absence verification,
-# which dominates the input budget on long papers.
-_AVG_COMMENTS_PER_SECTION = 3
-_TOKENS_PER_COMMENT = 350
-_EDITORIAL_OVERHEAD = 5000  # system + overview + contribution context
-
-# Overview context that proof_verify, completeness, and cross_section all
-# receive as part of their user prompt. ~5000 tokens on a typical run
-# (overview issues + calibration + abstract + title).
-_OVERVIEW_CONTEXT_OVERHEAD = 5000
-
-# Flat-fee stages
-_LITERATURE_FLAT_COST = 0.03  # Perplexity Sonar Pro via OpenRouter
-
-# Conservative multiplier applied to the final total. Covers instructor
-# retries, occasional long outputs, and the gap between heuristic
-# defaults and actual math/cross-section counts. Bumped from 1.15 after
-# a systematic under-count audit in April 2026.
-_COST_BUFFER = 1.30
-
-
-def _estimate_section_count(total_tokens: int) -> int:
-    """Estimate number of reviewable sections from paper token count."""
-    return max(
-        _MIN_SECTIONS,
-        min(_MAX_REVIEWABLE_SECTIONS, total_tokens // _TOKENS_PER_SECTION),
-    )
 
 
 def _append_model_stage(
@@ -126,7 +76,7 @@ def build_cost_estimate(
         paper_text: Extracted paper content; only `token_estimate` is read.
         config: Review config (default model, vision model, extraction_qa flag).
         section_count: Override for estimated reviewable sections. Defaults to
-            a heuristic based on paper length, capped at `_MAX_REVIEWABLE_SECTIONS`.
+            a heuristic based on paper length, capped at the runtime section limit.
             Values < 1 are clamped to 1 to prevent divide-by-zero.
         is_pdf: Whether the input is a PDF. The pipeline only runs
             extraction QA on PDFs (see pipeline.py:226), so non-PDFs skip
@@ -140,20 +90,16 @@ def build_cost_estimate(
     model = model or config.default_model
     total_tokens = max(0, paper_text.token_estimate)
     if section_count is None:
-        section_count = _estimate_section_count(total_tokens)
+        section_count = estimate_section_count(total_tokens)
     # Clamp defensively: section_count=0 would crash the divisions below.
-    # Callers may pass smaller values than the heuristic min (e.g. for
-    # very short papers in tests) — clamp to >= 1, not >= _MIN_SECTIONS.
-    section_count = max(1, section_count)
+    section_count = clamp_section_count(section_count)
     # Both derivations depend on section_count after clamping.
-    math_section_count = max(0, round(section_count * _MATH_SECTION_FRACTION))
-    cross_section_count = (
-        _EXPECTED_CROSS_SECTION_CALLS if section_count >= _CROSS_SECTION_MIN_SECTIONS else 0
-    )
+    math_section_count = estimate_math_section_count(section_count)
+    cross_section_count = estimate_cross_section_count(section_count)
 
     section_text_tokens = max(1, total_tokens // section_count)
-    section_input = section_text_tokens + _SECTION_PROMPT_OVERHEAD
-    est_pages = max(1, total_tokens // _TOKENS_PER_PAGE)
+    section_input = section_text_tokens + SECTION_PROMPT_OVERHEAD
+    est_pages = max(1, total_tokens // TOKENS_PER_PAGE)
 
     # Editorial agent reads all downstream comments plus the full paper for
     # quote/absence verification. Downstream comments include section,
@@ -161,12 +107,12 @@ def build_cost_estimate(
     # the raw section agent count — so this is the sum across all stages
     # that feed editorial.
     n_editorial_comments = (
-        section_count * _AVG_COMMENTS_PER_SECTION  # section agents
-        + _AVG_COMMENTS_PER_SECTION  # completeness (1 agent run)
-        + math_section_count * _AVG_COMMENTS_PER_SECTION  # proof_verify
+        section_count * AVG_COMMENTS_PER_SECTION  # section agents
+        + AVG_COMMENTS_PER_SECTION  # completeness (1 agent run)
+        + math_section_count * AVG_COMMENTS_PER_SECTION  # proof_verify
         + cross_section_count * 2  # cross-section synthesis comments
     )
-    editorial_in = n_editorial_comments * _TOKENS_PER_COMMENT + _EDITORIAL_OVERHEAD + total_tokens
+    editorial_in = n_editorial_comments * TOKENS_PER_COMMENT + EDITORIAL_OVERHEAD + total_tokens
 
     stages: list[CostStage] = []
 
@@ -178,7 +124,7 @@ def build_cost_estimate(
             model=OCR_MODEL,
             estimated_tokens_in=0,
             estimated_tokens_out=0,
-            estimated_cost_usd=est_pages * _OCR_COST_PER_PAGE,
+            estimated_cost_usd=est_pages * OCR_COST_PER_PAGE,
         )
     )
 
@@ -188,23 +134,25 @@ def build_cost_estimate(
     # that model, not the review default.
     if config.extraction_qa and is_pdf:
         # Input: full markdown + ~10 rendered page images encoded as
-        # multimodal tokens. Output: max_tokens=4096 in extraction_qa.py.
+        # multimodal tokens. Output budget comes from pipeline_spec.
         _append_model_stage(
             stages,
             "extraction_qa",
             config.vision_model,
             total_tokens + 5000,
-            4096,
+            STAGE_OUTPUT_TOKENS["extraction_qa"],
         )
 
     # Structure analysis (metadata + math detection) — both cheap.
-    _append_model_stage(stages, "metadata", model, 500, 256)
-    _append_model_stage(stages, "math_detection", model, 2000, 1024)
+    _append_model_stage(stages, "metadata", model, 500, STAGE_OUTPUT_TOKENS["metadata"])
+    _append_model_stage(
+        stages, "math_detection", model, 2000, STAGE_OUTPUT_TOKENS["math_detection"]
+    )
 
     # Parallel trio: calibration, literature search, contribution
     # extraction. All use the default model except Perplexity literature
     # search, which is flat-fee.
-    _append_model_stage(stages, "calibration", model, 1500, 2048)
+    _append_model_stage(stages, "calibration", model, 1500, STAGE_OUTPUT_TOKENS["calibration"])
 
     if has_provider_key("openrouter", config):
         stages.append(
@@ -213,21 +161,41 @@ def build_cost_estimate(
                 model=LITERATURE_SEARCH_MODEL,
                 estimated_tokens_in=0,
                 estimated_tokens_out=0,
-                estimated_cost_usd=_LITERATURE_FLAT_COST,
+                estimated_cost_usd=LITERATURE_FLAT_COST,
             )
         )
     else:
         # arXiv fallback: query-gen (512 out) + ranking (2048 out) —
         # two LLM calls on the default model.
-        _append_model_stage(stages, "literature_query_gen", model, 1500, 512)
-        _append_model_stage(stages, "literature_ranking", model, 4000, 2048)
+        _append_model_stage(
+            stages,
+            "literature_query_gen",
+            model,
+            1500,
+            STAGE_OUTPUT_TOKENS["literature_query_gen"],
+        )
+        _append_model_stage(
+            stages,
+            "literature_ranking",
+            model,
+            4000,
+            STAGE_OUTPUT_TOKENS["literature_ranking"],
+        )
 
-    _append_model_stage(stages, "contribution_extraction", model, 3000, 2048)
+    _append_model_stage(
+        stages,
+        "contribution_extraction",
+        model,
+        3000,
+        STAGE_OUTPUT_TOKENS["contribution_extraction"],
+    )
 
     # Overview: a single agent call. There is NO 3-judge panel — the
     # `OverviewAgent.run()` at src/coarse/agents/overview.py:80 makes
     # one `client.complete(..., max_tokens=8192)` call and returns.
-    _append_model_stage(stages, "overview", model, total_tokens + 3000, 8192)
+    _append_model_stage(
+        stages, "overview", model, total_tokens + 3000, STAGE_OUTPUT_TOKENS["overview"]
+    )
 
     # Completeness agent. Reads the full paper via `_build_sections_text`
     # plus overview + contribution context — so input is `total_tokens`,
@@ -236,15 +204,21 @@ def build_cost_estimate(
         stages,
         "completeness",
         model,
-        total_tokens + _OVERVIEW_CONTEXT_OVERHEAD,
-        4096,
+        total_tokens + OVERVIEW_CONTEXT_OVERHEAD,
+        STAGE_OUTPUT_TOKENS["completeness"],
     )
 
     # Section agents (parallel, one per reviewable section). max_tokens=
     # 16384 but most runs use 8–12k; budget at 10k and let the buffer
     # cover the tail.
     for i in range(section_count):
-        _append_model_stage(stages, f"section_{i + 1}", model, section_input, 10000)
+        _append_model_stage(
+            stages,
+            f"section_{i + 1}",
+            model,
+            section_input,
+            STAGE_OUTPUT_TOKENS["section"],
+        )
 
     # Proof verify (chained after section agents for math sections only).
     # max_tokens=16384. Input = section text + section's own comments +
@@ -254,8 +228,8 @@ def build_cost_estimate(
             stages,
             f"proof_verify_{i + 1}",
             model,
-            section_input + _OVERVIEW_CONTEXT_OVERHEAD,
-            16384,
+            section_input + OVERVIEW_CONTEXT_OVERHEAD,
+            STAGE_OUTPUT_TOKENS["proof_verify"],
         )
 
     # Cross-section synthesis (up to 3 calls — main results × top-3
@@ -266,17 +240,17 @@ def build_cost_estimate(
             stages,
             f"cross_section_{i + 1}",
             model,
-            section_text_tokens * 2 + _OVERVIEW_CONTEXT_OVERHEAD,
-            8192,
+            section_text_tokens * 2 + OVERVIEW_CONTEXT_OVERHEAD,
+            STAGE_OUTPUT_TOKENS["cross_section"],
         )
 
     # Editorial pass (single merged dedup+contradiction+quality+ordering
     # agent). Reads all downstream comments plus the full paper markdown
     # for quote verification. max_tokens=32768 but most runs use 20–25k;
     # budget at 24k.
-    _append_model_stage(stages, "editorial", model, editorial_in, 24000)
+    _append_model_stage(stages, "editorial", model, editorial_in, STAGE_OUTPUT_TOKENS["editorial"])
 
-    total = sum(s.estimated_cost_usd for s in stages) * _COST_BUFFER
+    total = sum(s.estimated_cost_usd for s in stages) * COST_BUFFER
     return CostEstimate(stages=stages, total_cost_usd=total)
 
 

--- a/src/coarse/pipeline.py
+++ b/src/coarse/pipeline.py
@@ -23,6 +23,7 @@ from coarse.config import CoarseConfig, load_config
 from coarse.cost import run_cost_gate
 from coarse.extraction import extract_file
 from coarse.llm import LLMClient
+from coarse.pipeline_spec import MAX_REVIEWABLE_SECTIONS
 from coarse.prompts import (
     CALIBRATION_SYSTEM,
     CONTRIBUTION_EXTRACTION_SYSTEM,
@@ -366,7 +367,7 @@ def review_paper(
         if s.section_type != SectionType.REFERENCES
         and (s.section_type != SectionType.APPENDIX or len(s.text) >= _MIN_APPENDIX_CHARS)
     ]
-    non_ref_sections = reviewable_sections[:25]
+    non_ref_sections = reviewable_sections[:MAX_REVIEWABLE_SECTIONS]
 
     # --- Phase 1: Overview (single-pass, full paper text) ---
     overview = overview_agent.run(

--- a/src/coarse/pipeline_spec.py
+++ b/src/coarse/pipeline_spec.py
@@ -1,0 +1,103 @@
+"""Canonical pipeline stage and estimation spec.
+
+This module is the single source of truth for the review-stage heuristics that
+must stay aligned across the Python runtime, the Python cost estimator, and the
+web cost estimator.
+"""
+
+from __future__ import annotations
+
+from coarse.models import REASONING_MODEL_PREFIXES, REASONING_MODEL_SUBSTRINGS
+
+# Section sizing
+TOKENS_PER_SECTION = 1200
+MAX_REVIEWABLE_SECTIONS = 25
+MIN_SECTIONS = 4
+SECTION_PROMPT_OVERHEAD = 8000
+
+# PDF/file extraction
+TOKENS_PER_PAGE = 250
+OCR_COST_PER_PAGE = 0.002
+EXTRACTION_QA_FLAT_COST = 0.035
+
+# Conditional-stage heuristics
+MATH_SECTION_FRACTION = 0.2
+CROSS_SECTION_MIN_SECTIONS = 6
+EXPECTED_CROSS_SECTION_CALLS = 1
+
+# Comment/editorial heuristics
+AVG_COMMENTS_PER_SECTION = 3
+TOKENS_PER_COMMENT = 350
+EDITORIAL_OVERHEAD = 5000
+OVERVIEW_CONTEXT_OVERHEAD = 5000
+
+# Flat-fee stages
+LITERATURE_FLAT_COST = 0.03
+
+# Conservative multiplier applied to the final total.
+COST_BUFFER = 1.30
+
+# Structured-output budgets per stage kind.
+STAGE_OUTPUT_TOKENS: dict[str, int] = {
+    "metadata": 256,
+    "math_detection": 1024,
+    "calibration": 2048,
+    "literature_query_gen": 512,
+    "literature_ranking": 2048,
+    "contribution_extraction": 2048,
+    "overview": 8192,
+    "completeness": 4096,
+    "section": 10000,
+    "proof_verify": 16384,
+    "cross_section": 8192,
+    "editorial": 24000,
+    "extraction_qa": 4096,
+}
+
+
+def estimate_section_count(total_tokens: int) -> int:
+    """Estimate the number of reviewable sections from paper length."""
+    return max(
+        MIN_SECTIONS,
+        min(MAX_REVIEWABLE_SECTIONS, total_tokens // TOKENS_PER_SECTION),
+    )
+
+
+def clamp_section_count(section_count: int) -> int:
+    """Clamp a caller-supplied section count to the safe runtime minimum."""
+    return max(1, section_count)
+
+
+def estimate_math_section_count(section_count: int) -> int:
+    """Estimate how many reviewable sections will trigger proof verification."""
+    return max(0, round(section_count * MATH_SECTION_FRACTION))
+
+
+def estimate_cross_section_count(section_count: int) -> int:
+    """Estimate how many cross-section synthesis calls will fire."""
+    return EXPECTED_CROSS_SECTION_CALLS if section_count >= CROSS_SECTION_MIN_SECTIONS else 0
+
+
+def export_web_spec() -> dict[str, object]:
+    """Return the JSON-serializable subset consumed by the web estimator."""
+    return {
+        "tokensPerSection": TOKENS_PER_SECTION,
+        "maxReviewableSections": MAX_REVIEWABLE_SECTIONS,
+        "minSections": MIN_SECTIONS,
+        "sectionPromptOverhead": SECTION_PROMPT_OVERHEAD,
+        "tokensPerPage": TOKENS_PER_PAGE,
+        "ocrCostPerPage": OCR_COST_PER_PAGE,
+        "extractionQaFlatCost": EXTRACTION_QA_FLAT_COST,
+        "mathSectionFraction": MATH_SECTION_FRACTION,
+        "crossSectionMinSections": CROSS_SECTION_MIN_SECTIONS,
+        "expectedCrossSectionCalls": EXPECTED_CROSS_SECTION_CALLS,
+        "avgCommentsPerSection": AVG_COMMENTS_PER_SECTION,
+        "tokensPerComment": TOKENS_PER_COMMENT,
+        "editorialOverhead": EDITORIAL_OVERHEAD,
+        "overviewContextOverhead": OVERVIEW_CONTEXT_OVERHEAD,
+        "literatureFlatCost": LITERATURE_FLAT_COST,
+        "costBuffer": COST_BUFFER,
+        "stageOutputTokens": STAGE_OUTPUT_TOKENS,
+        "reasoningModelPrefixes": list(REASONING_MODEL_PREFIXES),
+        "reasoningModelSubstrings": list(REASONING_MODEL_SUBSTRINGS),
+    }

--- a/src/coarse/pipeline_spec.py
+++ b/src/coarse/pipeline_spec.py
@@ -14,22 +14,34 @@ TOKENS_PER_SECTION = 1200
 MAX_REVIEWABLE_SECTIONS = 25
 MIN_SECTIONS = 4
 SECTION_PROMPT_OVERHEAD = 8000
+OVERVIEW_INPUT_OVERHEAD = 3000
 
 # PDF/file extraction
 TOKENS_PER_PAGE = 250
 OCR_COST_PER_PAGE = 0.002
 EXTRACTION_QA_FLAT_COST = 0.035
+EXTRACTION_QA_IMAGE_OVERHEAD = 5000
 
 # Conditional-stage heuristics
 MATH_SECTION_FRACTION = 0.2
 CROSS_SECTION_MIN_SECTIONS = 6
-EXPECTED_CROSS_SECTION_CALLS = 1
+MAX_CROSS_SECTION_CALLS = 3
 
 # Comment/editorial heuristics
 AVG_COMMENTS_PER_SECTION = 3
 TOKENS_PER_COMMENT = 350
 EDITORIAL_OVERHEAD = 5000
 OVERVIEW_CONTEXT_OVERHEAD = 5000
+REASONING_OVERHEAD_MULTIPLIER = 4
+
+FIXED_STAGE_INPUT_TOKENS: dict[str, int] = {
+    "metadata": 500,
+    "math_detection": 2000,
+    "calibration": 1500,
+    "literature_query_gen": 1500,
+    "literature_ranking": 4000,
+    "contribution_extraction": 3000,
+}
 
 # Flat-fee stages
 LITERATURE_FLAT_COST = 0.03
@@ -75,7 +87,7 @@ def estimate_math_section_count(section_count: int) -> int:
 
 def estimate_cross_section_count(section_count: int) -> int:
     """Estimate how many cross-section synthesis calls will fire."""
-    return EXPECTED_CROSS_SECTION_CALLS if section_count >= CROSS_SECTION_MIN_SECTIONS else 0
+    return min(MAX_CROSS_SECTION_CALLS, section_count // CROSS_SECTION_MIN_SECTIONS)
 
 
 def export_web_spec() -> dict[str, object]:
@@ -85,16 +97,20 @@ def export_web_spec() -> dict[str, object]:
         "maxReviewableSections": MAX_REVIEWABLE_SECTIONS,
         "minSections": MIN_SECTIONS,
         "sectionPromptOverhead": SECTION_PROMPT_OVERHEAD,
+        "overviewInputOverhead": OVERVIEW_INPUT_OVERHEAD,
         "tokensPerPage": TOKENS_PER_PAGE,
         "ocrCostPerPage": OCR_COST_PER_PAGE,
         "extractionQaFlatCost": EXTRACTION_QA_FLAT_COST,
+        "extractionQaImageOverhead": EXTRACTION_QA_IMAGE_OVERHEAD,
         "mathSectionFraction": MATH_SECTION_FRACTION,
         "crossSectionMinSections": CROSS_SECTION_MIN_SECTIONS,
-        "expectedCrossSectionCalls": EXPECTED_CROSS_SECTION_CALLS,
+        "maxCrossSectionCalls": MAX_CROSS_SECTION_CALLS,
         "avgCommentsPerSection": AVG_COMMENTS_PER_SECTION,
         "tokensPerComment": TOKENS_PER_COMMENT,
         "editorialOverhead": EDITORIAL_OVERHEAD,
         "overviewContextOverhead": OVERVIEW_CONTEXT_OVERHEAD,
+        "reasoningOverheadMultiplier": REASONING_OVERHEAD_MULTIPLIER,
+        "fixedStageInputTokens": FIXED_STAGE_INPUT_TOKENS,
         "literatureFlatCost": LITERATURE_FLAT_COST,
         "costBuffer": COST_BUFFER,
         "stageOutputTokens": STAGE_OUTPUT_TOKENS,

--- a/tests/test_pipeline_spec.py
+++ b/tests/test_pipeline_spec.py
@@ -1,0 +1,31 @@
+"""Tests for the canonical pipeline stage spec."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from coarse.pipeline_spec import (
+    MAX_REVIEWABLE_SECTIONS,
+    estimate_cross_section_count,
+    estimate_math_section_count,
+    estimate_section_count,
+    export_web_spec,
+)
+
+
+def test_section_count_caps_at_runtime_limit():
+    assert estimate_section_count(999_999) == MAX_REVIEWABLE_SECTIONS
+
+
+def test_math_and_cross_section_heuristics_are_stable():
+    assert estimate_math_section_count(8) == 2
+    assert estimate_cross_section_count(5) == 0
+    assert estimate_cross_section_count(6) == 1
+
+
+def test_exported_web_spec_matches_checked_in_json():
+    repo_root = Path(__file__).resolve().parents[1]
+    json_path = repo_root / "web" / "src" / "data" / "pipelineSpec.json"
+    checked_in = json.loads(json_path.read_text())
+    assert checked_in == export_web_spec()

--- a/tests/test_pipeline_spec.py
+++ b/tests/test_pipeline_spec.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
+from coarse.config import CoarseConfig
+from coarse.cost import build_cost_estimate
+from coarse.llm import model_cost_per_token
+from coarse.models import DEFAULT_MODEL
 from coarse.pipeline_spec import (
     MAX_REVIEWABLE_SECTIONS,
     estimate_cross_section_count,
@@ -12,6 +17,7 @@ from coarse.pipeline_spec import (
     estimate_section_count,
     export_web_spec,
 )
+from coarse.types import PaperText
 
 
 def test_section_count_caps_at_runtime_limit():
@@ -22,6 +28,8 @@ def test_math_and_cross_section_heuristics_are_stable():
     assert estimate_math_section_count(8) == 2
     assert estimate_cross_section_count(5) == 0
     assert estimate_cross_section_count(6) == 1
+    assert estimate_cross_section_count(12) == 2
+    assert estimate_cross_section_count(18) == 3
 
 
 def test_exported_web_spec_matches_checked_in_json():
@@ -29,3 +37,82 @@ def test_exported_web_spec_matches_checked_in_json():
     json_path = repo_root / "web" / "src" / "data" / "pipelineSpec.json"
     checked_in = json.loads(json_path.read_text())
     assert checked_in == export_web_spec()
+
+
+def _run_ts_estimator(
+    repo_root: Path,
+    total_tokens: int,
+    model_id: str,
+    is_pdf: bool,
+    section_count: int | None,
+    has_openrouter_key: bool,
+) -> float:
+    prompt_cost, completion_cost = model_cost_per_token(model_id)
+    section_arg = "undefined" if section_count is None else str(section_count)
+    script = f"""
+import {{ estimateReviewCost }} from "./web/src/lib/estimateCost.ts";
+
+const total = estimateReviewCost(
+  {total_tokens},
+  {{
+    promptCostPerToken: {prompt_cost},
+    completionCostPerToken: {completion_cost},
+  }},
+  "{model_id}",
+  {str(is_pdf).lower()},
+  {section_arg},
+  {str(has_openrouter_key).lower()},
+);
+console.log(JSON.stringify(total));
+"""
+    result = subprocess.run(
+        ["node", "--experimental-strip-types", "--input-type=module", "-e", script],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return float(json.loads(result.stdout))
+
+
+def test_ts_estimator_matches_python_cost_gate_for_openrouter_and_fallback_paths(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    paper_text = PaperText(full_markdown="x" * 4000, token_estimate=40_000)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    scenarios = [
+        {
+            "model_id": DEFAULT_MODEL,
+            "section_count": 18,
+            "is_pdf": False,
+            "has_openrouter_key": True,
+        },
+        {
+            "model_id": "openai/gpt-5-pro",
+            "section_count": 18,
+            "is_pdf": False,
+            "has_openrouter_key": False,
+        },
+    ]
+
+    for scenario in scenarios:
+        config = CoarseConfig(
+            default_model=scenario["model_id"],
+            extraction_qa=True,
+            api_keys={"openrouter": "key"} if scenario["has_openrouter_key"] else {},
+        )
+        py_total = build_cost_estimate(
+            paper_text,
+            config,
+            section_count=scenario["section_count"],
+            is_pdf=scenario["is_pdf"],
+            model=scenario["model_id"],
+        ).total_cost_usd
+        ts_total = _run_ts_estimator(
+            repo_root,
+            total_tokens=paper_text.token_estimate,
+            model_id=scenario["model_id"],
+            is_pdf=scenario["is_pdf"],
+            section_count=scenario["section_count"],
+            has_openrouter_key=scenario["has_openrouter_key"],
+        )
+        assert abs(ts_total - py_total) < 1e-9

--- a/web/src/data/pipelineSpec.json
+++ b/web/src/data/pipelineSpec.json
@@ -3,14 +3,24 @@
   "costBuffer": 1.3,
   "crossSectionMinSections": 6,
   "editorialOverhead": 5000,
-  "expectedCrossSectionCalls": 1,
   "extractionQaFlatCost": 0.035,
+  "extractionQaImageOverhead": 5000,
+  "fixedStageInputTokens": {
+    "calibration": 1500,
+    "contribution_extraction": 3000,
+    "literature_query_gen": 1500,
+    "literature_ranking": 4000,
+    "math_detection": 2000,
+    "metadata": 500
+  },
   "literatureFlatCost": 0.03,
   "mathSectionFraction": 0.2,
+  "maxCrossSectionCalls": 3,
   "maxReviewableSections": 25,
   "minSections": 4,
   "ocrCostPerPage": 0.002,
   "overviewContextOverhead": 5000,
+  "overviewInputOverhead": 3000,
   "reasoningModelPrefixes": [
     "openai/o1",
     "openai/o3",
@@ -31,6 +41,7 @@
     "reasoning",
     "deep-research"
   ],
+  "reasoningOverheadMultiplier": 4,
   "sectionPromptOverhead": 8000,
   "stageOutputTokens": {
     "calibration": 2048,

--- a/web/src/data/pipelineSpec.json
+++ b/web/src/data/pipelineSpec.json
@@ -1,0 +1,53 @@
+{
+  "avgCommentsPerSection": 3,
+  "costBuffer": 1.3,
+  "crossSectionMinSections": 6,
+  "editorialOverhead": 5000,
+  "expectedCrossSectionCalls": 1,
+  "extractionQaFlatCost": 0.035,
+  "literatureFlatCost": 0.03,
+  "mathSectionFraction": 0.2,
+  "maxReviewableSections": 25,
+  "minSections": 4,
+  "ocrCostPerPage": 0.002,
+  "overviewContextOverhead": 5000,
+  "reasoningModelPrefixes": [
+    "openai/o1",
+    "openai/o3",
+    "openai/o4",
+    "openai/gpt-5-pro",
+    "openai/gpt-5.1-pro",
+    "openai/gpt-5.2-pro",
+    "openai/gpt-5.3-pro",
+    "openai/gpt-5.4-pro",
+    "deepseek/deepseek-r",
+    "x-ai/grok-4",
+    "x-ai/grok-3-mini",
+    "perplexity/sonar-reasoning",
+    "arcee-ai/maestro-reasoning"
+  ],
+  "reasoningModelSubstrings": [
+    "thinking",
+    "reasoning",
+    "deep-research"
+  ],
+  "sectionPromptOverhead": 8000,
+  "stageOutputTokens": {
+    "calibration": 2048,
+    "completeness": 4096,
+    "contribution_extraction": 2048,
+    "cross_section": 8192,
+    "editorial": 24000,
+    "extraction_qa": 4096,
+    "literature_query_gen": 512,
+    "literature_ranking": 2048,
+    "math_detection": 1024,
+    "metadata": 256,
+    "overview": 8192,
+    "proof_verify": 16384,
+    "section": 10000
+  },
+  "tokensPerComment": 350,
+  "tokensPerPage": 250,
+  "tokensPerSection": 1200
+}

--- a/web/src/lib/estimateCost.ts
+++ b/web/src/lib/estimateCost.ts
@@ -10,7 +10,7 @@
  * Pricing: fetched from OpenRouter /api/v1/models.
  */
 
-import pipelineSpec from "@/data/pipelineSpec.json";
+import pipelineSpec from "../data/pipelineSpec.json" with { type: "json" };
 
 const PDFJS_CDN = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.min.mjs";
 const PDFJS_WORKER_CDN = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.worker.min.mjs";
@@ -105,18 +105,21 @@ const TOKENS_PER_SECTION = pipelineSpec.tokensPerSection;
 const MAX_REVIEWABLE_SECTIONS = pipelineSpec.maxReviewableSections;
 const MIN_SECTIONS = pipelineSpec.minSections;
 const SECTION_PROMPT_OVERHEAD = pipelineSpec.sectionPromptOverhead;
+const OVERVIEW_INPUT_OVERHEAD = pipelineSpec.overviewInputOverhead;
 
 const TOKENS_PER_PAGE = pipelineSpec.tokensPerPage;
 const OCR_COST_PER_PAGE = pipelineSpec.ocrCostPerPage;
 
 const MATH_SECTION_FRACTION = pipelineSpec.mathSectionFraction;
 const CROSS_SECTION_MIN_SECTIONS = pipelineSpec.crossSectionMinSections;
-const EXPECTED_CROSS_SECTION_CALLS = pipelineSpec.expectedCrossSectionCalls;
+const MAX_CROSS_SECTION_CALLS = pipelineSpec.maxCrossSectionCalls;
 
 const AVG_COMMENTS_PER_SECTION = pipelineSpec.avgCommentsPerSection;
 const TOKENS_PER_COMMENT = pipelineSpec.tokensPerComment;
 const EDITORIAL_OVERHEAD = pipelineSpec.editorialOverhead;
 const OVERVIEW_CONTEXT_OVERHEAD = pipelineSpec.overviewContextOverhead;
+const REASONING_OVERHEAD_MULTIPLIER = pipelineSpec.reasoningOverheadMultiplier;
+const FIXED_STAGE_INPUT_TOKENS = pipelineSpec.fixedStageInputTokens;
 
 const LITERATURE_FLAT_COST = pipelineSpec.literatureFlatCost;
 const EXTRACTION_QA_FLAT_COST = pipelineSpec.extractionQaFlatCost;
@@ -125,10 +128,6 @@ const STAGE_OUTPUT_TOKENS = pipelineSpec.stageOutputTokens;
 
 const REASONING_MODEL_PREFIXES: readonly string[] = pipelineSpec.reasoningModelPrefixes;
 const REASONING_MODEL_SUBSTRINGS: readonly string[] = pipelineSpec.reasoningModelSubstrings;
-// Empirical: reasoning models bill ~4x the visible output budget in hidden
-// reasoning tokens, charged at the output-token rate. See
-// _REASONING_OVERHEAD_MULTIPLIER in src/coarse/llm.py.
-const REASONING_OVERHEAD_MULTIPLIER = 4;
 
 function isReasoningModel(modelId: string): boolean {
   const lower = modelId.toLowerCase().replace(/^openrouter\//, "");
@@ -149,6 +148,10 @@ function estimateSectionCount(tokenEstimate: number): number {
   );
 }
 
+function estimateCrossSectionCount(sectionCount: number): number {
+  return Math.min(MAX_CROSS_SECTION_CALLS, Math.floor(sectionCount / CROSS_SECTION_MIN_SECTIONS));
+}
+
 /**
  * Estimate total review cost in USD.
  * Mirrors build_cost_estimate() from src/coarse/cost.py. Stage list and
@@ -160,6 +163,7 @@ export function estimateReviewCost(
   modelId: string = "",
   isPdf: boolean = true,
   sectionCount?: number,
+  hasOpenRouterKey: boolean = true,
 ): number {
   const { promptCostPerToken: inp, completionCostPerToken: out } = pricing;
   const totalTokens = Math.max(0, tokenEstimate);
@@ -169,8 +173,7 @@ export function estimateReviewCost(
   sections = Math.max(1, sections);
 
   const mathSectionCount = Math.max(0, Math.round(sections * MATH_SECTION_FRACTION));
-  const crossSectionCount =
-    sections >= CROSS_SECTION_MIN_SECTIONS ? EXPECTED_CROSS_SECTION_CALLS : 0;
+  const crossSectionCount = estimateCrossSectionCount(sections);
 
   const sectionTextTokens = Math.max(1, Math.floor(totalTokens / sections));
   const sectionInput = sectionTextTokens + SECTION_PROMPT_OVERHEAD;
@@ -189,7 +192,6 @@ export function estimateReviewCost(
   // Flat-fee stages (non-LLM / non-review-model).
   const estPages = Math.max(1, Math.floor(totalTokens / TOKENS_PER_PAGE));
   let total = estPages * OCR_COST_PER_PAGE; // pdf_extraction
-  total += LITERATURE_FLAT_COST; // literature_search (OpenRouter flat fee)
   if (isPdf) {
     // extraction_qa only runs on PDFs in the real pipeline (pipeline.py:226).
     total += EXTRACTION_QA_FLAT_COST;
@@ -198,11 +200,35 @@ export function estimateReviewCost(
   // Default-model stages mirror pipeline.py:review_paper() 1:1.
   // Format: [name, tokens_in, tokens_out]
   const stages: [string, number, number][] = [
-    ["metadata", 500, STAGE_OUTPUT_TOKENS.metadata],
-    ["math_detection", 2000, STAGE_OUTPUT_TOKENS.math_detection],
-    ["calibration", 1500, STAGE_OUTPUT_TOKENS.calibration],
-    ["contribution_extraction", 3000, STAGE_OUTPUT_TOKENS.contribution_extraction],
-    ["overview", totalTokens + 3000, STAGE_OUTPUT_TOKENS.overview],
+    ["metadata", FIXED_STAGE_INPUT_TOKENS.metadata, STAGE_OUTPUT_TOKENS.metadata],
+    ["math_detection", FIXED_STAGE_INPUT_TOKENS.math_detection, STAGE_OUTPUT_TOKENS.math_detection],
+    ["calibration", FIXED_STAGE_INPUT_TOKENS.calibration, STAGE_OUTPUT_TOKENS.calibration],
+  ];
+
+  if (hasOpenRouterKey) {
+    total += LITERATURE_FLAT_COST;
+  } else {
+    stages.push(
+      [
+        "literature_query_gen",
+        FIXED_STAGE_INPUT_TOKENS.literature_query_gen,
+        STAGE_OUTPUT_TOKENS.literature_query_gen,
+      ],
+      [
+        "literature_ranking",
+        FIXED_STAGE_INPUT_TOKENS.literature_ranking,
+        STAGE_OUTPUT_TOKENS.literature_ranking,
+      ],
+    );
+  }
+
+  stages.push(
+    [
+      "contribution_extraction",
+      FIXED_STAGE_INPUT_TOKENS.contribution_extraction,
+      STAGE_OUTPUT_TOKENS.contribution_extraction,
+    ],
+    ["overview", totalTokens + OVERVIEW_INPUT_OVERHEAD, STAGE_OUTPUT_TOKENS.overview],
     // Completeness reads the full paper via _build_sections_text
     // (agents/completeness.py:44), not a small 3k prompt.
     ["completeness", totalTokens + OVERVIEW_CONTEXT_OVERHEAD, STAGE_OUTPUT_TOKENS.completeness],
@@ -237,7 +263,7 @@ export function estimateReviewCost(
         ] as [string, number, number],
     ),
     ["editorial", editorialIn, STAGE_OUTPUT_TOKENS.editorial],
-  ];
+  );
 
   const reasoning = isReasoningModel(modelId);
   for (const [, tokIn, tokOut] of stages) {

--- a/web/src/lib/estimateCost.ts
+++ b/web/src/lib/estimateCost.ts
@@ -1,13 +1,16 @@
 /**
  * Client-side cost estimation for coarse reviews.
  *
- * Mirrors the heuristic from src/coarse/cost.py 1:1. When the Python
- * estimator changes, this file must change with it. Both list the same
- * stages with the same per-stage token budgets and the same _COST_BUFFER.
+ * Shared stage heuristics are generated from src/coarse/pipeline_spec.py into
+ * web/src/data/pipelineSpec.json. Dynamic assembly still happens here, but the
+ * section caps, stage budgets, and reasoning-model rules come from the same
+ * source as the Python estimator.
  *
  * Token estimate: extract text via pdf.js (loaded from CDN to avoid webpack issues).
  * Pricing: fetched from OpenRouter /api/v1/models.
  */
+
+import pipelineSpec from "@/data/pipelineSpec.json";
 
 const PDFJS_CDN = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.min.mjs";
 const PDFJS_WORKER_CDN = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.9.155/pdf.worker.min.mjs";
@@ -98,58 +101,30 @@ export async function estimateTokensFromPdf(file: File): Promise<number> {
   return Math.max(500, Math.round(totalChars / 4));
 }
 
-// Heuristic constants — mirror src/coarse/cost.py (verified 2026-04-11).
-// When a Python constant changes, update it here too.
-const TOKENS_PER_SECTION = 1200;
-const MAX_REVIEWABLE_SECTIONS = 25; // mirrors pipeline.py's reviewable_sections[:25]
-const MIN_SECTIONS = 4;
-const SECTION_PROMPT_OVERHEAD = 8000;
+const TOKENS_PER_SECTION = pipelineSpec.tokensPerSection;
+const MAX_REVIEWABLE_SECTIONS = pipelineSpec.maxReviewableSections;
+const MIN_SECTIONS = pipelineSpec.minSections;
+const SECTION_PROMPT_OVERHEAD = pipelineSpec.sectionPromptOverhead;
 
-const TOKENS_PER_PAGE = 250;
-const OCR_COST_PER_PAGE = 0.002;
+const TOKENS_PER_PAGE = pipelineSpec.tokensPerPage;
+const OCR_COST_PER_PAGE = pipelineSpec.ocrCostPerPage;
 
-const MATH_SECTION_FRACTION = 0.2;
-const CROSS_SECTION_MIN_SECTIONS = 6;
-const EXPECTED_CROSS_SECTION_CALLS = 1;
+const MATH_SECTION_FRACTION = pipelineSpec.mathSectionFraction;
+const CROSS_SECTION_MIN_SECTIONS = pipelineSpec.crossSectionMinSections;
+const EXPECTED_CROSS_SECTION_CALLS = pipelineSpec.expectedCrossSectionCalls;
 
-const AVG_COMMENTS_PER_SECTION = 3;
-const TOKENS_PER_COMMENT = 350;
-const EDITORIAL_OVERHEAD = 5000;
-const OVERVIEW_CONTEXT_OVERHEAD = 5000;
+const AVG_COMMENTS_PER_SECTION = pipelineSpec.avgCommentsPerSection;
+const TOKENS_PER_COMMENT = pipelineSpec.tokensPerComment;
+const EDITORIAL_OVERHEAD = pipelineSpec.editorialOverhead;
+const OVERVIEW_CONTEXT_OVERHEAD = pipelineSpec.overviewContextOverhead;
 
-const LITERATURE_FLAT_COST = 0.03;
-// Gemini Flash extraction QA on a typical paper (~45k in + 4096 out at
-// $0.50/$3.00 per 1M) runs about $0.035. Approximate as a flat fee rather
-// than fetching vision model pricing separately.
-const EXTRACTION_QA_FLAT_COST = 0.035;
+const LITERATURE_FLAT_COST = pipelineSpec.literatureFlatCost;
+const EXTRACTION_QA_FLAT_COST = pipelineSpec.extractionQaFlatCost;
+const COST_BUFFER = pipelineSpec.costBuffer;
+const STAGE_OUTPUT_TOKENS = pipelineSpec.stageOutputTokens;
 
-const COST_BUFFER = 1.3;
-
-// Reasoning model detection — mirrors `is_reasoning_model` in
-// src/coarse/models.py. Uses both prefix and substring rules so
-// thinking/reasoning variants across providers all get the 4x overhead
-// applied to tokens_out. Keep in sync with REASONING_MODEL_PREFIXES and
-// REASONING_MODEL_SUBSTRINGS in models.py.
-const REASONING_MODEL_PREFIXES: readonly string[] = [
-  "openai/o1",
-  "openai/o3",
-  "openai/o4",
-  "openai/gpt-5-pro",
-  "openai/gpt-5.1-pro",
-  "openai/gpt-5.2-pro",
-  "openai/gpt-5.3-pro",
-  "openai/gpt-5.4-pro",
-  "deepseek/deepseek-r",
-  "x-ai/grok-4",
-  "x-ai/grok-3-mini",
-  "perplexity/sonar-reasoning",
-  "arcee-ai/maestro-reasoning",
-];
-const REASONING_MODEL_SUBSTRINGS: readonly string[] = [
-  "thinking",
-  "reasoning",
-  "deep-research",
-];
+const REASONING_MODEL_PREFIXES: readonly string[] = pipelineSpec.reasoningModelPrefixes;
+const REASONING_MODEL_SUBSTRINGS: readonly string[] = pipelineSpec.reasoningModelSubstrings;
 // Empirical: reasoning models bill ~4x the visible output budget in hidden
 // reasoning tokens, charged at the output-token rate. See
 // _REASONING_OVERHEAD_MULTIPLIER in src/coarse/llm.py.
@@ -223,20 +198,23 @@ export function estimateReviewCost(
   // Default-model stages mirror pipeline.py:review_paper() 1:1.
   // Format: [name, tokens_in, tokens_out]
   const stages: [string, number, number][] = [
-    ["metadata", 500, 256],
-    ["math_detection", 2000, 1024],
-    ["calibration", 1500, 2048],
-    ["contribution_extraction", 3000, 2048],
-    // Overview is a SINGLE agent call at max_tokens=8192 (no 3-judge panel;
-    // see agents/overview.py:80).
-    ["overview", totalTokens + 3000, 8192],
+    ["metadata", 500, STAGE_OUTPUT_TOKENS.metadata],
+    ["math_detection", 2000, STAGE_OUTPUT_TOKENS.math_detection],
+    ["calibration", 1500, STAGE_OUTPUT_TOKENS.calibration],
+    ["contribution_extraction", 3000, STAGE_OUTPUT_TOKENS.contribution_extraction],
+    ["overview", totalTokens + 3000, STAGE_OUTPUT_TOKENS.overview],
     // Completeness reads the full paper via _build_sections_text
     // (agents/completeness.py:44), not a small 3k prompt.
-    ["completeness", totalTokens + OVERVIEW_CONTEXT_OVERHEAD, 4096],
+    ["completeness", totalTokens + OVERVIEW_CONTEXT_OVERHEAD, STAGE_OUTPUT_TOKENS.completeness],
     // Section agents (parallel, one per reviewable section).
     ...Array.from(
       { length: sections },
-      (_, i) => [`section_${i + 1}`, sectionInput, 10000] as [string, number, number],
+      (_, i) =>
+        [`section_${i + 1}`, sectionInput, STAGE_OUTPUT_TOKENS.section] as [
+          string,
+          number,
+          number,
+        ],
     ),
     // Proof verify (chained after section agents for math sections).
     ...Array.from(
@@ -245,7 +223,7 @@ export function estimateReviewCost(
         [
           `proof_verify_${i + 1}`,
           sectionInput + OVERVIEW_CONTEXT_OVERHEAD,
-          16384,
+          STAGE_OUTPUT_TOKENS.proof_verify,
         ] as [string, number, number],
     ),
     // Cross-section synthesis (conditional, up to 3).
@@ -255,11 +233,10 @@ export function estimateReviewCost(
         [
           `cross_section_${i + 1}`,
           sectionTextTokens * 2 + OVERVIEW_CONTEXT_OVERHEAD,
-          8192,
+          STAGE_OUTPUT_TOKENS.cross_section,
         ] as [string, number, number],
     ),
-    // Editorial pass (replaces legacy crossref+critique).
-    ["editorial", editorialIn, 24000],
+    ["editorial", editorialIn, STAGE_OUTPUT_TOKENS.editorial],
   ];
 
   const reasoning = isReasoningModel(modelId);


### PR DESCRIPTION
Summary:
- add a shared Python pipeline manifest plus generated web JSON data
- route Python and web cost heuristics through the shared stage constants
- add Node-backed parity coverage between the TS estimator and Python cost gate

Test plan:
- python3 scripts/security_scanner.py
- bash scripts/doc-sync-check.sh
- uv run pytest tests/ -v
- uv run ruff check src/coarse/cost.py src/coarse/pipeline.py src/coarse/pipeline_spec.py tests/test_pipeline_spec.py
