### PR TITLE
fix(web): always show manual commands after launch-button click

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -776,22 +776,33 @@ export default function Home() {
     // Codex gets codex://new?prompt=<text> (pre-fills composer).
     // Claude Code gets claude:// (opens app, clipboard fallback).
     // Gemini CLI has no app to open — show manual commands instead.
+    //
+    // IMPORTANT: custom URL schemes fail silently when the handler
+    // isn't registered (common on Windows where Claude Code is a
+    // CLI-only install). The browser gives no UI feedback — the
+    // button just appears to do nothing. Always expand the manual
+    // commands panel after the click so users have a reliable path
+    // forward regardless of whether the protocol handler fires.
     const launchUrl = buildLaunchUrl({ host, runCmd, setupCmd, attachCmd, logFile });
+    setShowManualCommands(true);
     if (launchUrl) {
       window.location.href = launchUrl;
       if (host === "codex") {
         setLaunchStatus(
-          `Codex opened with the review command pre-filled. Just hit send.`,
+          `Codex should open with the review command pre-filled — just hit send. ` +
+            `If Codex didn't open (desktop app not installed), copy the commands below ` +
+            `into your terminal instead.`,
         );
       } else {
         setLaunchStatus(
-          `${HOST_LABELS[host]} opened. Prompt copied — paste it (⌘V) into the chat.`,
+          `${HOST_LABELS[host]} should open now — paste the prompt from your clipboard (⌘V / Ctrl+V) into the chat. ` +
+            `If the app didn't open (not installed, or no protocol handler registered on Windows), ` +
+            `copy the commands below into your terminal instead.`,
         );
       }
     } else {
-      // No app to launch (Gemini CLI) — expand manual commands.
-      setShowManualCommands(true);
-      setLaunchStatus(`Command copied to clipboard.`);
+      // No app to launch (Gemini CLI) — manual commands already shown.
+      setLaunchStatus(`Command copied to clipboard. Paste it into your terminal.`);
     }
   }
 


### PR DESCRIPTION
## Summary

Reported by a user whose Windows friend clicked the "Open Claude Code" button on the preview form and saw nothing happen.

Root cause: custom URL schemes (\`claude://\`, \`codex://\`) **fail silently** when the protocol handler isn't registered. Claude Code is primarily a CLI install on Windows and does not register \`claude://\` unless the optional desktop app is installed and has been launched at least once. The browser gives zero UI feedback on a failed custom-scheme navigation — the button just appears to do nothing.

\`page.tsx:780-794\` previously only expanded the manual-commands panel for Gemini (the one host with no launch URL at all). For Claude Code and Codex it just set a status line claiming the app opened, which was misleading on any machine where the scheme wasn't handled.

## Fix

Always call \`setShowManualCommands(true)\` before firing the launch URL, regardless of host. The status message also now explicitly tells users to fall back to the terminal commands below if the app didn't open.

Two-line change + reworded status strings. No new abstractions, no focus-detection heuristics (which are fragile across browsers) — just "always show the terminal fallback so there's a reliable path forward."

## Test plan

- [x] \`./node_modules/.bin/tsc --noEmit\` in \`web/\` → clean
- [x] \`uv run ruff check src tests\` → clean
- [x] \`make security\` → clean
- [x] \`uv run pytest tests/test_headless_instructions.py\` → **7 passed** (drift tests unchanged)
- [ ] After merging: have the Windows friend retry — clicking Open Claude Code should now immediately expose the terminal commands as a fallback path, regardless of whether the protocol handler fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)