### PR TITLE
chore(codex): add Codex-native architecture and module review commands (#90)

### DIFF
--- a/.Codex/commands/architecture-review.md
+++ b/.Codex/commands/architecture-review.md
@@ -1,0 +1,219 @@
+# Architecture Review for coarse (Codex)
+
+Macro-level structural review of the `src/coarse/` package. Run when a large
+feature lands, a new agent appears, or the pipeline has been reshaped. This is
+the counterpart to `/module-review`: architecture review looks across modules,
+not inside one file.
+
+coarse is small enough that this command can stay in-session. Use one static
+scan plus three parallel in-session agents when the caller does not ask for
+`--scan-only`.
+
+## Arguments
+
+`$ARGUMENTS`:
+- `/architecture-review` — full review with static scan + 3-agent panel
+- `/architecture-review --scan-only` — import graph and layer checks only
+- `/architecture-review --scope coupling,data-flow` — restrict which agent
+  tracks to run
+
+## Package layer rules
+
+Treat these as the structural baseline.
+
+**Structural (HIGH):**
+1. `models.py` has zero internal dependencies.
+2. No import cycles anywhere.
+3. `agents/*.py` must not import `pipeline.py`, `cli.py`, `synthesis.py`,
+   `extraction.py`, or `extraction_qa.py`.
+4. `pipeline.py` is the orchestrator. Only `cli.py`, `__init__.py`,
+   `__main__.py`, and `deploy/*.py` may import it.
+
+**Smell (MEDIUM):**
+5. No file larger than 800 lines in `src/coarse/`.
+6. `types.py` may import from `models.py` only.
+7. `prompts.py` may import from `types.py` and `models.py` only.
+
+## Process
+
+### 1. Run the static scan
+
+Run an inline Python AST scan over `src/coarse/**/*.py`. Report:
+- import cycles
+- layer violations
+- oversized files
+- top fan-in modules
+
+Use this exact shape:
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && python3 <<'PY'
+import ast
+from pathlib import Path
+
+root = Path("src/coarse")
+agent_deny = {"pipeline", "cli", "synthesis", "extraction", "extraction_qa"}
+types_allow = {"models"}
+prompts_allow = {"models", "types"}
+
+graph: dict[str, set[str]] = {}
+sizes: dict[str, int] = {}
+for path in sorted(root.rglob("*.py")):
+    module = path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
+    source = path.read_text()
+    sizes[module] = source.count("\\n") + 1
+    tree = ast.parse(source)
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("coarse"):
+            imports.add(node.module.removeprefix("coarse.").split(".")[0] or "")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("coarse."):
+                    imports.add(alias.name.removeprefix("coarse.").split(".")[0])
+    graph[module] = {name for name in imports if name}
+
+def resolve(name: str) -> str | None:
+    if name in graph:
+        return name
+    for module in graph:
+        if module == name or module.endswith("." + name):
+            return module
+    return None
+
+structural: list[str] = []
+smells: list[str] = []
+for module, imports in graph.items():
+    name = module.split(".")[-1]
+    if name == "models" and imports:
+        structural.append(f"HIGH: models.py imports {sorted(imports)}")
+    if name == "types" and imports - types_allow:
+        smells.append(f"MEDIUM: types.py imports {sorted(imports - types_allow)}")
+    if name == "prompts" and imports - prompts_allow:
+        smells.append(f"MEDIUM: prompts.py imports {sorted(imports - prompts_allow)}")
+    if module.startswith("agents.") and imports & agent_deny:
+        structural.append(f"HIGH: {module} imports {sorted(imports & agent_deny)}")
+
+white, gray, black = 0, 1, 2
+color = {module: white for module in graph}
+cycles: list[list[str]] = []
+
+def walk(start: str) -> None:
+    stack = [(start, iter(graph.get(start, ())))]
+    path = [start]
+    color[start] = gray
+    while stack:
+        node, it = stack[-1]
+        try:
+            target_name = next(it)
+        except StopIteration:
+            color[node] = black
+            stack.pop()
+            path.pop()
+            continue
+        target = resolve(target_name)
+        if not target:
+            continue
+        if color.get(target) == gray:
+            index = path.index(target)
+            cycles.append(path[index:] + [target])
+        elif color.get(target) == white:
+            color[target] = gray
+            path.append(target)
+            stack.append((target, iter(graph.get(target, ()))))
+
+for module in list(graph):
+    if color[module] == white:
+        walk(module)
+
+fan_in = {module: 0 for module in graph}
+for imports in graph.values():
+    for imported in imports:
+        target = resolve(imported)
+        if target:
+            fan_in[target] += 1
+
+oversized = [f"{module} ({lines} lines)" for module, lines in sizes.items() if lines > 800]
+leaders = sorted(fan_in.items(), key=lambda item: -item[1])[:3]
+
+print(f"modules: {len(graph)}")
+print(f"oversized: {oversized or 'none'}")
+print(f"structural: {structural or 'none'}")
+print(f"smells: {smells or 'none'}")
+print(f"cycles: {cycles or 'none'}")
+print(f"fan-in leaders: {leaders}")
+PY
+```
+
+If `$ARGUMENTS` contains `--scan-only`, stop here and report.
+
+### 2. Launch 3 parallel agents
+
+Spawn three in-session agents in one batch. Give them the static scan output
+and the changed-file list when relevant.
+
+Agent A, `explorer`:
+- coupling and cohesion
+- modules doing multiple unrelated jobs
+- overly tight pairs that should merge or decouple
+
+Agent B, `explorer`:
+- data flow through `types.py`, `pipeline.py`, and `synthesis.py`
+- duplicated field derivation
+- raw dictionaries where Pydantic models should exist
+
+Agent C, `explorer`:
+- simplification opportunities in oversized files and `pipeline.py`
+- dead branches
+- one-off abstractions
+- extractable 200-line functions
+
+Each report should rank findings with file paths and small/medium/large effort.
+
+### 3. Adversarial pass
+
+Challenge the agent output yourself:
+- Is the problem real in this codebase, or generic pattern-matching?
+- Would the proposed split break existing tests or call sites?
+- Does the proposal change `types.py`, `models.py`, `pipeline.py` phase order,
+  or `agents/base.py`? If yes, escalate instead of auto-applying.
+
+### 4. Report
+
+Present the result in this form:
+
+```text
+ARCHITECTURE REVIEW — <branch>
+Modules: <N>  Violations: <N>  Cycles: <N>  Oversized: <N>
+
+Proposals:
+  1. [HIGH / small] <title>
+     Why: <one sentence>
+     Files: <paths>
+     Adversarial check: <pass/fail and why>
+```
+
+Always escalate:
+- changes to `types.py`
+- changes to `models.py`
+- pipeline phase-order changes
+- edits to `agents/base.py`
+- any proposal marked large
+
+Auto-apply only after telling the user what you are changing, and only for
+obvious dead-code removals or utility moves that do not alter behavior.
+
+### 5. Verify any approved edits
+
+For each applied change:
+1. edit in place
+2. run `uv run pytest tests/ -v`
+3. run `python3 scripts/security_scanner.py`
+4. stop and report if either fails
+
+## Important notes
+
+- Prefer in-session parallel agents over subprocess orchestration.
+- Keep the review finite. If the branch needs multiple architecture rounds,
+  that is itself a finding.
+- Favor proposals that remove code over proposals that add framework.

--- a/.Codex/commands/architecture-review.md
+++ b/.Codex/commands/architecture-review.md
@@ -47,38 +47,65 @@ Run an inline Python AST scan over `src/coarse/**/*.py`. Report:
 Use this exact shape:
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && python3 <<'PY'
+ROOT="$(git rev-parse --show-toplevel)" && cd "$ROOT" && python3 <<'PY'
 import ast
 from pathlib import Path
 
 root = Path("src/coarse")
+deploy_root = Path("deploy")
 agent_deny = {"pipeline", "cli", "synthesis", "extraction", "extraction_qa"}
 types_allow = {"models"}
 prompts_allow = {"models", "types"}
+pipeline_allow = {"cli", "__init__", "__main__"}
 
 graph: dict[str, set[str]] = {}
 sizes: dict[str, int] = {}
+
+def imported_targets(current_module: str, node: ast.AST) -> set[str]:
+    targets: set[str] = set()
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.name.startswith("coarse."):
+                targets.add(alias.name.removeprefix("coarse."))
+    elif isinstance(node, ast.ImportFrom):
+        if node.level:
+            base = current_module.split(".")[:-node.level]
+            if node.module:
+                targets.add(".".join([*base, node.module]))
+            else:
+                for alias in node.names:
+                    if alias.name != "*":
+                        targets.add(".".join([*base, alias.name]))
+        elif node.module == "coarse":
+            for alias in node.names:
+                if alias.name != "*":
+                    targets.add(alias.name)
+        elif node.module and node.module.startswith("coarse."):
+            base = node.module.removeprefix("coarse.")
+            targets.add(base)
+            for alias in node.names:
+                if alias.name != "*":
+                    targets.add(f"{base}.{alias.name}")
+    return {target for target in targets if target}
+
 for path in sorted(root.rglob("*.py")):
     module = path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
     source = path.read_text()
-    sizes[module] = source.count("\\n") + 1
+    sizes[module] = source.count("\n") + 1
     tree = ast.parse(source)
     imports: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("coarse"):
-            imports.add(node.module.removeprefix("coarse.").split(".")[0] or "")
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name.startswith("coarse."):
-                    imports.add(alias.name.removeprefix("coarse.").split(".")[0])
-    graph[module] = {name for name in imports if name}
+        imports.update(imported_targets(module, node))
+    graph[module] = imports
 
 def resolve(name: str) -> str | None:
-    if name in graph:
-        return name
-    for module in graph:
-        if module == name or module.endswith("." + name):
-            return module
+    candidate = name
+    while candidate:
+        if candidate in graph:
+            return candidate
+        if "." not in candidate:
+            break
+        candidate = candidate.rsplit(".", 1)[0]
     return None
 
 structural: list[str] = []
@@ -91,8 +118,11 @@ for module, imports in graph.items():
         smells.append(f"MEDIUM: types.py imports {sorted(imports - types_allow)}")
     if name == "prompts" and imports - prompts_allow:
         smells.append(f"MEDIUM: prompts.py imports {sorted(imports - prompts_allow)}")
-    if module.startswith("agents.") and imports & agent_deny:
-        structural.append(f"HIGH: {module} imports {sorted(imports & agent_deny)}")
+    denied = {target for target in imports if (resolve(target) or target) in agent_deny}
+    if module.startswith("agents.") and denied:
+        structural.append(f"HIGH: {module} imports {sorted(denied)}")
+    if module not in pipeline_allow and any(resolve(target) == "pipeline" for target in imports):
+        structural.append(f"HIGH: {module} imports pipeline")
 
 white, gray, black = 0, 1, 2
 color = {module: white for module in graph}
@@ -133,6 +163,16 @@ for imports in graph.values():
         if target:
             fan_in[target] += 1
 
+deploy_pipeline_importers: list[str] = []
+if deploy_root.exists():
+    for path in sorted(deploy_root.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        imports: set[str] = set()
+        for node in ast.walk(tree):
+            imports.update(imported_targets(path.stem, node))
+        if any(target == "pipeline" or target.startswith("pipeline.") for target in imports):
+            deploy_pipeline_importers.append(path.as_posix())
+
 oversized = [f"{module} ({lines} lines)" for module, lines in sizes.items() if lines > 800]
 leaders = sorted(fan_in.items(), key=lambda item: -item[1])[:3]
 
@@ -142,6 +182,7 @@ print(f"structural: {structural or 'none'}")
 print(f"smells: {smells or 'none'}")
 print(f"cycles: {cycles or 'none'}")
 print(f"fan-in leaders: {leaders}")
+print(f"deploy pipeline importers: {deploy_pipeline_importers or 'none'}")
 PY
 ```
 

--- a/.Codex/commands/module-review.md
+++ b/.Codex/commands/module-review.md
@@ -11,7 +11,7 @@ This is the module-level counterpart to `/architecture-review`.
 `$ARGUMENTS`:
 - `/module-review --module src/coarse/synthesis.py` — review one module
 - `/module-review --changed` — review recently changed coarse modules
-- `/module-review --all` — review every `src/coarse/*.py` module in dependency order
+- `/module-review --all` — review every `src/coarse/*.py` module in lexicographic order
 - `/module-review --review-only` — report findings only, do not edit
 
 ## The 11-point bug checklist
@@ -30,8 +30,8 @@ Every module is reviewed against these rules. Record each result as either:
    pipeline code is a violation.
 5. **No `print()` in library code.** CLI output can use `rich`; internals use
    logging.
-6. **Every `.py` in `src/coarse/` has a matching test file.** Missing tests
-   are a HIGH finding.
+6. **Every `.py` in `src/coarse/` has at least one plausible test target.**
+   Missing coverage is a HIGH finding.
 7. **Context managers for resources.** `ThreadPoolExecutor`, file handles, and
    sessions must use `with`.
 8. **Cost tracking uses `LLMClient.cost_usd` / `add_cost()`.** No manual
@@ -52,7 +52,7 @@ If `$ARGUMENTS` contains `--module <path>`, target that file.
 If `$ARGUMENTS` contains `--changed`, prefer these sources in order:
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+ROOT="$(git rev-parse --show-toplevel)" && cd "$ROOT" && \
 git diff --name-only origin/dev...HEAD -- 'src/coarse/*.py' 'src/coarse/**/*.py'
 ```
 
@@ -60,15 +60,15 @@ If that is empty because the current branch is `dev`, fall back to a recent
 window:
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+ROOT="$(git rev-parse --show-toplevel)" && cd "$ROOT" && \
 git diff --name-only HEAD~20..HEAD -- 'src/coarse/*.py' 'src/coarse/**/*.py'
 ```
 
 If `$ARGUMENTS` contains `--all`, enumerate:
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
-find src/coarse -name '*.py' -not -name '__init__.py' -not -name '__main__.py' | sort
+ROOT="$(git rev-parse --show-toplevel)" && cd "$ROOT" && \
+find src/coarse -name '*.py' | sort
 ```
 
 When more than 3 modules are queued, show the queue to the user and confirm
@@ -90,15 +90,19 @@ Do not assume the test is always named `tests/test_<module>.py` in this repo.
 Resolve tests in this order:
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
-basename="<module-basename-without-.py>" && \
-rg --files tests | rg "test_(${basename}|${basename//_/-}|${basename//-/_})([-_].+)?\\.py$"
+ROOT="$(git rev-parse --show-toplevel)" && cd "$ROOT" && \
+module_path="src/coarse/<module>.py" && \
+basename="$(basename "${module_path%.py}")" && \
+parent="$(basename "$(dirname "$module_path")")" && \
+rg --files tests | rg "test_(${basename}|${basename//_/-}|${basename//-/_}|${basename}-agent|agent-${basename}|${parent}-${basename}|${basename}-${parent})([-_].+)?\\.py$"
 ```
 
 Examples:
 - `section.py` → `tests/test_section-agent.py`
 - `structure.py` → `tests/test_structure-analysis.py`
 - `cost.py` → `tests/test_cost-estimator.py`
+- `__main__.py` → `tests/test_cli.py`
+- `__init__.py` → `tests/test_cli.py`, `tests/test_readme-+-packaging.py`
 
 If no plausible test file exists, record a HIGH finding and continue.
 
@@ -122,7 +126,7 @@ subagent.
 #### 2d. Run module-specific tests
 
 ```bash
-cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+ROOT="$(git rev-parse --show-toplevel)" && cd "$ROOT" && \
 uv run pytest <resolved-test-paths> -v
 ```
 
@@ -148,7 +152,7 @@ After each auto-fix, verify with:
 cd /private/tmp/coarse-<slug> && \
 uv run pytest <resolved-test-paths> -v && \
 uv run ruff check src/coarse/<module>.py && \
-python3 scripts/security_scanner.py --scope model-ids
+python3 scripts/security_scanner.py
 ```
 
 If a fix breaks verification, revert that fix only.

--- a/.Codex/commands/module-review.md
+++ b/.Codex/commands/module-review.md
@@ -1,0 +1,192 @@
+# Module Review for coarse (Codex)
+
+Focused code review of one module or a recent set of modules against coarse's
+11-point bug checklist. Use this when you want a tight module-level audit
+before a release, after a refactor, or when a file looks risky.
+
+This is the module-level counterpart to `/architecture-review`.
+
+## Arguments
+
+`$ARGUMENTS`:
+- `/module-review --module src/coarse/synthesis.py` — review one module
+- `/module-review --changed` — review recently changed coarse modules
+- `/module-review --all` — review every `src/coarse/*.py` module in dependency order
+- `/module-review --review-only` — report findings only, do not edit
+
+## The 11-point bug checklist
+
+Every module is reviewed against these rules. Record each result as either:
+- `[OK]`
+- `[FINDING: <severity>] <file>:<line> <description>`
+
+1. **Model IDs only in `models.py`.** Any `"provider/name"` literal outside
+   `src/coarse/models.py` is a violation.
+2. **LLM calls go through `LLMClient`.** No direct `litellm.completion(...)`
+   outside `src/coarse/llm.py`.
+3. **Structured output uses `instructor` + Pydantic.** No raw JSON parsing
+   of LLM responses outside `llm.py`.
+4. **Prompts live in `prompts.py`.** Scattered prompt strings in agents or
+   pipeline code is a violation.
+5. **No `print()` in library code.** CLI output can use `rich`; internals use
+   logging.
+6. **Every `.py` in `src/coarse/` has a matching test file.** Missing tests
+   are a HIGH finding.
+7. **Context managers for resources.** `ThreadPoolExecutor`, file handles, and
+   sessions must use `with`.
+8. **Cost tracking uses `LLMClient.cost_usd` / `add_cost()`.** No manual
+   per-call cost arithmetic outside `llm.py`.
+9. **API keys through `resolve_api_key()`.** No bare `os.getenv("*_API_KEY")`
+   outside `config.py`.
+10. **OCR / extraction paths handle empty or garbled output.** Extraction code
+    must degrade gracefully on empty content.
+11. **Verbatim quotes pass `quote_verify.py`.** Any producer of
+    `DetailedComment.quote` must verify the quote before returning.
+
+## Process
+
+### 1. Select modules
+
+If `$ARGUMENTS` contains `--module <path>`, target that file.
+
+If `$ARGUMENTS` contains `--changed`, prefer these sources in order:
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+git diff --name-only origin/dev...HEAD -- 'src/coarse/*.py' 'src/coarse/**/*.py'
+```
+
+If that is empty because the current branch is `dev`, fall back to a recent
+window:
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+git diff --name-only HEAD~20..HEAD -- 'src/coarse/*.py' 'src/coarse/**/*.py'
+```
+
+If `$ARGUMENTS` contains `--all`, enumerate:
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+find src/coarse -name '*.py' -not -name '__init__.py' -not -name '__main__.py' | sort
+```
+
+When more than 3 modules are queued, show the queue to the user and confirm
+before proceeding. Prefer the recently changed modules that are central to the
+pipeline first: `pipeline.py`, `extraction.py`, `prompts.py`, `structure.py`,
+`llm.py`, then changed agents.
+
+### 2. Per-module review loop
+
+For each module:
+
+#### 2a. Read the module and its tests
+
+Read:
+- `src/coarse/<module>.py`
+- the matching test file(s) under `tests/`
+
+Do not assume the test is always named `tests/test_<module>.py` in this repo.
+Resolve tests in this order:
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+basename="<module-basename-without-.py>" && \
+rg --files tests | rg "test_(${basename}|${basename//_/-}|${basename//-/_})([-_].+)?\\.py$"
+```
+
+Examples:
+- `section.py` → `tests/test_section-agent.py`
+- `structure.py` → `tests/test_structure-analysis.py`
+- `cost.py` → `tests/test_cost-estimator.py`
+
+If no plausible test file exists, record a HIGH finding and continue.
+
+#### 2b. Apply the 11-point checklist inline
+
+Review the file directly. Do not delegate the checklist.
+
+#### 2c. Run a subjective review pass
+
+Do an additional code-review pass for:
+- Dead code
+- Duplicated logic already present elsewhere in the package
+- Overly complex functions
+- Confusing control flow or poor names
+- Missing type hints on public functions
+- Error messages that leak provider internals or raw API payloads
+
+This subjective pass is still done locally by Codex. Do not hand it off to a
+subagent.
+
+#### 2d. Run module-specific tests
+
+```bash
+cd "/Users/davidvandijcke/University of Michigan Dropbox/David Van Dijcke/coarse" && \
+uv run pytest <resolved-test-paths> -v
+```
+
+If no matching test file exists, note that explicitly instead of fabricating one.
+
+#### 2e. Classify findings
+
+For each finding choose one:
+- **AUTO-FIX**: mechanical, safe, scoped
+- **PROPOSE**: needs design judgment
+- **ESCALATE**: touches `types.py`, `models.py`, `pipeline.py`, `agents/base.py`,
+  or changes a public API
+- **DEFER**: valid but out of scope for this review
+
+#### 2f. Apply auto-fixes unless `--review-only`
+
+Before editing, move to a dedicated worktree under `/private/tmp/` and use
+full paths for every edit.
+
+After each auto-fix, verify with:
+
+```bash
+cd /private/tmp/coarse-<slug> && \
+uv run pytest <resolved-test-paths> -v && \
+uv run ruff check src/coarse/<module>.py && \
+python3 scripts/security_scanner.py --scope model-ids
+```
+
+If a fix breaks verification, revert that fix only.
+
+#### 2g. Report the module
+
+Use this shape:
+
+```text
+MODULE: src/coarse/<module>.py
+  Tests:         <status>
+  Checklist:     <N OK>  <N findings>
+  Subjective:    <N additional findings>
+
+  Auto-fixed:    <list or none>
+  Proposed:      <list or none>
+  Escalated:     <list or none>
+  Deferred:      <list or none>
+```
+
+### 3. Final summary
+
+After the queue is done:
+
+```text
+MODULE REVIEW — <branch>
+Reviewed: <N> modules
+Total findings: <N>
+Auto-fixed: <N>
+Still open: <N> (list with severities)
+
+Next suggested action: <one sentence>
+```
+
+## Important notes
+
+- Keep the review focused on the target module; do not broaden scope unless a
+  finding requires a clearly related cross-file fix.
+- Treat the 11-point checklist as the source of truth.
+- If you make edits, commit per module with a conventional commit scoped to the
+  module, for example: `fix(extraction): apply module-review auto-fixes`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Extraction now logs real OpenRouter denial details and falls back after paid OCR denials (#71)** — the PDF extractor no longer hard-fails immediately when the first `mistral-ocr` file-parser call comes back as a user-actionable OpenRouter denial. It now records a scrubbed one-line summary of the provider response body (status, message, code, metadata when present) so operators can distinguish `402 Payment Required` / spend-limit failures from `403 Forbidden` privacy-or-terms failures in Modal logs, and it allows the extraction chain to continue from paid `mistral-ocr` to free `pdf-text` / `cloudflare-ai` and then Docling for recoverable OpenRouter `402` / `403` denials. `401` auth failures still fail fast. New tests pin both production-shaped cases: `402` and `403` on the first extraction call now skip retries on that backend, log the scrubbed reason, and successfully fall through to the next extractor when available.
 
+### Added
+
+- **Codex-native architecture and module review commands** — `.Codex/commands/architecture-review.md` and `.Codex/commands/module-review.md` now exist in-repo, including the repo-specific test-resolution guidance needed for files like `test_section-agent.py`, `test_structure-analysis.py`, and `test_cost-estimator.py`.
+
 ## v1.2.2 — 2026-04-12
 
 Patch release. Clears the false "system busy (N/20 slots in use)" banner that the landing page was showing even when Modal was idle, and bundles the unreleased `dev` work (GPT-5.4 compare-panel + author-steering fallthroughs) that had accumulated since v1.2.1.


### PR DESCRIPTION
## Summary
- add `.Codex/commands/architecture-review.md` and `.Codex/commands/module-review.md`
- align both command docs with repo worktree usage instead of the main checkout path
- cover repo-specific test discovery cases like `test_section-agent.py`, `test_structure-analysis.py`, `test_cost-estimator.py`, and `test_agent-base.py`

## Testing
- python3 scripts/security_scanner.py
- python3 scripts/security_scanner.py --strict --json
- bash scripts/doc-sync-check.sh
- uv run pytest tests/ -v

## Notes
- Full-repo `uv run ruff check src/ tests/` still reports the same unrelated baseline failures in existing test files outside this branch.