### PR TITLE
fix(handoff): bump uvx pin to include preview 401 fixes

### DIFF
--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -98,7 +98,7 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 // on every uvx invocation (slow), and installs whatever is currently at that
 // commit (no semver guarantees). Do NOT forget to revert.
 const DEFAULT_MCP_UVX_FROM =
-  "coarse-ink[mcp] @ git+https://github.com/Davidvandijcke/coarse@913c8f186916";
+  "coarse-ink[mcp] @ git+https://github.com/Davidvandijcke/coarse@1f6603f515e3";
 
 export function resolvePinnedUvFrom(): string {
   const raw = (process.env.NEXT_PUBLIC_COARSE_UVX_FROM ?? "").trim();


### PR DESCRIPTION
## Summary

Root-cause fix for the "still getting HTTP 401 with 15-min TTL message" report — #121 and #122 landed the server-side + middleware fixes, but the CLI binary Codex actually runs was still stale because the uvx pin in `web/src/lib/mcpHandoff.ts:101` pointed at `@913c8f186916` (the "refactor(cli): extract --attach watcher" commit), which predates both PRs. So the web form was handing out a command that installed a pre-#121 CLI via uvx, and the pre-#121 CLI:

- Still had the "token may have expired (15-min TTL)" error string (hence the user still seeing it).
- Had no `x-vercel-protection-bypass` handling in `_fetch_handoff`.
- Had no 401/403/404/410 differentiation.

Bump `DEFAULT_MCP_UVX_FROM` to `@1f6603f515e3` (the #123 release-audit merge commit on dev, which includes #121, #122, #123). The pin stays a git ref rather than flipping to `coarse-ink[mcp]==1.3.0` because we're still pre-release — `tests/test_headless_instructions.py::test_release_blocker_pin_is_coupled_to_unreleased_version` enforces the coupling so the pin will auto-fail CI the moment `__version__` bumps, forcing the flip-to-semver as part of the `dev -> main` release PR.

No other files reference the old sha (verified with `rg 913c8f`).

## User next step after merge

Re-trigger the handoff from the preview web form. The command shown in the form is generated from `DEFAULT_MCP_UVX_FROM` per-submission, so a fresh submission will give a fresh command pointing at the new sha.

**Also verify**: `VERCEL_AUTOMATION_BYPASS_SECRET` is actually set in the Vercel dashboard under **Settings → Deployment Protection → Protection Bypass for Automation → Generate Secret**. #121's server-side bypass query-param append is gated on the secret existing — without it, the `cli-handoff` route warns but can't actually bypass the Vercel login wall. Watch the `/api/cli-handoff` response for a `warning` field that names this step if it's still missing.

## Test plan

- [x] `uv run pytest tests/` → **957 passed, 1 deselected**
- [x] `uv run ruff check src tests` → clean
- [x] `./node_modules/.bin/tsc --noEmit` in `web/` → clean
- [x] `make security` → clean
- [x] `python3 scripts/release_audit.py` → "OK: all references to preview-only env vars are guarded"
- [x] `tests/test_headless_instructions.py` 5/5 pass (prefix pin + RELEASE BLOCKER coupling guard both still green with the new sha)

🤖 Generated with [Claude Code](https://claude.com/claude-code)