### PR TITLE
hotfix(web): eliminate review_secrets race on Modal webhook timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Web submit route: race condition between Modal webhook timeout and worker spawn caused ~21% of Modal-backed reviews to fail with `OPENROUTER_API_KEY=MISSING` after ~5 min of Docling OCR.** Modal's `run_review` webhook calls `do_review.spawn()` *before* sending the HTTP response, so a cold-start tail of 9–10s on the previous 10s Vercel `AbortController` caused the submit route's catch block to fire *after* the worker had already been queued. That catch block then deleted the just-inserted `review_secrets` row and called `markFailed()`, so the worker started with no `OPENROUTER_API_KEY` and every LLM call failed with a provider-specific auth error (`litellm.AuthenticationError: DeepseekException`, `Missing Anthropic API Key`, `BadRequestError: LLM Provider NOT provided`, etc.). Forensics from the last 24h of `modal app logs coarse-review`: 100 `do_review` invocations vs 74 logged `POST / -> 200 OK` responses (26 aborted-before-response); 21 `OPENROUTER_API_KEY=MISSING` entries; 9 of 14 affected users *also* had successful reviews (ruling out "never provided a key"). Fix in `web/src/app/api/submit/route.ts`: bump `MODAL_TRIGGER_TIMEOUT_MS` from 10s → 25s (2.5× the observed 9.78s cold-start tail, still 5s below the `maxDuration=30` ceiling); in the `catch` block, stop deleting `review_secrets` and stop calling `markFailed` — the worker unconditionally sets `status=running` on start, and genuinely orphaned rows are swept by the hourly `cleanup_review_secrets` cron + the 15-minute `sweep_stale_reviews` cron. The `!workerResp.ok` branch (Modal returned an explicit 4xx/5xx, so the spawn definitely did not happen) still cleans up. The route now returns 202 with `{id, accessToken, warning}` on timeout so the client's `submitResp.ok` check still passes and it redirects to the status page — which the user would reach anyway as the worker catches up.
+
 ## v1.3.0 — 2026-04-15
 
 ### Security

--- a/web/src/app/api/submit/route.ts
+++ b/web/src/app/api/submit/route.ts
@@ -21,7 +21,15 @@ import { getSubmissionPauseResponse } from "@/lib/systemStatus";
 import { getSiteOriginForRequest } from "@/lib/siteOrigin";
 
 export const maxDuration = 30;
-const MODAL_TRIGGER_TIMEOUT_MS = 10_000;
+// Budget below the 30s Vercel function ceiling. A slow Modal cold start of
+// `run_review` was routinely hitting 9-10s on the previous 10s cap, racing
+// the AbortController against a do_review.spawn() that had already fired
+// server-side — the catch block below would then delete review_secrets and
+// mark the review failed while the worker kept running with no key. 25s
+// gives ~2.5x margin over the observed 9.78s cold-start tail and leaves
+// ~5s for the Supabase inserts, optional confirmation email, and response
+// serialization before Vercel kills the function at maxDuration.
+const MODAL_TRIGGER_TIMEOUT_MS = 25_000;
 const MODAL_WEBHOOK_HOST_SUFFIXES = [
   buildModalWebhookHostSuffix("coarse-review", "run-review"),
 ];
@@ -332,14 +340,44 @@ export async function POST(request: NextRequest) {
       );
     }
   } catch (err) {
-    await supabaseAdmin.from("review_secrets").delete().eq("review_id", id);
+    // DO NOT delete review_secrets or markFailed here. Modal's run_review
+    // calls do_review.spawn() BEFORE returning its HTTP response, so on an
+    // AbortError (we timed out waiting) or a network error the spawn may
+    // have already registered the worker. Cleaning up review_secrets on
+    // that path is what caused the "OPENROUTER_API_KEY=MISSING" production
+    // bug — the worker would then start with the key gone and fail every
+    // LLM call. The worker unconditionally sets status=running on start
+    // (deploy/modal_worker.py ~line 591), so any markFailed here is
+    // transient noise that the worker would overwrite anyway.
+    //
+    // If the spawn genuinely did not happen (Modal is down or the network
+    // dropped before the request landed), the row is orphaned. That case
+    // is handled by two existing crons:
+    //   - cleanup_review_secrets.yml (hourly, TTL 3h) sweeps stale secrets
+    //   - sweep_stale_reviews.yml (every 15 min) marks queued/running rows
+    //     older than 3h as failed with a user-friendly message.
+    //
+    // The !workerResp.ok branch above still cleans up — that path is an
+    // explicit Modal 4xx/5xx, which means the spawn did NOT execute.
+    //
+    // Return 202 with {id, accessToken} so the client's submitResp.ok
+    // check passes and it redirects to /status/<id>. The status page
+    // polls and shows queued → running → done as the worker catches up.
     const isAbort = err instanceof Error && err.name === "AbortError";
-    const message = isAbort
-      ? "Review worker did not respond in time"
-      : "Failed to start review worker";
-    await markFailed(message);
-    console.error(`[${id}] worker dispatch failed`, err);
-    return NextResponse.json({ error: message }, { status: 503 });
+    console.error(
+      `[${id}] webhook dispatch uncertain (${isAbort ? "timeout" : "network"}) — ` +
+        `letting worker proceed; cleanup_review_secrets will sweep if spawn never fired`,
+      err,
+    );
+    return NextResponse.json(
+      {
+        id,
+        accessToken,
+        warning:
+          "Review submitted. The worker is still starting — the status page will update in a moment.",
+      },
+      { status: 202 },
+    );
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
## Summary

Fixes a production race condition that caused ~21% of Modal-backed reviews to fail with `OPENROUTER_API_KEY=MISSING` after ~5 min of Docling OCR fallback. Web-only change in `web/src/app/api/submit/route.ts`.

## Why this targets \`main\` directly (not \`dev\`)

User-facing production bug; fix is web-only (no Modal image rebuild, no PyPI cut); \`main\` and \`dev\` are currently at the same commit (\`bf29053\`) so the follow-up FF-merge back to \`dev\` is trivial. The broken behavior is live now.

## Root cause

Modal's \`run_review\` webhook endpoint calls \`do_review.spawn()\` **before** returning its HTTP response. On cold starts >10 s, Vercel's \`AbortController\` fired on the submit route's \`fetch\` and the catch block:
1. **deleted** the just-inserted \`review_secrets\` row
2. **called \`markFailed()\`** to set the review failed
3. returned 503

But the spawn had already registered the worker on Modal's side. The worker started ~20 s later, read \`review_secrets\`, found the row gone, logged \`OPENROUTER_API_KEY=MISSING (len=0)\`, and every LLM call failed with a provider-specific auth error depending on the model prefix (\`DeepseekException\`, \`Missing Anthropic API Key\`, \`BadRequestError: LLM Provider NOT provided\`, \`OpenAIException\`).

## Forensics (last 24 h on production Modal)

- **100** \`do_review\` invocations (\`OPENROUTER_API_KEY=\` log lines)
- **74** logged \`POST / -> 200 OK\` webhook responses → **26 webhook calls aborted before their response was logged**
- **21** reviews with \`OPENROUTER_API_KEY=MISSING (len=0)\`
- **9 of 14** affected users ALSO had successful reviews in the same window → rules out "never provided a key"
- Observed worst-case \`run_review\` cold start: **9.78 s** on a 10 s Vercel timeout; the distribution had 7 calls in the 9.0–9.8 s band

## What the fix does

1. **\`MODAL_TRIGGER_TIMEOUT_MS\`: 10 s → 25 s** (2.5× the observed cold-start tail, still 5 s below the \`maxDuration = 30\` ceiling so the Supabase inserts, best-effort Resend email, and response serialization all fit)
2. **\`catch\` block no longer deletes \`review_secrets\` or calls \`markFailed\`** — lets the worker consume the key if the spawn went through. The worker unconditionally sets \`status=running\` on start (\`deploy/modal_worker.py\` ~line 591), so any \`markFailed\` we did was transient noise. Truly orphaned rows are swept by the hourly \`cleanup_review_secrets\` cron + the 15-minute \`sweep_stale_reviews\` cron at 3 h.
3. **Return 202 with \`{id, accessToken, warning}\`** instead of 503. The client's \`submitResp.ok\` check (verified in \`web/src/app/page.tsx\`) treats 202 identically to 200 and redirects to \`/status/<id>\`. The status page polls every 3 s and renders queued → running → done as the worker catches up.

The \`!workerResp.ok\` branch above stays **unchanged** — that path is an explicit Modal 4xx/5xx, meaning the spawn definitely did NOT execute, so the cleanup is correct.

## Test plan

- [x] \`cd web && npx tsc --noEmit\` — exit 0
- [x] \`uv run pytest tests/\` — 938 passed (no Python code changed; guardrail)
- [x] \`python3 scripts/security_scanner.py\` — clean (via pre-commit hook)
- [x] Grep sanity: \`review_secrets.*delete\` + \`markFailed\` only appear in the three correct code paths (email-insert failure, secrets-insert failure, \`!modalWebhookConfig\`, \`!workerResp.ok\`) and the catch-block explanatory comment
- [ ] Post-merge: watch \`modal app logs coarse-review -f\` for the next hour; confirm \`OPENROUTER_API_KEY=MISSING\` count drops to 0 for new submissions
- [ ] Post-merge: FF-merge \`main\` → \`dev\` so both branches line up

## Rollback

\`git revert <merge-sha> -m 1 && git push origin main\` → Vercel redeploys the previous version in 2–4 min. Review rows submitted during the broken window self-heal via the 3 h TTL sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)