### PR TITLE
refactor(agents): move shared review helpers into neutral module (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Extraction now logs real OpenRouter denial details and falls back after paid OCR denials (#71)** — the PDF extractor no longer hard-fails immediately when the first `mistral-ocr` file-parser call comes back as a user-actionable OpenRouter denial. It now records a scrubbed one-line summary of the provider response body (status, message, code, metadata when present) so operators can distinguish `402 Payment Required` / spend-limit failures from `403 Forbidden` privacy-or-terms failures in Modal logs, and it allows the extraction chain to continue from paid `mistral-ocr` to free `pdf-text` / `cloudflare-ai` and then Docling for recoverable OpenRouter `402` / `403` denials. `401` auth failures still fail fast. New tests pin both production-shaped cases: `402` and `403` on the first extraction call now skip retries on that backend, log the scrubbed reason, and successfully fall through to the next extractor when available.
 
+### Changed
+
+- **Shared text helpers no longer live behind private cross-module imports** — section-text assembly and Jaccard/tokenization helpers moved into `src/coarse/review_utils.py`, so `CompletenessAgent`, `OverviewAgent`, `quote_verify.py`, and `recall.py` can share them directly without importing another module's underscore-prefixed internals.
+
 ## v1.2.2 — 2026-04-12
 
 Patch release. Clears the false "system busy (N/20 slots in use)" banner that the landing page was showing even when Modal was idle, and bundles the unreleased `dev` work (GPT-5.4 compare-panel + author-steering fallthroughs) that had accumulated since v1.2.1.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ src/coarse/
 ├── garble.py                # OCR garble detection and normalization
 ├── llm.py                   # litellm wrapper, model registry, cost tracking
 ├── prompts.py               # All prompt templates
+├── review_utils.py          # Shared text/token/similarity helpers across review modules
 ├── types.py                 # Pydantic models
 ├── pipeline.py              # review_paper() orchestrator
 ├── synthesis.py             # Review → markdown string

--- a/src/coarse/agents/completeness.py
+++ b/src/coarse/agents/completeness.py
@@ -7,7 +7,6 @@ import logging
 from pydantic import BaseModel, Field
 
 from coarse.agents.base import ReviewAgent
-from coarse.agents.overview import _build_sections_text
 from coarse.llm import LLMClient
 from coarse.prompts import (
     COMPLETENESS_SYSTEM,
@@ -15,6 +14,7 @@ from coarse.prompts import (
     completeness_user,
     document_form_notice,
 )
+from coarse.review_utils import build_sections_text
 from coarse.types import (
     ContributionContext,
     DomainCalibration,
@@ -67,7 +67,7 @@ class CompletenessAgent(ReviewAgent):
             )
             return []
 
-        sections_text = _build_sections_text(structure.sections)
+        sections_text = build_sections_text(structure.sections)
 
         user_text = author_notes_block(author_notes) + completeness_user(
             structure.title,

--- a/src/coarse/agents/overview.py
+++ b/src/coarse/agents/overview.py
@@ -15,29 +15,18 @@ from coarse.prompts import (
     overview_paper_context,
     overview_user,
 )
+from coarse.review_utils import build_sections_text, jaccard_similarity
 from coarse.types import (
     DomainCalibration,
     OverviewFeedback,
     OverviewIssue,
     PaperStructure,
-    SectionInfo,
     SectionType,
 )
 
 logger = logging.getLogger(__name__)
 
 _OVERVIEW_TEMPERATURE = 0.5
-
-
-def _build_sections_text(sections: list[SectionInfo]) -> str:
-    """Convert sections list to a text block with full, untruncated text."""
-    parts: list[str] = []
-    for sec in sections:
-        if not sec.text:
-            parts.append(f"## {sec.number}. {sec.title} ({sec.section_type.value})\n(empty)")
-            continue
-        parts.append(f"## {sec.number}. {sec.title} ({sec.section_type.value})\n{sec.text}")
-    return "\n\n".join(parts)
 
 
 class OverviewAgent(ReviewAgent):
@@ -53,7 +42,7 @@ class OverviewAgent(ReviewAgent):
         literature_context: str = "",
         author_notes: str | None = None,
     ) -> OverviewFeedback:
-        sections_text = _build_sections_text(structure.sections)
+        sections_text = build_sections_text(structure.sections)
 
         # Append the document-form addendum to the system prompt. Empty string
         # for manuscripts/preprints so that path is unchanged; a tailored block
@@ -209,6 +198,4 @@ def _normalize_title(title: str) -> str:
 
 def _title_overlap(a: str, b: str) -> float:
     """Word-level Jaccard similarity between two normalized titles."""
-    from coarse.quote_verify import _jaccard
-
-    return _jaccard(set(a.split()), set(b.split()))
+    return jaccard_similarity(set(a.split()), set(b.split()))

--- a/src/coarse/quote_verify.py
+++ b/src/coarse/quote_verify.py
@@ -149,7 +149,7 @@ def _find_nearest_passage(
     window_size = max(int(quote_len * window_factor), _MIN_WINDOW_SIZE)
     step = max(1, quote_len // 4)
 
-    quote_tokens = tokenize_text(quote)
+    quote_tokens = tokenize_text(quote, mode="whitespace")
 
     # Phase 1: Jaccard pre-filter — score all chunks cheaply. Stop the range
     # at len(paper_text) - window_size + 1 so every chunk is a full window;
@@ -158,7 +158,7 @@ def _find_nearest_passage(
     candidates: list[tuple[float, int]] = []
     for i in range(0, stop, step):
         chunk = paper_text[i : i + window_size]
-        score = jaccard_similarity(quote_tokens, tokenize_text(chunk))
+        score = jaccard_similarity(quote_tokens, tokenize_text(chunk, mode="whitespace"))
         candidates.append((score, i))
 
     # Take top-k by Jaccard score

--- a/src/coarse/quote_verify.py
+++ b/src/coarse/quote_verify.py
@@ -13,6 +13,7 @@ import logging
 import re
 
 from coarse.garble import garble_ratio as _passage_garble_score
+from coarse.review_utils import jaccard_similarity, tokenize_text
 from coarse.types import DetailedComment
 
 logger = logging.getLogger(__name__)
@@ -130,18 +131,6 @@ _MIN_WINDOW_SIZE = 50
 _JACCARD_TOP_K = 5  # number of candidate chunks to refine with SequenceMatcher
 
 
-def _tokenize(text: str) -> set[str]:
-    """Split lowercased text into word-level tokens for Jaccard similarity."""
-    return set(text.lower().split())
-
-
-def _jaccard(a: set[str], b: set[str]) -> float:
-    """Jaccard similarity between two token sets."""
-    if not a or not b:
-        return 0.0
-    return len(a & b) / len(a | b)
-
-
 def _find_nearest_passage(
     quote: str, paper_text: str, window_factor: float = 1.5
 ) -> tuple[str, float]:
@@ -160,7 +149,7 @@ def _find_nearest_passage(
     window_size = max(int(quote_len * window_factor), _MIN_WINDOW_SIZE)
     step = max(1, quote_len // 4)
 
-    quote_tokens = _tokenize(quote)
+    quote_tokens = tokenize_text(quote)
 
     # Phase 1: Jaccard pre-filter — score all chunks cheaply. Stop the range
     # at len(paper_text) - window_size + 1 so every chunk is a full window;
@@ -169,7 +158,7 @@ def _find_nearest_passage(
     candidates: list[tuple[float, int]] = []
     for i in range(0, stop, step):
         chunk = paper_text[i : i + window_size]
-        score = _jaccard(quote_tokens, _tokenize(chunk))
+        score = jaccard_similarity(quote_tokens, tokenize_text(chunk))
         candidates.append((score, i))
 
     # Take top-k by Jaccard score

--- a/src/coarse/recall.py
+++ b/src/coarse/recall.py
@@ -4,6 +4,7 @@ Measures what percentage of expert-identified errors the system actually found.
 Two-stage matching: location-based (cheap, via quote overlap) then semantic
 (LLM judge for unmatched pairs).
 """
+
 from __future__ import annotations
 
 import datetime
@@ -16,6 +17,7 @@ from pydantic import BaseModel, Field
 
 from coarse.llm import LLMClient
 from coarse.models import QUALITY_MODEL
+from coarse.review_utils import jaccard_similarity, tokenize_text
 from coarse.types import DetailedComment
 
 logger = logging.getLogger(__name__)
@@ -23,7 +25,9 @@ logger = logging.getLogger(__name__)
 
 class _YesNo(BaseModel):
     """Binary answer for semantic matching judge."""
+
     answer: str = Field(description="YES or NO")
+
 
 # ---------------------------------------------------------------------------
 # Ground-truth comment model
@@ -95,9 +99,14 @@ def parse_refine_review(markdown: str) -> list[GroundTruthComment]:
         if not feedback:
             feedback = block.strip()
 
-        comments.append(GroundTruthComment(
-            index=idx, title=title, quote=quote, feedback_text=feedback,
-        ))
+        comments.append(
+            GroundTruthComment(
+                index=idx,
+                title=title,
+                quote=quote,
+                feedback_text=feedback,
+            )
+        )
 
     return comments
 
@@ -133,15 +142,22 @@ def parse_plain_review(markdown: str) -> list[GroundTruthComment]:
         title = ""
         first_period = text.find(".")
         first_colon = text.find(":")
-        sep = min(
-            p for p in (first_period, first_colon) if p > 0
-        ) if any(p > 0 for p in (first_period, first_colon)) else -1
+        sep = (
+            min(p for p in (first_period, first_colon) if p > 0)
+            if any(p > 0 for p in (first_period, first_colon))
+            else -1
+        )
         if 0 < sep < 120:
             title = text[:sep].strip()
 
-        comments.append(GroundTruthComment(
-            index=global_idx, title=title, quote="", feedback_text=text,
-        ))
+        comments.append(
+            GroundTruthComment(
+                index=global_idx,
+                title=title,
+                quote="",
+                feedback_text=text,
+            )
+        )
 
     return comments
 
@@ -157,19 +173,6 @@ def parse_review_auto(markdown: str) -> list[GroundTruthComment]:
 # ---------------------------------------------------------------------------
 # Matching functions
 # ---------------------------------------------------------------------------
-
-def _tokenize(text: str) -> set[str]:
-    """Tokenize text into lowercase word set."""
-    return set(re.findall(r"\w+", text.lower()))
-
-
-def _jaccard(a: set[str], b: set[str]) -> float:
-    """Jaccard similarity between two token sets."""
-    if not a or not b:
-        return 0.0
-    return len(a & b) / len(a | b)
-
-
 def location_match(
     gt: GroundTruthComment,
     pred: DetailedComment,
@@ -182,7 +185,7 @@ def location_match(
     """
     # Primary: quote-to-quote match
     if gt.quote and pred.quote:
-        sim = _jaccard(_tokenize(gt.quote), _tokenize(pred.quote))
+        sim = jaccard_similarity(tokenize_text(gt.quote), tokenize_text(pred.quote))
         if sim >= threshold:
             return True
 
@@ -190,12 +193,15 @@ def location_match(
     gt_text = gt.quote or gt.feedback_text
     pred_text = pred.quote or pred.feedback
 
-    sim = _jaccard(_tokenize(gt_text), _tokenize(pred_text))
+    sim = jaccard_similarity(tokenize_text(gt_text), tokenize_text(pred_text))
     if sim >= threshold:
         return True
 
     # Tertiary: feedback-to-feedback (lower threshold for semantic overlap)
-    fb_sim = _jaccard(_tokenize(gt.feedback_text), _tokenize(pred.feedback))
+    fb_sim = jaccard_similarity(
+        tokenize_text(gt.feedback_text),
+        tokenize_text(pred.feedback),
+    )
     return fb_sim >= threshold * 1.5
 
 
@@ -213,11 +219,7 @@ def _semantic_judge_prompt(gt: GroundTruthComment, pred: DetailedComment) -> str
     gt_block += f"Quote: {gt.quote}\n" if gt.quote else ""
     gt_block += f"Feedback: {gt.feedback_text[:500]}"
 
-    pred_block = (
-        f"Title: {pred.title}\n"
-        f"Quote: {pred.quote}\n"
-        f"Feedback: {pred.feedback[:500]}"
-    )
+    pred_block = f"Title: {pred.title}\nQuote: {pred.quote}\nFeedback: {pred.feedback[:500]}"
 
     return f"""\
 Do these two review comments identify the same issue in the paper?
@@ -301,7 +303,8 @@ def compute_recall(
         gen_comments = parse_refine_review(generated)
         generated = [
             DetailedComment(
-                number=c.index, title=c.title,
+                number=c.index,
+                title=c.title,
                 quote=c.quote or "placeholder quote text",
                 feedback=c.feedback_text,
             )
@@ -312,9 +315,15 @@ def compute_recall(
 
     if not reference:
         return RecallReport(
-            location_recall=0.0, semantic_recall=0.0, precision=0.0, f1=0.0,
-            n_ground_truth=0, n_generated=len(generated),
-            matched_pairs=[], unmatched_gt=[], unmatched_pred=[],
+            location_recall=0.0,
+            semantic_recall=0.0,
+            precision=0.0,
+            f1=0.0,
+            n_ground_truth=0,
+            n_generated=len(generated),
+            matched_pairs=[],
+            unmatched_gt=[],
+            unmatched_pred=[],
         )
 
     # Phase 1: Location matching (free)
@@ -327,10 +336,13 @@ def compute_recall(
             if pred.number in matched_pred:
                 continue
             if location_match(gt, pred, threshold=location_threshold):
-                matched_pairs.append(MatchPair(
-                    gt_index=gt.index, pred_number=pred.number,
-                    match_type="location",
-                ))
+                matched_pairs.append(
+                    MatchPair(
+                        gt_index=gt.index,
+                        pred_number=pred.number,
+                        match_type="location",
+                    )
+                )
                 matched_gt.add(gt.index)
                 matched_pred.add(pred.number)
                 break
@@ -347,7 +359,8 @@ def compute_recall(
     if unmatched_gt_comments and unmatched_pred_comments:
         # Run semantic matching in parallel for speed
         def _check_pair(
-            gt: GroundTruthComment, pred: DetailedComment,
+            gt: GroundTruthComment,
+            pred: DetailedComment,
         ) -> tuple[GroundTruthComment, DetailedComment, bool]:
             return gt, pred, semantic_match(gt, pred, client)
 
@@ -361,10 +374,13 @@ def compute_recall(
             for future in futures:
                 gt, pred, is_match = future.result()
                 if is_match and gt.index not in matched_gt and pred.number not in matched_pred:
-                    matched_pairs.append(MatchPair(
-                        gt_index=gt.index, pred_number=pred.number,
-                        match_type="semantic",
-                    ))
+                    matched_pairs.append(
+                        MatchPair(
+                            gt_index=gt.index,
+                            pred_number=pred.number,
+                            match_type="semantic",
+                        )
+                    )
                     matched_gt.add(gt.index)
                     matched_pred.add(pred.number)
 
@@ -372,7 +388,8 @@ def compute_recall(
     precision = len(matched_pred) / len(generated) if generated else 0.0
     f1 = (
         2 * semantic_recall * precision / (semantic_recall + precision)
-        if (semantic_recall + precision) > 0 else 0.0
+        if (semantic_recall + precision) > 0
+        else 0.0
     )
 
     return RecallReport(

--- a/src/coarse/review_utils.py
+++ b/src/coarse/review_utils.py
@@ -1,0 +1,30 @@
+"""Shared text helpers for review agents and evaluation code."""
+
+from __future__ import annotations
+
+import re
+
+from coarse.types import SectionInfo
+
+
+def build_sections_text(sections: list[SectionInfo]) -> str:
+    """Convert sections list to a text block with full, untruncated text."""
+    parts: list[str] = []
+    for sec in sections:
+        if not sec.text:
+            parts.append(f"## {sec.number}. {sec.title} ({sec.section_type.value})\n(empty)")
+            continue
+        parts.append(f"## {sec.number}. {sec.title} ({sec.section_type.value})\n{sec.text}")
+    return "\n\n".join(parts)
+
+
+def tokenize_text(text: str) -> set[str]:
+    """Tokenize text into a lowercase word set."""
+    return set(re.findall(r"\w+", text.lower()))
+
+
+def jaccard_similarity(a: set[str], b: set[str]) -> float:
+    """Jaccard similarity between two token sets."""
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)

--- a/src/coarse/review_utils.py
+++ b/src/coarse/review_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Literal
 
 from coarse.types import SectionInfo
 
@@ -18,9 +19,16 @@ def build_sections_text(sections: list[SectionInfo]) -> str:
     return "\n\n".join(parts)
 
 
-def tokenize_text(text: str) -> set[str]:
-    """Tokenize text into a lowercase word set."""
-    return set(re.findall(r"\w+", text.lower()))
+def tokenize_text(text: str, *, mode: Literal["words", "whitespace"] = "words") -> set[str]:
+    """Tokenize text into a lowercase token set.
+
+    `quote_verify` needs whitespace-delimited tokens so punctuation-heavy
+    claims like `p<0.05` remain distinct. Recall matching uses word tokens.
+    """
+    normalized = text.lower()
+    if mode == "whitespace":
+        return {token for token in normalized.split() if token}
+    return set(re.findall(r"\w+", normalized))
 
 
 def jaccard_similarity(a: set[str], b: set[str]) -> float:

--- a/tests/test_overview-agent.py
+++ b/tests/test_overview-agent.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import MagicMock
 
-from coarse.agents.overview import OverviewAgent, _build_sections_text, merge_overview
+from coarse.agents.overview import OverviewAgent, merge_overview
 from coarse.llm import LLMClient
 from coarse.prompts import OVERVIEW_SYSTEM
+from coarse.review_utils import build_sections_text
 from coarse.types import (
     OverviewFeedback,
     OverviewIssue,
@@ -117,7 +118,7 @@ def test_build_sections_text_includes_all_sections():
             claims=["Claim D", "Claim E"],
         ),
     ]
-    result = _build_sections_text(sections)
+    result = build_sections_text(sections)
 
     for sec in sections:
         assert sec.title in result
@@ -134,7 +135,7 @@ def test_build_sections_text_no_truncation():
             section_type=SectionType.INTRODUCTION,
         ),
     ]
-    result = _build_sections_text(sections)
+    result = build_sections_text(sections)
     assert long_text in result
     assert "[...truncated]" not in result
 
@@ -144,7 +145,7 @@ def test_build_sections_text_empty_text():
     sections = [
         SectionInfo(number=1, title="Empty", text="", section_type=SectionType.OTHER),
     ]
-    result = _build_sections_text(sections)
+    result = build_sections_text(sections)
     assert "(empty)" in result
 
 

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -1,4 +1,5 @@
 """Tests for recall.py — recall-based evaluation against ground-truth reviews."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -7,8 +8,6 @@ from coarse.recall import (
     GroundTruthComment,
     MatchPair,
     RecallReport,
-    _jaccard,
-    _tokenize,
     compute_recall,
     location_match,
     parse_plain_review,
@@ -16,6 +15,7 @@ from coarse.recall import (
     parse_review_auto,
     save_recall_report,
 )
+from coarse.review_utils import jaccard_similarity, tokenize_text
 from coarse.types import DetailedComment  # noqa: I001
 
 # ---------------------------------------------------------------------------
@@ -136,9 +136,13 @@ def test_parse_review_auto_plain():
 # Matching tests
 # ---------------------------------------------------------------------------
 
+
 def _gt(index: int, quote: str = "", feedback: str = "feedback") -> GroundTruthComment:
     return GroundTruthComment(
-        index=index, title=f"GT {index}", quote=quote, feedback_text=feedback,
+        index=index,
+        title=f"GT {index}",
+        quote=quote,
+        feedback_text=feedback,
     )
 
 
@@ -148,33 +152,34 @@ def _pred(
     feedback: str = "some generic test feedback content",
 ) -> DetailedComment:
     return DetailedComment(
-        number=number, title=f"Pred {number}",
+        number=number,
+        title=f"Pred {number}",
         quote=quote,
         feedback=feedback,
     )
 
 
 def test_tokenize():
-    tokens = _tokenize("Hello world! This is a test.")
+    tokens = tokenize_text("Hello world! This is a test.")
     assert "hello" in tokens
     assert "world" in tokens
 
 
 def test_jaccard_identical():
     s = {"a", "b", "c"}
-    assert _jaccard(s, s) == 1.0
+    assert jaccard_similarity(s, s) == 1.0
 
 
 def test_jaccard_disjoint():
-    assert _jaccard({"a", "b"}, {"c", "d"}) == 0.0
+    assert jaccard_similarity({"a", "b"}, {"c", "d"}) == 0.0
 
 
 def test_jaccard_partial():
-    assert 0.0 < _jaccard({"a", "b", "c"}, {"b", "c", "d"}) < 1.0
+    assert 0.0 < jaccard_similarity({"a", "b", "c"}, {"b", "c", "d"}) < 1.0
 
 
 def test_jaccard_empty():
-    assert _jaccard(set(), {"a"}) == 0.0
+    assert jaccard_similarity(set(), {"a"}) == 0.0
 
 
 def test_location_match_same_quote():
@@ -211,6 +216,7 @@ def test_location_match_no_quote_uses_feedback():
 # Recall computation tests
 # ---------------------------------------------------------------------------
 
+
 def test_compute_recall_perfect():
     """All ground-truth comments matched."""
     gt = [
@@ -230,16 +236,20 @@ def test_compute_recall_perfect():
 
 def test_compute_recall_none():
     """No matches."""
-    gt = [_gt(
-        1,
-        quote="convergence rate of the maximum likelihood estimator",
-        feedback="the proof of theorem three has a fundamental gap",
-    )]
-    gen = [_pred(
-        1,
-        quote="the table entries for experiment seven are inconsistent",
-        feedback="numerical values in table seven do not match equation twelve",
-    )]
+    gt = [
+        _gt(
+            1,
+            quote="convergence rate of the maximum likelihood estimator",
+            feedback="the proof of theorem three has a fundamental gap",
+        )
+    ]
+    gen = [
+        _pred(
+            1,
+            quote="the table entries for experiment seven are inconsistent",
+            feedback="numerical values in table seven do not match equation twelve",
+        )
+    ]
 
     # Mock client that always says NO
     mock_client = MagicMock()
@@ -270,12 +280,18 @@ def test_compute_recall_from_markdown():
 # Report persistence tests
 # ---------------------------------------------------------------------------
 
+
 def test_save_recall_report(tmp_path):
     report = RecallReport(
-        location_recall=0.5, semantic_recall=0.75, precision=0.6, f1=0.667,
-        n_ground_truth=4, n_generated=5,
+        location_recall=0.5,
+        semantic_recall=0.75,
+        precision=0.6,
+        f1=0.667,
+        n_ground_truth=4,
+        n_generated=5,
         matched_pairs=[MatchPair(gt_index=1, pred_number=1, match_type="location")],
-        unmatched_gt=[2, 3], unmatched_pred=[4, 5],
+        unmatched_gt=[2, 3],
+        unmatched_pred=[4, 5],
     )
     out = tmp_path / "recall.md"
     save_recall_report(report, out, "ref.md", "gen.md")
@@ -289,6 +305,7 @@ def test_save_recall_report(tmp_path):
 # Model tests
 # ---------------------------------------------------------------------------
 
+
 def test_ground_truth_comment_model():
     c = GroundTruthComment(index=1, feedback_text="test")
     assert c.index == 1
@@ -298,8 +315,14 @@ def test_ground_truth_comment_model():
 
 def test_recall_report_model():
     r = RecallReport(
-        location_recall=0.5, semantic_recall=0.5, precision=0.5, f1=0.5,
-        n_ground_truth=2, n_generated=2,
-        matched_pairs=[], unmatched_gt=[], unmatched_pred=[],
+        location_recall=0.5,
+        semantic_recall=0.5,
+        precision=0.5,
+        f1=0.5,
+        n_ground_truth=2,
+        n_generated=2,
+        matched_pairs=[],
+        unmatched_gt=[],
+        unmatched_pred=[],
     )
     assert r.f1 == 0.5

--- a/tests/test_review-utils.py
+++ b/tests/test_review-utils.py
@@ -15,12 +15,41 @@ def test_build_sections_text_marks_empty_sections():
     assert "(empty)" in result
 
 
+def test_build_sections_text_formats_populated_sections_with_type_and_spacing():
+    sections = [
+        SectionInfo(
+            number=1,
+            title="Intro",
+            text="First section text.",
+            section_type=SectionType.INTRODUCTION,
+        ),
+        SectionInfo(
+            number=2,
+            title="Methods",
+            text="Second section text.",
+            section_type=SectionType.METHODOLOGY,
+        ),
+    ]
+
+    result = build_sections_text(sections)
+
+    assert "## 1. Intro (introduction)\nFirst section text." in result
+    assert "\n\n## 2. Methods (methodology)\nSecond section text." in result
+
+
 def test_tokenize_text_extracts_word_tokens():
     tokens = tokenize_text("Hello, world! Equation x_1 = 2.")
 
     assert "hello" in tokens
     assert "world" in tokens
     assert "x_1" in tokens
+
+
+def test_tokenize_text_whitespace_mode_preserves_punctuation_sensitive_tokens():
+    tokens = tokenize_text("p<0.05 alpha-beta", mode="whitespace")
+
+    assert "p<0.05" in tokens
+    assert "alpha-beta" in tokens
 
 
 def test_jaccard_similarity_handles_overlap():

--- a/tests/test_review-utils.py
+++ b/tests/test_review-utils.py
@@ -1,0 +1,27 @@
+"""Tests for review_utils.py."""
+
+from coarse.review_utils import build_sections_text, jaccard_similarity, tokenize_text
+from coarse.types import SectionInfo, SectionType
+
+
+def test_build_sections_text_marks_empty_sections():
+    sections = [
+        SectionInfo(number=1, title="Intro", text="", section_type=SectionType.INTRODUCTION),
+    ]
+
+    result = build_sections_text(sections)
+
+    assert "## 1. Intro" in result
+    assert "(empty)" in result
+
+
+def test_tokenize_text_extracts_word_tokens():
+    tokens = tokenize_text("Hello, world! Equation x_1 = 2.")
+
+    assert "hello" in tokens
+    assert "world" in tokens
+    assert "x_1" in tokens
+
+
+def test_jaccard_similarity_handles_overlap():
+    assert jaccard_similarity({"a", "b", "c"}, {"b", "c", "d"}) == 0.5


### PR DESCRIPTION
## Summary
- move shared section-text and token/similarity helpers into `coarse.review_utils`
- rewire overview, completeness, quote verification, and recall to use the neutral helper module
- preserve punctuation-sensitive `quote_verify` tokenization and add direct helper coverage

## Testing
- python3 scripts/security_scanner.py
- python3 scripts/security_scanner.py --strict --json
- bash scripts/doc-sync-check.sh
- uv run ruff check src/coarse/review_utils.py src/coarse/quote_verify.py tests/test_review-utils.py
- uv run pytest tests/test_review-utils.py tests/test_quote_verify.py tests/test_recall.py tests/test_overview-agent.py tests/test_completeness-agent.py -v
- uv run pytest tests/ -v

## Notes
- Full-repo `uv run ruff check src/ tests/` still reports the same unrelated baseline failures in existing test files outside this branch.