### PR TITLE
fix(readme): switch downloads badge from pypistats to pepy (rate-limit fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Davidvandijcke/coarse/actions/workflows/ci.yml/badge.svg)](https://github.com/Davidvandijcke/coarse/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/coarse-ink)](https://pypi.org/project/coarse-ink/)
-[![Downloads](https://img.shields.io/pypi/dm/coarse-ink)](https://pypi.org/project/coarse-ink/)
+[![Downloads](https://img.shields.io/pepy/dt/coarse-ink)](https://pepy.tech/project/coarse-ink)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/github/license/Davidvandijcke/coarse)](LICENSE)
 


### PR DESCRIPTION
## Summary

The GitHub repo page intermittently shows "rate limited by upstream service" on the Downloads badge. Root cause: \`img.shields.io/pypi/dm/*\` pulls monthly download counts from pypistats.org, which has strict per-proxy rate limits that shields.io trips constantly.

## Fix

Swap \`img.shields.io/pypi/dm/coarse-ink\` → \`img.shields.io/pepy/dt/coarse-ink\`. pepy.tech has far saner rate limits for shields.io's proxy. shields.io's \`/pepy/dm\` and \`/pepy/dw\` endpoints return 404, so the total-downloads (\`dt\`) variant is the only working pepy option.

Also repoints the link from \`pypi.org/project/coarse-ink\` to \`pepy.tech/project/coarse-ink\`, which shows the download-trend chart most people want when they click a downloads badge.

Changes: 1 line in \`README.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)