### PR TITLE
fix(web): add Cloudflare Turnstile check to presign endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+- **Cloudflare Turnstile gate on the review submit flow** — `/api/presign` now verifies a Turnstile token via Cloudflare siteverify (5s timeout) before minting a review row or upload URL, so headless scripts can no longer drive the review pipeline. The widget is rendered above the landing-page submit button in managed mode, its token rides on the presign body, and the helper in `web/src/lib/turnstile.ts` fails open when `TURNSTILE_SECRET_KEY` is unset so local dev without a secret still works. Enforcement flips on automatically once `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` are set on Vercel. `/api/submit` is already tightly bound to presign via the existing signed upload URL, so protecting presign alone covers the whole flow.
+
 ### Fixed
 
 - **Web UI now disables the email field and shows a banner while the coarse Gmail account is suspended** — added an `EMAIL_DELIVERY_DISABLED` kill switch in `web/src/lib/emailCapacity.ts` that forces `isEmailCapacityReached()` to return true and makes `/api/status` return `emailCapacityReached: true` plus a top-banner message ("Email delivery is temporarily down — save your review key when you submit and check back at coarse.ink/status/<your-key> in about an hour"). While the switch is on, the landing page disables the email input, accepts empty-email submissions, and prints the field-level note "Email delivery is temporarily down. Save your review key when you submit and check back in about an hour." The DB `system_status.banner_message` still overrides the hardcoded banner when an operator sets an incident-specific notice. This unblocks submissions while `/api/submit` was rejecting every request with an empty 500 body (browser surfaced as `Failed to execute 'json' on 'Response': Unexpected end of JSON input`) because `mailer.sendMail(...)` was throwing uncaught against the suspended Gmail account. Flip the constant back to `false` once email is healthy again.

--- a/web/src/app/api/presign/route.ts
+++ b/web/src/app/api/presign/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { NextRequest, NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/rateLimit";
+import { verifyTurnstileToken } from "@/lib/turnstile";
 
 const SUPPORTED_EXTENSIONS = new Set([
   ".pdf", ".txt", ".md", ".tex", ".latex",
@@ -30,9 +31,11 @@ export async function POST(request: NextRequest) {
   if (rateLimited) return rateLimited;
 
   let filename = "";
+  let turnstileToken = "";
   try {
     const body = await request.json();
     filename = (body.filename ?? "").trim();
+    turnstileToken = (body.turnstile_token ?? "").trim();
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
@@ -50,6 +53,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: `Unsupported format. Supported: ${[...SUPPORTED_EXTENSIONS].join(", ")}` },
       { status: 400 },
+    );
+  }
+
+  // Turnstile guards the entry point to the review pipeline. Fails open when
+  // TURNSTILE_SECRET_KEY is unset so local dev without a secret still works;
+  // in production set the env var on Vercel to enable enforcement.
+  const turnstileResult = await verifyTurnstileToken(turnstileToken, ip);
+  if (!turnstileResult.ok) {
+    return NextResponse.json(
+      { error: "Human check failed. Please refresh the page and try again." },
+      { status: 403 },
     );
   }
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -44,6 +44,14 @@ function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', '${GA_ID}');`}
         </Script>
+        {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY && (
+          <Script
+            src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+            strategy="afterInteractive"
+            async
+            defer
+          />
+        )}
       </head>
       <body>
         {/* SVG filter definitions for textured rules */}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,26 @@ import OpenRouterLoginButton from "@/components/OpenRouterLoginButton";
 import { estimateTokensFromPdf, estimateTokensFromText, estimateTokensFromDocx, estimateTokensFromEpub, getModelPricing, estimateReviewCost } from "@/lib/estimateCost";
 import { beginLogin, completeLogin, loadStoredKey, saveStoredKey, clearStoredKey } from "@/lib/openrouterAuth";
 
+/* ── Turnstile window API type + helper ───────────────────── */
+type TurnstileApi = {
+  render: (
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      callback: (token: string) => void;
+      "error-callback"?: () => void;
+      "expired-callback"?: () => void;
+      theme?: "light" | "dark" | "auto";
+    },
+  ) => string;
+  reset: (widgetId?: string) => void;
+  remove: (widgetId?: string) => void;
+};
+function getTurnstileApi(): TurnstileApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { turnstile?: TurnstileApi }).turnstile;
+}
+
 /* ── Split-flap AI name display ────────────────────────────── */
 const AI_NAMES = ["Claude,", "Gemini,", "Qwen,", "ChatGPT,", "DeepSeek,", "Kimi,", "Grok,", "MiniMax,", "Mistral,", "Llama,"];
 const CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -189,41 +209,36 @@ export default function Home() {
   // Render the Cloudflare Turnstile widget once its script has loaded. The
   // <Script strategy="afterInteractive"> tag in layout.tsx pulls the API
   // asynchronously, so window.turnstile may not exist yet on first effect
-  // run — retry with a small backoff until it shows up or the component
-  // unmounts. No-op entirely when NEXT_PUBLIC_TURNSTILE_SITE_KEY is unset.
+  // run — retry with a small backoff until it shows up. Bounded at
+  // ~7.5s total so a failed CDN fetch doesn't poll forever. No-op
+  // entirely when NEXT_PUBLIC_TURNSTILE_SITE_KEY is unset.
   useEffect(() => {
     if (!turnstileSiteKey) return;
     const container = turnstileContainerRef.current;
     if (!container) return;
 
-    type TurnstileApi = {
-      render: (
-        el: HTMLElement,
-        opts: {
-          sitekey: string;
-          callback: (token: string) => void;
-          "error-callback"?: () => void;
-          "expired-callback"?: () => void;
-          theme?: "light" | "dark" | "auto";
-        },
-      ) => string;
-      reset: (widgetId?: string) => void;
-      remove: (widgetId?: string) => void;
-    };
-    const getTurnstile = (): TurnstileApi | undefined =>
-      (window as unknown as { turnstile?: TurnstileApi }).turnstile;
-
     let cancelled = false;
     let retryTimer: number | undefined;
+    let retries = 0;
+    const MAX_RETRIES = 50; // 50 * 150ms = 7.5s
 
     const tryRender = () => {
       if (cancelled) return;
-      const api = getTurnstile();
+      const api = getTurnstileApi();
       if (!api) {
+        retries += 1;
+        if (retries >= MAX_RETRIES) {
+          console.error("Turnstile api.js failed to load within 7.5s");
+          return;
+        }
         retryTimer = window.setTimeout(tryRender, 150);
         return;
       }
       if (turnstileWidgetIdRef.current !== undefined) return;
+      // Clear the container defensively so a React-strict-mode mount→
+      // unmount→mount doesn't stack two widgets if the cleanup path's
+      // api.remove(widgetId) fails silently.
+      container.innerHTML = "";
       turnstileWidgetIdRef.current = api.render(container, {
         sitekey: turnstileSiteKey,
         callback: (token: string) => {
@@ -243,7 +258,7 @@ export default function Home() {
     return () => {
       cancelled = true;
       if (retryTimer !== undefined) window.clearTimeout(retryTimer);
-      const api = getTurnstile();
+      const api = getTurnstileApi();
       const widgetId = turnstileWidgetIdRef.current;
       if (api && widgetId !== undefined) {
         try {
@@ -257,12 +272,15 @@ export default function Home() {
     };
   }, [turnstileSiteKey]);
 
-  // Reset the Turnstile widget so the next presign call gets a fresh,
-  // single-use token. Called after every presign attempt (success or
-  // failure). No-op when Turnstile is disabled.
+  // Reset the Turnstile widget so the next submission gets a fresh,
+  // single-use token. Always called from handleSubmit's finally block —
+  // the token is consumed server-side on every presign attempt (success
+  // or failure), so a retry always needs a fresh one. Turnstile
+  // auto-refreshes the widget after reset in managed mode, so the next
+  // token lands in the ref within ~1s. No-op when Turnstile is disabled.
   const resetTurnstile = useCallback(() => {
     turnstileTokenRef.current = "";
-    const api = (window as unknown as { turnstile?: { reset: (w?: string) => void } }).turnstile;
+    const api = getTurnstileApi();
     if (api) {
       try {
         api.reset(turnstileWidgetIdRef.current);
@@ -391,7 +409,6 @@ export default function Home() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ filename: file.name, turnstile_token: turnstileToken }),
       });
-      resetTurnstile();
       if (!presignResp.ok) {
         const data = await presignResp.json();
         throw new Error(data.error || "Failed to prepare upload");
@@ -432,6 +449,11 @@ export default function Home() {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Submission failed");
       setSubmitting(false);
+    } finally {
+      // Turnstile tokens are single-use per siteverify call, so reset
+      // after every attempt (success or failure). Placed in finally so
+      // it runs exactly once per submit regardless of which step threw.
+      resetTurnstile();
     }
   }
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -172,6 +172,10 @@ export default function Home() {
   const [costLoading, setCostLoading] = useState(false);
   const tokenCacheRef = useRef<{ name: string; size: number; tokens: number } | null>(null);
   const oauthConsumedRef = useRef(false);
+  const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const turnstileTokenRef = useRef<string>("");
+  const turnstileContainerRef = useRef<HTMLDivElement | null>(null);
+  const turnstileWidgetIdRef = useRef<string | undefined>(undefined);
   const [systemStatus, setSystemStatus] = useState<{
     accepting: boolean; banner: string | null; activeReviews: number; capacity: number;
     emailCapacityReached?: boolean;
@@ -180,6 +184,92 @@ export default function Home() {
   // Fetch system capacity status on mount
   useEffect(() => {
     fetch("/api/status").then(r => r.json()).then(setSystemStatus).catch(() => {});
+  }, []);
+
+  // Render the Cloudflare Turnstile widget once its script has loaded. The
+  // <Script strategy="afterInteractive"> tag in layout.tsx pulls the API
+  // asynchronously, so window.turnstile may not exist yet on first effect
+  // run — retry with a small backoff until it shows up or the component
+  // unmounts. No-op entirely when NEXT_PUBLIC_TURNSTILE_SITE_KEY is unset.
+  useEffect(() => {
+    if (!turnstileSiteKey) return;
+    const container = turnstileContainerRef.current;
+    if (!container) return;
+
+    type TurnstileApi = {
+      render: (
+        el: HTMLElement,
+        opts: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "error-callback"?: () => void;
+          "expired-callback"?: () => void;
+          theme?: "light" | "dark" | "auto";
+        },
+      ) => string;
+      reset: (widgetId?: string) => void;
+      remove: (widgetId?: string) => void;
+    };
+    const getTurnstile = (): TurnstileApi | undefined =>
+      (window as unknown as { turnstile?: TurnstileApi }).turnstile;
+
+    let cancelled = false;
+    let retryTimer: number | undefined;
+
+    const tryRender = () => {
+      if (cancelled) return;
+      const api = getTurnstile();
+      if (!api) {
+        retryTimer = window.setTimeout(tryRender, 150);
+        return;
+      }
+      if (turnstileWidgetIdRef.current !== undefined) return;
+      turnstileWidgetIdRef.current = api.render(container, {
+        sitekey: turnstileSiteKey,
+        callback: (token: string) => {
+          turnstileTokenRef.current = token;
+        },
+        "error-callback": () => {
+          turnstileTokenRef.current = "";
+        },
+        "expired-callback": () => {
+          turnstileTokenRef.current = "";
+        },
+        theme: "dark",
+      });
+    };
+    tryRender();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+      const api = getTurnstile();
+      const widgetId = turnstileWidgetIdRef.current;
+      if (api && widgetId !== undefined) {
+        try {
+          api.remove(widgetId);
+        } catch {
+          /* best-effort; happens if the script was torn down first */
+        }
+      }
+      turnstileWidgetIdRef.current = undefined;
+      turnstileTokenRef.current = "";
+    };
+  }, [turnstileSiteKey]);
+
+  // Reset the Turnstile widget so the next presign call gets a fresh,
+  // single-use token. Called after every presign attempt (success or
+  // failure). No-op when Turnstile is disabled.
+  const resetTurnstile = useCallback(() => {
+    turnstileTokenRef.current = "";
+    const api = (window as unknown as { turnstile?: { reset: (w?: string) => void } }).turnstile;
+    if (api) {
+      try {
+        api.reset(turnstileWidgetIdRef.current);
+      } catch {
+        /* best-effort */
+      }
+    }
   }, []);
 
   // Hydrate OpenRouter key from localStorage and handle OAuth callback (?code=...)
@@ -292,11 +382,16 @@ export default function Home() {
     setError(null);
     try {
       // Step 1: Get a presigned upload URL (small JSON request — no file)
+      const turnstileToken = turnstileTokenRef.current;
+      if (turnstileSiteKey && !turnstileToken) {
+        throw new Error("Please complete the human check before submitting.");
+      }
       const presignResp = await fetch("/api/presign", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ filename: file.name }),
+        body: JSON.stringify({ filename: file.name, turnstile_token: turnstileToken }),
       });
+      resetTurnstile();
       if (!presignResp.ok) {
         const data = await presignResp.json();
         throw new Error(data.error || "Failed to prepare upload");
@@ -801,6 +896,13 @@ export default function Home() {
                     ? `Estimated API cost: $${costEstimate < 0.01 ? costEstimate.toFixed(4) : costEstimate.toFixed(2)}`
                     : "Cost estimate unavailable for this model"}
               </p>
+            )}
+
+            {turnstileSiteKey && (
+              <div
+                ref={turnstileContainerRef}
+                style={{ minHeight: "65px" }}
+              />
             )}
 
             {error && (

--- a/web/src/lib/turnstile.ts
+++ b/web/src/lib/turnstile.ts
@@ -1,10 +1,6 @@
 const TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 const TURNSTILE_VERIFY_TIMEOUT_MS = 5_000;
 
-export function isTurnstileEnabled(): boolean {
-  return !!process.env.TURNSTILE_SECRET_KEY?.trim();
-}
-
 export async function verifyTurnstileToken(
   token: string,
   remoteIp: string,
@@ -40,7 +36,7 @@ export async function verifyTurnstileToken(
     if (!resp.ok) {
       return { ok: false, error: `Turnstile verify HTTP ${resp.status}` };
     }
-    const data = (await resp.json()) as { success?: boolean; "error-codes"?: string[] };
+    const data = (await resp.json()) as { success?: boolean };
     if (data.success === true) return { ok: true };
     return { ok: false, error: "Turnstile challenge failed" };
   } catch (err) {

--- a/web/src/lib/turnstile.ts
+++ b/web/src/lib/turnstile.ts
@@ -1,0 +1,54 @@
+const TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const TURNSTILE_VERIFY_TIMEOUT_MS = 5_000;
+
+export function isTurnstileEnabled(): boolean {
+  return !!process.env.TURNSTILE_SECRET_KEY?.trim();
+}
+
+export async function verifyTurnstileToken(
+  token: string,
+  remoteIp: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const secret = process.env.TURNSTILE_SECRET_KEY?.trim();
+  if (!secret) {
+    return { ok: true };
+  }
+
+  const trimmed = (token ?? "").trim();
+  if (!trimmed) {
+    return { ok: false, error: "Missing Turnstile token" };
+  }
+  if (trimmed.length > 2048) {
+    return { ok: false, error: "Invalid Turnstile token" };
+  }
+
+  const form = new URLSearchParams();
+  form.append("secret", secret);
+  form.append("response", trimmed);
+  if (remoteIp && remoteIp !== "unknown") {
+    form.append("remoteip", remoteIp);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TURNSTILE_VERIFY_TIMEOUT_MS);
+  try {
+    const resp = await fetch(TURNSTILE_VERIFY_URL, {
+      method: "POST",
+      body: form,
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      return { ok: false, error: `Turnstile verify HTTP ${resp.status}` };
+    }
+    const data = (await resp.json()) as { success?: boolean; "error-codes"?: string[] };
+    if (data.success === true) return { ok: true };
+    return { ok: false, error: "Turnstile challenge failed" };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { ok: false, error: "Turnstile verify timed out" };
+    }
+    return { ok: false, error: "Turnstile verify request failed" };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
## Summary

- Guards `/api/presign` behind a Cloudflare Turnstile managed challenge so headless scripts can no longer drive the review pipeline without a real browser
- Renders the widget above the submit button, threads its token on the presign body, and verifies via Cloudflare siteverify before any \`reviews\` row is created
- Fails open when \`TURNSTILE_SECRET_KEY\` is unset so local dev without the secret still works; enforcement flips on automatically once two env vars are set on Vercel

## Why this is a hotfix to main

Traffic analysis this afternoon confirmed organic load, not an attack — but there is currently no CAPTCHA / human check on the submit flow, so a single motivated attacker with a funded OpenRouter key and an IP-rotating proxy pool can drive Modal to its container ceiling. This closes that gap.

## Env vars needed on Vercel (production)

- \`NEXT_PUBLIC_TURNSTILE_SITE_KEY\` — public, baked into the client bundle at build time
- \`TURNSTILE_SECRET_KEY\` — server-only, used by \`verifyTurnstileToken\`

Both already set; this PR is what actually wires the code to use them.

## Files

- \`web/src/lib/turnstile.ts\` (new) — 5-second-timeout siteverify client, fails open when secret unset
- \`web/src/app/api/presign/route.ts\` — accepts \`turnstile_token\`, verifies before any DB writes, 403 on failure
- \`web/src/app/layout.tsx\` — conditionally loads Cloudflare's \`api.js\` via \`next/script\` when the public site key is set
- \`web/src/app/page.tsx\` — explicit \`turnstile.render()\` in a useEffect (more reliable than implicit class scanner inside React's lifecycle), stores token in a ref, threads it into the presign fetch, resets after each attempt (tokens are single-use)

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx next build\` passes
- [ ] After merge, verify site key is rendered in page source at coarse.ink
- [ ] Submit a test review and confirm the widget is rendered + verified before presign proceeds
- [ ] Confirm an unverified POST to \`/api/presign\` is rejected with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)