### PR TITLE
fix(extraction): recover from empty tex extraction and stale caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Blank Docling `.tex` extraction now falls back to the LaTeX regex backend instead of propagating an empty document into the review pipeline.** `extract_file()` used to accept Docling output for non-PDF formats even when it was only whitespace, which let `.tex` reviews reach the extraction quality gate with `full_markdown=""` and fail later with a misleading "no sections found" error. The non-PDF Docling path now treats empty/whitespace output as unusable and immediately falls back to the existing extension-specific extractor, restoring the intended LaTeX source review flow. Regression coverage added in `tests/test_extraction.py`.
+
 ## v1.3.0 — 2026-04-15
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **Blank Docling `.tex` extraction now falls back to the LaTeX regex backend instead of propagating an empty document into the review pipeline.** `extract_file()` used to accept Docling output for non-PDF formats even when it was only whitespace, which let `.tex` reviews reach the extraction quality gate with `full_markdown=""` and fail later with a misleading "no sections found" error. The non-PDF Docling path now treats empty/whitespace output as unusable and immediately falls back to the existing extension-specific extractor, restoring the intended LaTeX source review flow. Regression coverage added in `tests/test_extraction.py`.
+- **Blank Docling `.tex` extraction now falls back to the LaTeX regex backend instead of propagating an empty document into the review pipeline.** `extract_file()` used to accept Docling output for non-PDF formats even when it was only whitespace, which let `.tex` reviews reach the extraction quality gate with `full_markdown=""` and fail later with a misleading "no sections found" error. The non-PDF Docling path now treats empty/whitespace output as unusable and immediately falls back to the existing extension-specific extractor, and the cache loader now ignores previously saved empty extraction payloads so stale pre-fix `.extraction_cache.json` files do not keep reproducing the bug. Regression coverage added in `tests/test_extraction.py` and `tests/test_extraction_cache.py`.
 
 ## v1.3.0 — 2026-04-15
 

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -229,6 +229,11 @@ def _estimate_tokens(text: str) -> int:
     return len(text) // 4
 
 
+def _has_meaningful_markdown(text: str) -> bool:
+    """Return True when extracted markdown contains non-whitespace content."""
+    return bool(text.strip())
+
+
 _DOCLING_FORMATS = frozenset({".docx", ".html", ".htm", ".tex", ".latex"})
 _FALLBACKS = {
     ".docx": _extract_docx_mammoth,
@@ -269,9 +274,11 @@ def extract_file(file_path: str | Path, use_cache: bool = True) -> PaperText:
     if ext in _DOCLING_FORMATS:
         try:
             full_markdown = _extract_docling(path)
+            if not _has_meaningful_markdown(full_markdown):
+                raise ExtractionError("Docling returned empty content")
             logger.info("Extracted %s via Docling (%d chars)", ext, len(full_markdown))
         except Exception as exc:
-            logger.info("Docling unavailable for %s: %s, using fallback", ext, exc)
+            logger.info("Docling unusable for %s: %s, using fallback", ext, exc)
             full_markdown = _FALLBACKS[ext](path)
     elif ext == ".epub":
         full_markdown = _extract_epub(path)

--- a/src/coarse/extraction_cache.py
+++ b/src/coarse/extraction_cache.py
@@ -28,6 +28,9 @@ def _load_cache(pdf_path: Path) -> PaperText | None:
     try:
         data = json.loads(cache.read_text(encoding="utf-8"))
         paper_text = PaperText.model_validate(data)
+        if not paper_text.full_markdown.strip():
+            logger.warning("Cache empty, re-extracting")
+            return None
         logger.info("Loaded extraction cache from %s", cache.name)
         return paper_text
     except Exception:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -237,6 +237,29 @@ def test_all_backends_fail(minimal_pdf: Path) -> None:
                 extract_text(minimal_pdf, use_cache=False)
 
 
+def test_extract_file_latex_falls_back_when_docling_returns_empty(tmp_path: Path) -> None:
+    """Blank Docling output for LaTeX should trigger the regex fallback.
+
+    Regression guard for the .tex path where Docling can return an empty
+    string without raising, which used to propagate blank markdown all the
+    way to the extraction quality gate.
+    """
+    tex = tmp_path / "paper.tex"
+    tex.write_text("\\section{Intro}\nBody text.\n", encoding="utf-8")
+
+    fallback = MagicMock(return_value="# Intro\n\nBody text.\n")
+
+    with (
+        patch("coarse.extraction._extract_docling", return_value="  \n\t"),
+        patch.dict("coarse.extraction._FALLBACKS", {".tex": fallback}, clear=False),
+    ):
+        result = extract_file(tex, use_cache=False)
+
+    fallback.assert_called_once_with(tex)
+    assert result.full_markdown == "# Intro\n\nBody text.\n"
+    assert result.token_estimate == len(result.full_markdown) // 4
+
+
 # --- OpenRouter OCR error handling and retry ---
 
 

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -41,6 +41,17 @@ def test_load_cache_returns_none_for_corrupt_json(tmp_path: Path) -> None:
     assert _load_cache(source) is None
 
 
+def test_load_cache_returns_none_for_empty_markdown(tmp_path: Path) -> None:
+    source = tmp_path / "paper.txt"
+    source.write_text("hello")
+    source.with_suffix(".extraction_cache.json").write_text(
+        '{"full_markdown":"","token_estimate":0,"garble_ratio":0.0}',
+        encoding="utf-8",
+    )
+
+    assert _load_cache(source) is None
+
+
 def test_save_cache_skips_symlink_path(tmp_path: Path) -> None:
     source = tmp_path / "paper.txt"
     source.write_text("hello")


### PR DESCRIPTION
Hi David — thanks for maintaining coarse. I'll probably try to contribute from time to time, so I wanted to start with this small extraction/cache fix.

## Summary
- treat empty or whitespace Docling output for non-PDF files as extraction failure and fall back to the format-specific extractor
- ignore stale empty `.extraction_cache.json` payloads so pre-fix caches do not keep reproducing the bug
- add regression coverage for both the `.tex` fallback path and empty-cache invalidation
- update `CHANGELOG.md` under `## Unreleased`

## Testing
- `python3 scripts/security_scanner.py`
- `bash scripts/doc-sync-check.sh`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -v`