### PR TITLE
refactor(pipeline): move stage helpers out of orchestrator (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 - **Architecture docs now match the runtime pipeline** — README, CONTRIBUTING, and CLAUDE now describe the single overview pass, completeness stage, cross-section/editorial flow, and legacy `crossref`/`critique` fallback that the code actually runs. The changelog entry that prematurely claimed `StageRouter`/`STAGE_MODELS` shipped was also corrected, and `scripts/doc-sync-check.sh` now blocks stale architecture phrases from creeping back in.
 
+### Changed
+
+- **`pipeline.py` is back to being an orchestrator** — the section-review helpers, calibration/contribution extraction, and editorial fallback logic moved into `src/coarse/review_stages.py`, leaving `pipeline.py` responsible for stage ordering, fan-out, and final assembly instead of stage-local implementation details.
+
 ## v1.2.2 — 2026-04-12
 
 Patch release. Clears the false "system busy (N/20 slots in use)" banner that the landing page was showing even when Modal was idle, and bundles the unreleased `dev` work (GPT-5.4 compare-panel + author-steering fallthroughs) that had accumulated since v1.2.1.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ src/coarse/
 ├── prompts.py               # All prompt templates
 ├── types.py                 # Pydantic models
 ├── pipeline.py              # review_paper() orchestrator
+├── review_stages.py         # Stage-local review helpers used by pipeline.py
 ├── synthesis.py             # Review → markdown string
 ├── quality.py               # Quality eval against reference (dev only)
 ├── recall.py                # Recall eval vs. ground-truth expert reviews (dev only)

--- a/src/coarse/pipeline.py
+++ b/src/coarse/pipeline.py
@@ -11,10 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from coarse.agents.completeness import CompletenessAgent
-from coarse.agents.critique import CritiqueAgent
 from coarse.agents.cross_section import CrossSectionAgent
-from coarse.agents.crossref import CrossrefAgent
-from coarse.agents.editorial import EditorialAgent
 from coarse.agents.literature import search_literature
 from coarse.agents.overview import OverviewAgent, merge_overview
 from coarse.agents.quote_repair import QuoteRepairAgent
@@ -487,9 +484,6 @@ def review_paper(
         contribution_context=contribution_context,
         document_form=structure.document_form,
         author_notes=author_notes,
-        editorial_agent_cls=EditorialAgent,
-        crossref_agent_cls=CrossrefAgent,
-        critique_agent_cls=CritiqueAgent,
     )
 
     # Programmatic quote verification against full paper text

--- a/src/coarse/pipeline.py
+++ b/src/coarse/pipeline.py
@@ -25,22 +25,22 @@ from coarse.cost import run_cost_gate
 from coarse.extraction import extract_file
 from coarse.llm import LLMClient
 from coarse.pipeline_spec import MAX_REVIEWABLE_SECTIONS
-from coarse.prompts import (
-    CALIBRATION_SYSTEM,
-    CONTRIBUTION_EXTRACTION_SYSTEM,
-    calibration_user,
-    contribution_extraction_user,
-)
 from coarse.quote_verify import QuoteVerificationDrop, verify_quotes, verify_quotes_detailed
+from coarse.review_stages import (
+    _detect_section_focus,
+    _review_section,
+    calibrate_domain,
+    extract_contribution,
+    run_editorial_pass,
+)
+from coarse.review_stages import (
+    _section_needs_proof_verify as _section_needs_proof_verify,  # noqa: F401
+)
 from coarse.structure import analyze_structure
 from coarse.synthesis import render_review
 from coarse.types import (
-    ContributionContext,
     DetailedComment,
-    DocumentForm,
-    DomainCalibration,
     ExtractionError,
-    OverviewFeedback,
     PaperStructure,
     PaperText,
     Review,
@@ -185,116 +185,10 @@ def _verify_section_with_fallback(
 
 _MIN_APPENDIX_CHARS = 500  # skip appendix sections shorter than this
 
-# Minimum text length for proof_verify to run on a math-flagged section.
-# proof_verify chains an adversarial re-derivation pass after the section
-# agent and costs one full-budget LLM call (~$0.30 on sonnet-4.6,
-# proportionally more on reasoning models). Running it on a section that's
-# just one inline equation in a footnote isn't worth that cost — there's
-# nothing to adversarially verify in 150 chars of text. This threshold is
-# set deliberately LOW so short lemmas with their proofs aren't missed
-# (typical lemma-with-short-proof paragraphs run 300-800 chars), and
-# sections that have ANY extracted formal claim (`section.claims` non-
-# empty) bypass the length check entirely — we always verify real formal
-# statements regardless of how short the section is.
-_MIN_PROOF_VERIFY_SECTION_CHARS = 500
-
-
-def _section_needs_proof_verify(section: SectionInfo) -> bool:
-    """Return True iff proof_verify should chain after the section agent.
-
-    Requires the LLM-set ``math_content`` flag AND one of:
-    - at least one extracted formal claim (Theorem/Lemma/etc), OR
-    - section text length >= ``_MIN_PROOF_VERIFY_SECTION_CHARS``.
-
-    The claims-non-empty bypass is important: a short formal lemma with
-    a one-line proof might have only 250 characters of text but still
-    deserves verification because the paper explicitly called it out
-    as a formal result. The length threshold filters the opposite case:
-    a discussion section that happened to have one inline equation.
-    """
-    if not section.math_content:
-        return False
-    if section.claims:
-        return True
-    return len(section.text) >= _MIN_PROOF_VERIFY_SECTION_CHARS
-
 
 def _renumber_comments(comments: list[DetailedComment]) -> list[DetailedComment]:
     """Renumber comments sequentially 1..N."""
     return [c.model_copy(update={"number": i}) for i, c in enumerate(comments, start=1)]
-
-
-def _detect_section_focus(section: SectionInfo) -> str:
-    """Detect section focus based on LLM-detected math content and section type.
-
-    Returns one of: "proof", "methodology", "results", "literature", "discussion", "general".
-    The math_content flag is set during structure analysis by an LLM call.
-    """
-    if section.math_content:
-        return "proof"
-    if section.section_type == SectionType.METHODOLOGY:
-        return "methodology"
-    if section.section_type == SectionType.RESULTS:
-        return "results"
-    if section.section_type == SectionType.RELATED_WORK:
-        return "literature"
-    if section.section_type in (SectionType.DISCUSSION, SectionType.CONCLUSION):
-        return "discussion"
-    return "general"
-
-
-def _review_section(
-    section_agent: SectionAgent,
-    verify_agent: ProofVerifyAgent,
-    section: SectionInfo,
-    paper_markdown: str,
-    paper_title: str,
-    overview: OverviewFeedback | None,
-    calibration: DomainCalibration | None,
-    focus: str,
-    literature_context: str,
-    all_sections: list[SectionInfo],
-    abstract: str,
-    *,
-    document_form: DocumentForm = "manuscript",
-    author_notes: str | None = None,
-) -> list[DetailedComment]:
-    """Review a section; chain with adversarial verification for proof sections."""
-    comments = section_agent.run(
-        section,
-        paper_title,
-        overview,
-        calibration,
-        focus,
-        literature_context,
-        all_sections=all_sections,
-        abstract=abstract,
-        document_form=document_form,
-        author_notes=author_notes,
-    )
-    comments = _verify_with_fallback(
-        comments,
-        paper_markdown,
-        stage_name=f"Section-agent quote verification for '{section.title}'",
-        drop_unverified=False,
-    )
-    if focus == "proof" and comments and _section_needs_proof_verify(section):
-        comments = verify_agent.run(
-            section,
-            paper_title,
-            comments,
-            abstract=abstract,
-            document_form=document_form,
-            author_notes=author_notes,
-        )
-        comments = _verify_with_fallback(
-            comments,
-            paper_markdown,
-            stage_name=f"Proof-verify quote verification for '{section.title}'",
-            drop_unverified=False,
-        )
-    return comments
-
 
 def extract_and_structure(
     file_path: str | Path,
@@ -354,71 +248,6 @@ def extract_and_structure(
             "The file may be scanned/image-only with no extractable text."
         )
     return paper_text, structure
-
-
-def calibrate_domain(structure: PaperStructure, client: LLMClient) -> DomainCalibration | None:
-    """Generate domain-specific review criteria from the paper's content.
-
-    Single cheap LLM call (~$0.02). Returns None on failure (fallback to generic).
-    """
-    section_titles = ", ".join(f"{s.number}. {s.title}" for s in structure.sections)
-    messages = [
-        {"role": "system", "content": CALIBRATION_SYSTEM},
-        {
-            "role": "user",
-            "content": calibration_user(
-                structure.title,
-                structure.domain,
-                structure.abstract,
-                section_titles,
-            ),
-        },
-    ]
-    try:
-        return client.complete(messages, DomainCalibration, max_tokens=2048, temperature=0.3)
-    except Exception:
-        logger.warning("Domain calibration failed, using generic prompts", exc_info=True)
-        return None
-
-
-def extract_contribution(
-    structure: PaperStructure,
-    client: LLMClient,
-) -> ContributionContext | None:
-    """Extract paper's stated contributions via cheap LLM call (~$0.02).
-
-    Returns None on failure (pipeline proceeds without contribution context).
-    """
-    intro_text = ""
-    conclusion_text = ""
-    for s in structure.sections:
-        if s.section_type == SectionType.INTRODUCTION:
-            intro_text = s.text
-        elif s.section_type == SectionType.CONCLUSION:
-            conclusion_text = s.text
-
-    if not intro_text:
-        intro_text = structure.abstract
-
-    messages = [
-        {"role": "system", "content": CONTRIBUTION_EXTRACTION_SYSTEM},
-        {
-            "role": "user",
-            "content": contribution_extraction_user(
-                structure.title,
-                structure.abstract,
-                intro_text,
-                conclusion_text,
-            ),
-        },
-    ]
-    try:
-        return client.complete(messages, ContributionContext, max_tokens=2048, temperature=0.2)
-    except Exception:
-        logger.warning("Contribution extraction failed, proceeding without", exc_info=True)
-        return None
-
-
 def review_paper(
     pdf_path: str | Path,
     model: str | None = None,
@@ -453,9 +282,9 @@ def review_paper(
     1. Extract file → PaperText (format-specific extraction)
     2. Cost gate (optional)
     3. Analyze structure via markdown parsing + cheap LLM metadata → PaperStructure
-    4. Phase 1: Overview agent (blocking)
-    5. Phase 2: Section agents (parallel, text-only with overview context)
-    6. Cross-reference + quote verification + critique + quote re-verification
+    4. Phase 1: Overview, completeness, and section-context setup
+    5. Phase 2: Section agents + proof verification + cross-section synthesis
+    6. Editorial filtering (with legacy fallback) + quote verification/repair
     7. Synthesis → markdown
 
     Returns:
@@ -533,9 +362,7 @@ def review_paper(
 
     overview_agent = OverviewAgent(client)
     section_agent = SectionAgent(client)
-    editorial_agent = EditorialAgent(client)
     quote_repair_agent = QuoteRepairAgent(client)
-
     reviewable_sections = [
         s
         for s in structure.sections
@@ -650,61 +477,20 @@ def review_paper(
 
     # --- Phase 3: Editorial filter (single pass — dedup + contradiction + quality) ---
     # The editorial agent receives full paper text for quote/absence verification.
-    try:
-        filtered_comments = editorial_agent.run(
-            paper_text.full_markdown,
-            overview,
-            section_comments,
-            title=structure.title,
-            abstract=structure.abstract,
-            contribution_context=contribution_context,
-            document_form=structure.document_form,
-            author_notes=author_notes,
-        )
-        filtered_comments = _verify_with_fallback(
-            filtered_comments,
-            paper_text.full_markdown,
-            stage_name="Editorial quote verification",
-            drop_unverified=False,
-        )
-    except Exception:
-        # Fallback: use legacy crossref → critique pipeline if editorial agent fails
-        logger.warning("Editorial agent failed, falling back to crossref+critique", exc_info=True)
-        crossref_agent = CrossrefAgent(client)
-        critique_agent = CritiqueAgent(client)
-        try:
-            filtered_comments = crossref_agent.run(
-                overview,
-                section_comments,
-                title=structure.title,
-                abstract=structure.abstract,
-                author_notes=author_notes,
-            )
-            filtered_comments = _verify_with_fallback(
-                filtered_comments,
-                paper_text.full_markdown,
-                stage_name="Crossref quote verification",
-                drop_unverified=False,
-            )
-        except Exception:
-            logger.warning("Crossref fallback also failed", exc_info=True)
-            filtered_comments = section_comments
-        try:
-            filtered_comments = critique_agent.run(
-                overview,
-                filtered_comments,
-                title=structure.title,
-                abstract=structure.abstract,
-                author_notes=author_notes,
-            )
-            filtered_comments = _verify_with_fallback(
-                filtered_comments,
-                paper_text.full_markdown,
-                stage_name="Critique quote verification",
-                drop_unverified=False,
-            )
-        except Exception:
-            logger.warning("Critique fallback also failed", exc_info=True)
+    filtered_comments = run_editorial_pass(
+        client,
+        paper_text.full_markdown,
+        overview,
+        section_comments,
+        title=structure.title,
+        abstract=structure.abstract,
+        contribution_context=contribution_context,
+        document_form=structure.document_form,
+        author_notes=author_notes,
+        editorial_agent_cls=EditorialAgent,
+        crossref_agent_cls=CrossrefAgent,
+        critique_agent_cls=CritiqueAgent,
+    )
 
     # Programmatic quote verification against full paper text
     final_comments = _verify_with_repair_fallback(

--- a/src/coarse/review_stages.py
+++ b/src/coarse/review_stages.py
@@ -1,0 +1,259 @@
+"""Stage-local review helpers used by the pipeline orchestrator."""
+
+from __future__ import annotations
+
+import logging
+
+from coarse.agents.critique import CritiqueAgent
+from coarse.agents.crossref import CrossrefAgent
+from coarse.agents.editorial import EditorialAgent
+from coarse.agents.section import SectionAgent
+from coarse.agents.verify import ProofVerifyAgent
+from coarse.llm import LLMClient
+from coarse.prompts import (
+    CALIBRATION_SYSTEM,
+    CONTRIBUTION_EXTRACTION_SYSTEM,
+    calibration_user,
+    contribution_extraction_user,
+)
+from coarse.quote_verify import verify_quotes
+from coarse.types import (
+    ContributionContext,
+    DetailedComment,
+    DocumentForm,
+    DomainCalibration,
+    OverviewFeedback,
+    PaperStructure,
+    SectionInfo,
+    SectionType,
+)
+
+logger = logging.getLogger(__name__)
+
+# Minimum text length for proof_verify to run on a math-flagged section.
+_MIN_PROOF_VERIFY_SECTION_CHARS = 500
+
+
+def _section_needs_proof_verify(section: SectionInfo) -> bool:
+    """Return True iff proof_verify should chain after the section agent."""
+    if not section.math_content:
+        return False
+    if section.claims:
+        return True
+    return len(section.text) >= _MIN_PROOF_VERIFY_SECTION_CHARS
+
+
+def _verify_with_fallback(
+    comments: list[DetailedComment],
+    paper_markdown: str,
+    *,
+    stage_name: str,
+    drop_unverified: bool = False,
+) -> list[DetailedComment]:
+    """Run quote verification, keeping originals if everything is dropped."""
+    verified = verify_quotes(comments, paper_markdown, drop_unverified=drop_unverified)
+    if comments and not verified:
+        logger.warning("%s dropped ALL comments — keeping original comments", stage_name)
+        return comments
+    return verified
+
+
+def _detect_section_focus(section: SectionInfo) -> str:
+    """Detect section focus from the section type and math-content flag."""
+    if section.math_content:
+        return "proof"
+    if section.section_type == SectionType.METHODOLOGY:
+        return "methodology"
+    if section.section_type == SectionType.RESULTS:
+        return "results"
+    if section.section_type == SectionType.RELATED_WORK:
+        return "literature"
+    if section.section_type in (SectionType.DISCUSSION, SectionType.CONCLUSION):
+        return "discussion"
+    return "general"
+
+
+def _review_section(
+    section_agent: SectionAgent,
+    verify_agent: ProofVerifyAgent,
+    section: SectionInfo,
+    paper_markdown: str,
+    paper_title: str,
+    overview: OverviewFeedback | None,
+    calibration: DomainCalibration | None,
+    focus: str,
+    literature_context: str,
+    all_sections: list[SectionInfo],
+    abstract: str,
+    *,
+    document_form: DocumentForm = "manuscript",
+    author_notes: str | None = None,
+) -> list[DetailedComment]:
+    """Review a section; chain with adversarial verification for proof sections."""
+    comments = section_agent.run(
+        section,
+        paper_title,
+        overview,
+        calibration,
+        focus,
+        literature_context,
+        all_sections=all_sections,
+        abstract=abstract,
+        document_form=document_form,
+        author_notes=author_notes,
+    )
+    comments = _verify_with_fallback(
+        comments,
+        paper_markdown,
+        stage_name=f"Section-agent quote verification for '{section.title}'",
+    )
+    if focus == "proof" and comments and _section_needs_proof_verify(section):
+        comments = verify_agent.run(
+            section,
+            paper_title,
+            comments,
+            abstract=abstract,
+            document_form=document_form,
+            author_notes=author_notes,
+        )
+        comments = _verify_with_fallback(
+            comments,
+            paper_markdown,
+            stage_name=f"Proof-verify quote verification for '{section.title}'",
+        )
+    return comments
+
+
+def calibrate_domain(structure: PaperStructure, client: LLMClient) -> DomainCalibration | None:
+    """Generate domain-specific review criteria from the paper's content."""
+    section_titles = ", ".join(f"{s.number}. {s.title}" for s in structure.sections)
+    messages = [
+        {"role": "system", "content": CALIBRATION_SYSTEM},
+        {
+            "role": "user",
+            "content": calibration_user(
+                structure.title,
+                structure.domain,
+                structure.abstract,
+                section_titles,
+            ),
+        },
+    ]
+    try:
+        return client.complete(messages, DomainCalibration, max_tokens=2048, temperature=0.3)
+    except Exception:
+        logger.warning("Domain calibration failed, using generic prompts", exc_info=True)
+        return None
+
+
+def extract_contribution(
+    structure: PaperStructure,
+    client: LLMClient,
+) -> ContributionContext | None:
+    """Extract the paper's stated contributions for downstream review stages."""
+    intro_text = ""
+    conclusion_text = ""
+    for section in structure.sections:
+        if section.section_type == SectionType.INTRODUCTION:
+            intro_text = section.text
+        elif section.section_type == SectionType.CONCLUSION:
+            conclusion_text = section.text
+
+    if not intro_text:
+        intro_text = structure.abstract
+
+    messages = [
+        {"role": "system", "content": CONTRIBUTION_EXTRACTION_SYSTEM},
+        {
+            "role": "user",
+            "content": contribution_extraction_user(
+                structure.title,
+                structure.abstract,
+                intro_text,
+                conclusion_text,
+            ),
+        },
+    ]
+    try:
+        return client.complete(messages, ContributionContext, max_tokens=2048, temperature=0.2)
+    except Exception:
+        logger.warning("Contribution extraction failed, proceeding without", exc_info=True)
+        return None
+
+
+def run_editorial_pass(
+    client: LLMClient,
+    paper_text: str,
+    overview: OverviewFeedback,
+    comments: list[DetailedComment],
+    *,
+    title: str = "",
+    abstract: str = "",
+    contribution_context: ContributionContext | None = None,
+    document_form: DocumentForm = "manuscript",
+    author_notes: str | None = None,
+    editorial_agent_cls: type[EditorialAgent] | None = None,
+    crossref_agent_cls: type[CrossrefAgent] | None = None,
+    critique_agent_cls: type[CritiqueAgent] | None = None,
+) -> list[DetailedComment]:
+    """Run the primary editorial pass with the legacy fallback chain."""
+    editorial_agent_cls = editorial_agent_cls or EditorialAgent
+    crossref_agent_cls = crossref_agent_cls or CrossrefAgent
+    critique_agent_cls = critique_agent_cls or CritiqueAgent
+
+    editorial_agent = editorial_agent_cls(client)
+    try:
+        filtered_comments = editorial_agent.run(
+            paper_text,
+            overview,
+            comments,
+            title=title,
+            abstract=abstract,
+            contribution_context=contribution_context,
+            document_form=document_form,
+            author_notes=author_notes,
+        )
+        return _verify_with_fallback(
+            filtered_comments,
+            paper_text,
+            stage_name="Editorial quote verification",
+        )
+    except Exception:
+        logger.warning("Editorial agent failed, falling back to crossref+critique", exc_info=True)
+
+    crossref_agent = crossref_agent_cls(client)
+    critique_agent = critique_agent_cls(client)
+
+    try:
+        filtered_comments = crossref_agent.run(
+            overview,
+            comments,
+            title=title,
+            abstract=abstract,
+            author_notes=author_notes,
+        )
+        filtered_comments = _verify_with_fallback(
+            filtered_comments,
+            paper_text,
+            stage_name="Crossref quote verification",
+        )
+    except Exception:
+        logger.warning("Crossref fallback also failed", exc_info=True)
+        filtered_comments = comments
+
+    try:
+        filtered_comments = critique_agent.run(
+            overview,
+            filtered_comments,
+            title=title,
+            abstract=abstract,
+            author_notes=author_notes,
+        )
+        return _verify_with_fallback(
+            filtered_comments,
+            paper_text,
+            stage_name="Critique quote verification",
+        )
+    except Exception:
+        logger.warning("Critique fallback also failed", exc_info=True)
+        return filtered_comments

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -163,7 +163,7 @@ def test_review_paper_calls_stages_in_order():
         patch("coarse.pipeline.CompletenessAgent") as MockCompleteness,
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
-        patch("coarse.pipeline.EditorialAgent") as MockEditorial,
+        patch("coarse.review_stages.EditorialAgent") as MockEditorial,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", side_effect=fake_render),
     ):
@@ -220,8 +220,8 @@ def test_review_paper_skips_references_section():
         patch("coarse.pipeline.OverviewAgent") as MockOverview,
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
-        patch("coarse.pipeline.CrossrefAgent") as MockCrossref,
-        patch("coarse.pipeline.CritiqueAgent") as MockCritique,
+        patch("coarse.review_stages.CrossrefAgent") as MockCrossref,
+        patch("coarse.review_stages.CritiqueAgent") as MockCritique,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value="md"),
     ):
@@ -338,7 +338,7 @@ def test_review_paper_forwards_author_notes_to_all_review_agents():
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
         patch("coarse.pipeline.CompletenessAgent") as MockCompleteness,
         patch("coarse.pipeline.CrossSectionAgent") as MockCrossSection,
-        patch("coarse.pipeline.EditorialAgent") as MockEditorial,
+        patch("coarse.review_stages.EditorialAgent") as MockEditorial,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value="md"),
     ):
@@ -411,9 +411,9 @@ def test_review_paper_forwards_author_notes_to_fallback_crossref_and_critique():
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
         patch("coarse.pipeline.CompletenessAgent") as MockCompleteness,
-        patch("coarse.pipeline.EditorialAgent") as MockEditorial,
-        patch("coarse.pipeline.CrossrefAgent") as MockCrossref,
-        patch("coarse.pipeline.CritiqueAgent") as MockCritique,
+        patch("coarse.review_stages.EditorialAgent") as MockEditorial,
+        patch("coarse.review_stages.CrossrefAgent") as MockCrossref,
+        patch("coarse.review_stages.CritiqueAgent") as MockCritique,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value="md"),
     ):
@@ -450,8 +450,8 @@ def test_review_paper_date_format():
         patch("coarse.pipeline.OverviewAgent") as MockOverview,
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
-        patch("coarse.pipeline.CrossrefAgent") as MockCrossref,
-        patch("coarse.pipeline.CritiqueAgent") as MockCritique,
+        patch("coarse.review_stages.CrossrefAgent") as MockCrossref,
+        patch("coarse.review_stages.CritiqueAgent") as MockCritique,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value="md"),
         patch("coarse.pipeline.datetime") as mock_dt,
@@ -480,8 +480,8 @@ def _patch_pipeline_deps(overview: OverviewFeedback):
     mock_ov = stack.enter_context(patch("coarse.pipeline.OverviewAgent"))
     mock_sec = stack.enter_context(patch("coarse.pipeline.SectionAgent"))
     mock_vf = stack.enter_context(patch("coarse.pipeline.ProofVerifyAgent"))
-    mock_cr = stack.enter_context(patch("coarse.pipeline.CrossrefAgent"))
-    mock_ct = stack.enter_context(patch("coarse.pipeline.CritiqueAgent"))
+    mock_cr = stack.enter_context(patch("coarse.review_stages.CrossrefAgent"))
+    mock_ct = stack.enter_context(patch("coarse.review_stages.CritiqueAgent"))
     stack.enter_context(patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c))
     stack.enter_context(patch("coarse.pipeline.render_review", return_value="md"))
 
@@ -526,8 +526,8 @@ def test_review_paper_returns_review_and_markdown():
         patch("coarse.pipeline.OverviewAgent") as MockOverview,
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
-        patch("coarse.pipeline.CrossrefAgent") as MockCrossref,
-        patch("coarse.pipeline.CritiqueAgent") as MockCritique,
+        patch("coarse.review_stages.CrossrefAgent") as MockCrossref,
+        patch("coarse.review_stages.CritiqueAgent") as MockCritique,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value=expected_markdown),
     ):
@@ -582,7 +582,7 @@ def test_review_paper_section_comments_flattened():
         patch("coarse.pipeline.CompletenessAgent") as MockCompleteness,
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
-        patch("coarse.pipeline.EditorialAgent") as MockEditorial,
+        patch("coarse.review_stages.EditorialAgent") as MockEditorial,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value="md"),
     ):
@@ -670,8 +670,8 @@ def test_review_paper_uses_provided_config():
         patch("coarse.pipeline.OverviewAgent") as MockOverview,
         patch("coarse.pipeline.SectionAgent") as MockSection,
         patch("coarse.pipeline.ProofVerifyAgent") as MockVerify,
-        patch("coarse.pipeline.CrossrefAgent") as MockCrossref,
-        patch("coarse.pipeline.CritiqueAgent") as MockCritique,
+        patch("coarse.review_stages.CrossrefAgent") as MockCrossref,
+        patch("coarse.review_stages.CritiqueAgent") as MockCritique,
         patch("coarse.pipeline.verify_quotes", side_effect=lambda c, t, **kw: c),
         patch("coarse.pipeline.render_review", return_value="md"),
     ):

--- a/tests/test_review-stages.py
+++ b/tests/test_review-stages.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock, patch
 from coarse.review_stages import (
     _detect_section_focus,
     _review_section,
+    calibrate_domain,
+    extract_contribution,
     run_editorial_pass,
 )
 from coarse.types import DetailedComment, OverviewFeedback, OverviewIssue, SectionInfo, SectionType
@@ -118,3 +120,103 @@ def test_run_editorial_pass_falls_back_to_crossref_and_critique():
     assert result == critique_comments
     MockCrossref.return_value.run.assert_called_once()
     MockCritique.return_value.run.assert_called_once()
+
+
+def test_run_editorial_pass_returns_editorial_output_without_fallback():
+    editorial_comments = [_comment(20)]
+
+    class EditorialStub:
+        def __init__(self, client):
+            self.client = client
+
+        def run(self, *args, **kwargs):
+            return editorial_comments
+
+    class CrossrefStub:
+        def __init__(self, client):
+            raise AssertionError("crossref fallback should not run")
+
+    class CritiqueStub:
+        def __init__(self, client):
+            raise AssertionError("critique fallback should not run")
+
+    result = run_editorial_pass(
+        Mock(),
+        "paper text",
+        _overview(),
+        [_comment(1)],
+        editorial_agent_cls=EditorialStub,
+        crossref_agent_cls=CrossrefStub,
+        critique_agent_cls=CritiqueStub,
+    )
+
+    assert result == editorial_comments
+
+
+def test_run_editorial_pass_returns_crossref_comments_when_critique_fails():
+    crossref_comments = [_comment(30)]
+
+    class EditorialStub:
+        def __init__(self, client):
+            self.client = client
+
+        def run(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    class CrossrefStub:
+        def __init__(self, client):
+            self.client = client
+
+        def run(self, *args, **kwargs):
+            return crossref_comments
+
+    class CritiqueStub:
+        def __init__(self, client):
+            self.client = client
+
+        def run(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    result = run_editorial_pass(
+        Mock(),
+        "paper text",
+        _overview(),
+        [_comment(1)],
+        editorial_agent_cls=EditorialStub,
+        crossref_agent_cls=CrossrefStub,
+        critique_agent_cls=CritiqueStub,
+    )
+
+    assert result == crossref_comments
+
+
+def test_calibrate_domain_returns_none_on_client_failure():
+    client = Mock()
+    client.complete.side_effect = RuntimeError("boom")
+    structure = Mock(
+        title="Paper",
+        domain="social_sciences/economics",
+        abstract="Abstract",
+        sections=[Mock(number=1, title="Intro")],
+    )
+
+    assert calibrate_domain(structure, client) is None
+
+
+def test_extract_contribution_returns_none_on_client_failure():
+    client = Mock()
+    client.complete.side_effect = RuntimeError("boom")
+    structure = Mock(
+        title="Paper",
+        abstract="Abstract",
+        sections=[
+            SectionInfo(
+                number=1,
+                title="Intro",
+                text="Intro text",
+                section_type=SectionType.INTRODUCTION,
+            )
+        ],
+    )
+
+    assert extract_contribution(structure, client) is None

--- a/tests/test_review-stages.py
+++ b/tests/test_review-stages.py
@@ -1,0 +1,120 @@
+"""Tests for coarse.review_stages."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from coarse.review_stages import (
+    _detect_section_focus,
+    _review_section,
+    run_editorial_pass,
+)
+from coarse.types import DetailedComment, OverviewFeedback, OverviewIssue, SectionInfo, SectionType
+
+
+def _comment(number: int = 1) -> DetailedComment:
+    return DetailedComment(
+        number=number,
+        title=f"Comment {number}",
+        quote="This is a sufficiently long quote from the paper.",
+        feedback="This is detailed feedback.",
+    )
+
+
+def _overview() -> OverviewFeedback:
+    return OverviewFeedback(
+        summary="",
+        issues=[OverviewIssue(title="Issue", body="Body")],
+    )
+
+
+def test_detect_section_focus_routes_common_section_types():
+    assert (
+        _detect_section_focus(
+            SectionInfo(number=1, title="Methods", text="x", section_type=SectionType.METHODOLOGY)
+        )
+        == "methodology"
+    )
+    assert (
+        _detect_section_focus(
+            SectionInfo(
+                number=1,
+                title="Discussion",
+                text="x",
+                section_type=SectionType.DISCUSSION,
+            )
+        )
+        == "discussion"
+    )
+    assert (
+        _detect_section_focus(
+            SectionInfo(
+                number=1,
+                title="Proof",
+                text="x" * 600,
+                section_type=SectionType.OTHER,
+                math_content=True,
+            )
+        )
+        == "proof"
+    )
+
+
+def test_review_section_chains_verify_for_proof_sections():
+    section_agent = Mock()
+    verify_agent = Mock()
+    first_pass = [_comment(1)]
+    verified = [_comment(2)]
+    section_agent.run.return_value = first_pass
+    verify_agent.run.return_value = verified
+    section = SectionInfo(
+        number=1,
+        title="Proof",
+        text="x" * 600,
+        section_type=SectionType.OTHER,
+        math_content=True,
+    )
+
+    result = _review_section(
+        section_agent,
+        verify_agent,
+        section,
+        "Paper",
+        _overview(),
+        None,
+        "proof",
+        "",
+        [section],
+        "Abstract",
+    )
+
+    assert result == verified
+    section_agent.run.assert_called_once()
+    verify_agent.run.assert_called_once()
+
+
+def test_run_editorial_pass_falls_back_to_crossref_and_critique():
+    with (
+        patch("coarse.review_stages.EditorialAgent") as MockEditorial,
+        patch("coarse.review_stages.CrossrefAgent") as MockCrossref,
+        patch("coarse.review_stages.CritiqueAgent") as MockCritique,
+    ):
+        MockEditorial.return_value.run.side_effect = RuntimeError("boom")
+        crossref_comments = [_comment(10)]
+        critique_comments = [_comment(11)]
+        MockCrossref.return_value.run.return_value = crossref_comments
+        MockCritique.return_value.run.return_value = critique_comments
+
+        result = run_editorial_pass(
+            Mock(),
+            "paper text",
+            _overview(),
+            [_comment(1)],
+            title="Paper",
+            abstract="Abstract",
+            author_notes="please focus on identification",
+        )
+
+    assert result == critique_comments
+    MockCrossref.return_value.run.assert_called_once()
+    MockCritique.return_value.run.assert_called_once()


### PR DESCRIPTION
## Summary
- move stage-local pipeline helpers into `coarse.review_stages`
- keep `pipeline.py` focused on orchestration and preserve behavior
- add focused tests around editorial fallback seams and extracted helpers

## Testing
- python3 scripts/security_scanner.py
- bash scripts/doc-sync-check.sh
- uv run ruff check src/coarse/pipeline.py src/coarse/review_stages.py tests/test_pipeline.py tests/test_review-stages.py
- uv run pytest tests/test_review-stages.py tests/test_pipeline.py -v
- uv run pytest tests/ -v

## Notes
- Full-repo `uv run ruff check src/ tests/` still reports pre-existing unrelated baseline failures in existing test files outside this branch.