### PR TITLE
fix(handoff): bump uvx pin to include all recent fixes (Windows --attach, ANTHROPIC_API_KEY strip, cp1252, etc.)

### DIFF
--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -109,7 +109,7 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 // python-multipart, etc.). `install-skills` is pure stdlib and works
 // without the extra.
 const DEFAULT_MCP_UVX_FROM =
-  "coarse-ink @ git+https://github.com/Davidvandijcke/coarse@1f6603f515e3";
+  "coarse-ink @ git+https://github.com/Davidvandijcke/coarse@1adc98e0e0cf";
 
 export function resolvePinnedUvFrom(): string {
   const raw = (process.env.NEXT_PUBLIC_COARSE_UVX_FROM ?? "").trim();


### PR DESCRIPTION
## Summary

**Your friend is still hitting the Windows \`--attach\` bug because the uvx pin is stale.** The pin was last bumped in #124 to \`@1f6603f515e3\` (the #123 release-audit commit), but **six subsequent PRs** landed on dev without bumping it:

- **#125** exempt-list trailing-slash bug fix
- **#126** shell-quote URL in pasted command
- **#127** callback URL bypass
- **#128** 1800s timeout + \`/review/\` exempt + clickable view URL + **strip \`ANTHROPIC_API_KEY\` from subprocess env**
- **#129** launch-button manual-commands fallback
- **#130** drop \`[mcp]\` extra + Windows \`--attach\` fix + Windows cp1252 encoding fix

Your friend installed the CLI from \`@1f6603f\` via uvx, which is **pre-#125**. So they got none of those fixes: \`--attach\` still crashed, billing still routed to \`ANTHROPIC_API_KEY\`, and Windows Unicode paper content still hit cp1252.

## Fix

One-character edit: bump \`DEFAULT_MCP_UVX_FROM\` in \`web/src/lib/mcpHandoff.ts:112\` from \`@1f6603f515e3\` to \`@1adc98e0e0cf\` (the #130 merge commit on dev, which includes everything from tonight's chain). After this merges and Vercel rebuilds the preview, the next submission from the form will hand out a fresh command with the new sha.

## Process gap to address separately

The sha bump is easy to forget because most PRs don't need it — there's no forcing function. This is the **second time** tonight (first was after #121/#122, I only noticed when you reported the stale \`15-min TTL\` message). Options for later:

1. **CI check**: fail the PR if it touches \`src/coarse/cli_review.py\`, \`cli_attach.py\`, \`headless_clients.py\`, or \`headless_review.py\` without also bumping \`DEFAULT_MCP_UVX_FROM\`. Caught only at merge time but unambiguous.
2. **Rolling tag**: switch to \`@latest-dev\` or a branch ref that auto-follows the dev head. No manual bump needed, but re-clones on every uvx invocation and means every pre-release user always sees the latest HEAD (no stability).

Leaving as-is for now — happy to ship option 1 as a follow-up if you want. For now, the fix is: bump the pin, merge, done.

## Test plan

- [x] \`uv run pytest tests/test_headless_instructions.py\` → **7 passed** (prefix drift tests unchanged; they don't pin the specific sha)
- [x] \`uv run ruff check src tests\` → clean
- [x] \`make security\` → clean
- [ ] After merging: wait ~60s for Vercel rebuild, then have the friend re-submit from the preview form and run the fresh command. Expected: \`--attach\` blocks normally on Windows, no Unicode crash, billed to Claude Code subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)