### PR TITLE
feat(cli): include model in default review filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Blank Docling `.tex` extraction now falls back to the LaTeX regex backend instead of propagating an empty document into the review pipeline.** `extract_file()` used to accept Docling output for non-PDF formats even when it was only whitespace, which let `.tex` reviews reach the extraction quality gate with `full_markdown=""` and fail later with a misleading "no sections found" error. The non-PDF Docling path now treats empty/whitespace output as unusable and immediately falls back to the existing extension-specific extractor, and the cache loader now ignores previously saved empty extraction payloads so stale pre-fix `.extraction_cache.json` files do not keep reproducing the bug. Regression coverage added in `tests/test_extraction.py` and `tests/test_extraction_cache.py`.
+
+### Changed
+
+- **Default review filenames now include the review model ID.** Auto-generated output paths from both `coarse review` and `coarse-review` now use the pattern `<paper_stem>_review_<model>.md` instead of `<paper_stem>_review.md`, making repeated runs against the same paper easier to distinguish when comparing different models. Explicit user-provided output paths are unchanged. Regression coverage added in `tests/test_cli.py`, `tests/test_cli_review.py`, and `tests/test_models.py`.
 ## v1.3.0 — 2026-04-15
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ paper.pdf (or .txt, .md, .tex, .docx, .html, .epub)
   -> crossref agent       Legacy fallback if editorial fails
   -> critique agent      Legacy fallback if editorial fails
   -> quote_verify.py      Programmatic fuzzy-match quotes against text
-  -> synthesis.py        Deterministic render -> paper_review.md
+  -> synthesis.py        Deterministic render -> paper_review_<model>.md
 ```
 
 ## Development rules

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Get an API key from [OpenRouter](https://openrouter.ai/keys) (free to sign up), 
 uvx coarse-ink review paper.pdf --api-key sk-or-v1-YOUR_KEY
 ```
 
-That's it. The review is written to `paper_review.md` in the current directory.
+That's it. The review is written to `paper_review_<model>.md` in the current directory.
 
 ### Prerequisites
 
@@ -81,7 +81,7 @@ paper.pdf (or .txt, .md, .tex, .docx, .html, .epub)
   -> Editorial filter                     Primary deduplication, contradiction, and quality pass
   -> Legacy crossref/critique fallback    Only used if the editorial pass fails
   -> Quote verification                   Fuzzy-match quotes against paper text (stricter for math)
-  -> Synthesis                            Render final paper_review.md
+  -> Synthesis                            Render final paper_review_<model>.md
 ```
 
 The pipeline extracts text, classifies the paper's domain and structure, then generates

--- a/src/coarse/cli.py
+++ b/src/coarse/cli.py
@@ -22,7 +22,7 @@ from coarse.config import (
     save_config,
 )
 from coarse.extraction import SUPPORTED_EXTENSIONS
-from coarse.models import CHEAP_MODELS, QUALITY_MODEL
+from coarse.models import CHEAP_MODELS, QUALITY_MODEL, model_filename_slug
 from coarse.pipeline import review_paper
 
 app = typer.Typer(
@@ -113,7 +113,10 @@ def review(
         help="Path to paper file (PDF, TXT, MD, TeX, DOCX, HTML, EPUB)",
     ),
     output: Optional[Path] = typer.Option(
-        None, "--output", "-o", help="Output file path (default: <pdf_stem>_review.md)"
+        None,
+        "--output",
+        "-o",
+        help="Output file path (default: <pdf_stem>_review_<model>.md)",
     ),
     model: Optional[str] = typer.Option(
         None, "--model", "-m", help="LiteLLM model string (e.g. openai/gpt-4o)"
@@ -195,7 +198,7 @@ def review(
         )
 
     # Determine output path
-    out_path = output or Path(f"{pdf.stem}_review.md")
+    out_path = output or Path(f"{pdf.stem}_review_{model_filename_slug(resolved_model)}.md")
 
     console.print(f"[bold]Reviewing[/bold] {pdf.name} with {resolved_model}")
 

--- a/src/coarse/cli_review.py
+++ b/src/coarse/cli_review.py
@@ -40,7 +40,7 @@ from coarse.cli_attach import (
     write_pidfile,
 )
 from coarse.extraction import SUPPORTED_EXTENSIONS
-from coarse.models import HEADLESS_DEFAULT_MODELS
+from coarse.models import HEADLESS_DEFAULT_MODELS, model_filename_slug
 
 _DETACHED_ENV = "COARSE_REVIEW_DETACHED"
 # Informational only: must match FINALIZE_TOKEN_TTL_MINUTES in
@@ -722,7 +722,7 @@ def main(argv: list[str] | None = None) -> int:
         # `cp1252` encoding crashes on those. `PYTHONUTF8=1` in the
         # detached child also covers this, but the explicit encoding
         # makes the non-detached path safe too.
-        review_md_path = out_dir / f"{paper_path.stem}_review.md"
+        review_md_path = out_dir / f"{paper_path.stem}_review_{model_filename_slug(model)}.md"
         review_md_path.write_text(md_text, encoding="utf-8")
         logger.info("Wrote %d-char review to %s", len(md_text), review_md_path)
 

--- a/src/coarse/headless_review.py
+++ b/src/coarse/headless_review.py
@@ -8,7 +8,7 @@ Usage:
 - ``<paper_path>``: PDF, MD, TeX, DOCX, HTML, or EPUB.
 - ``<pre_extracted_md>``: optional pre-extracted markdown — skips OCR,
   saves ~$0.05-0.15 and ~30 seconds.
-- ``<output_dir>``: where to write ``<stem>_review.md``. Default:
+- ``<output_dir>``: where to write ``<stem>_review_<model>.md``. Default:
   ``./coarse-output/``.
 
 Environment:
@@ -29,7 +29,7 @@ import os
 import sys
 from pathlib import Path
 
-from coarse.models import HEADLESS_DEFAULT_MODELS
+from coarse.models import HEADLESS_DEFAULT_MODELS, model_filename_slug
 
 
 def _find_openrouter_key() -> str | None:
@@ -306,7 +306,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 4
 
-    out_path = out_dir / f"{paper_path.stem}_review.md"
+    resolved_model = args.model or HEADLESS_DEFAULT_MODELS[args.host]
+    out_path = out_dir / f"{paper_path.stem}_review_{model_filename_slug(resolved_model)}.md"
     out_path.write_text(markdown, encoding="utf-8")
     logger.info("Wrote %d-char review to %s", len(markdown), out_path)
 

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -7,6 +7,8 @@ this module. Verify IDs against OpenRouter before changing:
 Last verified: 2026-03-04
 """
 
+import re
+
 # Primary review model (routed via OpenRouter for non-direct providers)
 DEFAULT_MODEL = "qwen/qwen3.5-plus-02-15"
 
@@ -140,6 +142,8 @@ REASONING_MAX_TOKENS_MULTIPLIER: int = 8
 # reasoning_effort explicitly in kwargs.
 REASONING_EFFORT_DEFAULT: str = "medium"
 
+_MODEL_FILENAME_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
 
 def is_reasoning_model(model_id: str) -> bool:
     """Return True if the model uses hidden reasoning tokens that count
@@ -154,3 +158,10 @@ def is_reasoning_model(model_id: str) -> bool:
         if lower.startswith(prefix):
             return True
     return any(substring in lower for substring in REASONING_MODEL_SUBSTRINGS)
+
+
+def model_filename_slug(model_id: str) -> str:
+    """Return a filesystem-friendly slug for a model identifier."""
+    slug = _MODEL_FILENAME_SLUG_RE.sub("_", model_id.strip())
+    slug = slug.strip("._")
+    return slug or "model"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,8 +50,9 @@ def _fake_review_paper(pdf_path, model=None, skip_cost_gate=False, config=None):
 # ---------------------------------------------------------------------------
 
 
-def test_review_command_invokes_pipeline(tmp_path):
+def test_review_command_invokes_pipeline(tmp_path, monkeypatch):
     """review command calls pipeline.review_paper and writes output file."""
+    monkeypatch.chdir(tmp_path)
     pdf = tmp_path / "paper.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
 
@@ -71,7 +72,7 @@ def test_review_command_invokes_pipeline(tmp_path):
 
 
 def test_review_command_default_output_path(tmp_path, monkeypatch):
-    """Output file defaults to <pdf_stem>_review.md in cwd."""
+    """Output file defaults to <pdf_stem>_review_<model>.md in cwd."""
     monkeypatch.chdir(tmp_path)
     pdf = tmp_path / "myresearch.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
@@ -84,7 +85,7 @@ def test_review_command_default_output_path(tmp_path, monkeypatch):
         result = runner.invoke(app, ["review", str(pdf), "--yes"])
 
     assert result.exit_code == 0, result.output
-    expected = tmp_path / "myresearch_review.md"
+    expected = tmp_path / "myresearch_review_qwen_qwen3.5-plus-02-15.md"
     assert expected.exists()
 
 
@@ -116,13 +117,35 @@ def test_review_command_custom_output_path(tmp_path):
     assert out.read_text() == "# Custom Output\n"
 
 
+def test_review_command_default_output_path_uses_explicit_model_slug(tmp_path, monkeypatch):
+    """Explicit --model should flow into the default output filename."""
+    monkeypatch.chdir(tmp_path)
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    with (
+        patch("coarse.cli.resolve_api_key", return_value="sk-test"),
+        patch("coarse.cli.load_config", return_value=CoarseConfig()),
+        patch("coarse.cli.review_paper", _fake_review_paper),
+    ):
+        result = runner.invoke(
+            app,
+            ["review", str(pdf), "--model", "anthropic/claude-sonnet-4-6", "--yes"],
+        )
+
+    assert result.exit_code == 0, result.output
+    expected = tmp_path / "paper_review_anthropic_claude-sonnet-4-6.md"
+    assert expected.exists()
+
+
 # ---------------------------------------------------------------------------
 # test_review_yes_flag_skips_cost_gate
 # ---------------------------------------------------------------------------
 
 
-def test_review_yes_flag_skips_cost_gate(tmp_path):
+def test_review_yes_flag_skips_cost_gate(tmp_path, monkeypatch):
     """--yes passes skip_cost_gate=True to review_paper."""
+    monkeypatch.chdir(tmp_path)
     pdf = tmp_path / "paper.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
 
@@ -271,8 +294,9 @@ def test_review_nonexistent_pdf():
     assert result.exit_code != 0
 
 
-def test_review_interactive_path_does_not_enter_status(tmp_path):
+def test_review_interactive_path_does_not_enter_status(tmp_path, monkeypatch):
     """Interactive runs leave the cost prompt unobscured by Rich Status."""
+    monkeypatch.chdir(tmp_path)
     pdf = tmp_path / "paper.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
 
@@ -301,8 +325,9 @@ def test_review_interactive_path_does_not_enter_status(tmp_path):
     assert entered == []
 
 
-def test_review_yes_path_enters_status(tmp_path):
+def test_review_yes_path_enters_status(tmp_path, monkeypatch):
     """Non-interactive --yes runs keep the Rich status spinner."""
+    monkeypatch.chdir(tmp_path)
     pdf = tmp_path / "paper.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
 
@@ -336,10 +361,11 @@ def test_review_yes_path_enters_status(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_review_eval_flag_saves_quality_report(tmp_path):
+def test_review_eval_flag_saves_quality_report(tmp_path, monkeypatch):
     """--eval runs quality evaluation and writes a quality report file."""
     from coarse.quality import DimensionScore, QualityReport
 
+    monkeypatch.chdir(tmp_path)
     pdf = tmp_path / "paper.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
     ref = tmp_path / "reference.md"

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -244,7 +244,7 @@ def test_main_handoff_supports_markdown_source(tmp_path) -> None:
         "effort": "high",
         "pre_extracted": None,
     }
-    assert (out_dir / "paper_review.md").read_text(encoding="utf-8") == "# Review\n"
+    assert (out_dir / "paper_review_gpt-5.4.md").read_text(encoding="utf-8") == "# Review\n"
 
 
 def test_main_handoff_success_prints_absolute_local_and_view_lines(tmp_path, capsys) -> None:
@@ -292,7 +292,7 @@ def test_main_handoff_success_prints_absolute_local_and_view_lines(tmp_path, cap
     stdout = capsys.readouterr().out
     assert "PUBLISHED TO COARSE WEB" in stdout
     assert "  view:     https://example.test/review/123" in stdout
-    assert f"  local:    {(out_dir / 'paper_review.md').resolve()}" in stdout
+    assert f"  local:    {(out_dir / 'paper_review_gpt-5.4.md').resolve()}" in stdout
     assert "REVIEW COMPLETE" in stdout
 
 
@@ -341,7 +341,7 @@ def test_main_handoff_callback_failure_still_prints_local_footer(tmp_path, capsy
     stdout = capsys.readouterr().out
     assert "WEB CALLBACK FAILED" in stdout
     assert "  view:     unavailable" in stdout
-    assert f"  local:    {(out_dir / 'paper_review.md').resolve()}" in stdout
+    assert f"  local:    {(out_dir / 'paper_review_gpt-5.4.md').resolve()}" in stdout
     assert "REVIEW COMPLETE" in stdout
 
 
@@ -371,7 +371,7 @@ def test_main_local_mode_prints_absolute_local_footer(tmp_path, capsys) -> None:
     assert rc == 0
     stdout = capsys.readouterr().out
     assert "REVIEW COMPLETE" in stdout
-    assert f"  local:    {(out_dir / 'paper_review.md').resolve()}" in stdout
+    assert f"  local:    {(out_dir / 'paper_review_gpt-5.4.md').resolve()}" in stdout
 
 
 def test_main_loads_openrouter_key_from_headless_helper(tmp_path, monkeypatch) -> None:

--- a/tests/test_headless_review.py
+++ b/tests/test_headless_review.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from coarse.headless_review import _find_openrouter_key, _make_client_factory
+from coarse.headless_review import _find_openrouter_key, _make_client_factory, main
+from coarse.models import HEADLESS_DEFAULT_MODELS, model_filename_slug
 
 
 def test_find_openrouter_key_reads_api_keys_config(tmp_path, monkeypatch) -> None:
@@ -50,3 +52,26 @@ def test_client_factory_accepts_pipeline_style_kwargs() -> None:
             factory("overview", "ignored-positional", extra=1)
 
             assert fake_client.call_count == 3
+
+
+def test_main_writes_review_filename_with_default_model_slug(tmp_path, capsys) -> None:
+    paper = tmp_path / "paper.pdf"
+    paper.write_bytes(b"%PDF-1.4 fake")
+    out_dir = tmp_path / "out"
+
+    review = SimpleNamespace(detailed_comments=[])
+
+    expected = out_dir / f"paper_review_{model_filename_slug(HEADLESS_DEFAULT_MODELS['codex'])}.md"
+
+    with (
+        patch("coarse.headless_review._require_openrouter_key"),
+        patch(
+            "coarse.headless_review.run_headless_review",
+            return_value=(review, "# Review\n", object()),
+        ),
+    ):
+        rc = main(["--host", "codex", str(paper), ".", str(out_dir)])
+
+    assert rc == 0
+    assert expected.read_text(encoding="utf-8") == "# Review\n"
+    assert str(expected) in capsys.readouterr().out

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ from coarse.models import (
     REASONING_MODEL_SUBSTRINGS,
     VISION_MODEL,
     is_reasoning_model,
+    model_filename_slug,
 )
 
 
@@ -159,3 +160,14 @@ def test_reasoning_max_tokens_multiplier_sensible():
 
 def test_reasoning_effort_default_is_recognized_value():
     assert REASONING_EFFORT_DEFAULT in {"low", "medium", "high"}
+
+
+def test_model_filename_slug_preserves_common_model_id_characters():
+    assert model_filename_slug("anthropic/claude-sonnet-4-6") == "anthropic_claude-sonnet-4-6"
+    assert model_filename_slug("gpt-5.4") == "gpt-5.4"
+
+
+def test_model_filename_slug_normalizes_separators_and_whitespace():
+    assert model_filename_slug("  qwen/qwen-plus-2025-07-28:thinking  ") == (
+        "qwen_qwen-plus-2025-07-28_thinking"
+    )


### PR DESCRIPTION
Hi David,

I'll probably try to contribute from time to time, and here's a small CLI quality-of-life improvement.

## Summary
- include the review model ID in the default output filename for `coarse review`
- align `coarse-review` and the headless helper with the same `<paper_stem>_review_<model>.md` naming pattern
- add a reusable model-to-filename slug helper plus regression coverage for CLI, headless, and docs updates
- update `README.md`, `CONTRIBUTING.md`, and `CHANGELOG.md` to reflect the new default filenames

## Testing
- `python3 scripts/security_scanner.py`
- `bash scripts/doc-sync-check.sh`
- `./.venv/bin/ruff check src/ tests/`
- `env HOME=/tmp/coarse-test-home PATH=/Users/federico/.local/bin:/opt/homebrew/bin:/usr/bin:/bin ./.venv/bin/python -m pytest tests/ -v`
