### PR TITLE
fix(readme): revert downloads badge to pypi/dm (pepy includes mirror inflation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Davidvandijcke/coarse/actions/workflows/ci.yml/badge.svg)](https://github.com/Davidvandijcke/coarse/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/coarse-ink)](https://pypi.org/project/coarse-ink/)
-[![Downloads](https://img.shields.io/pepy/dt/coarse-ink)](https://pepy.tech/project/coarse-ink)
+[![Downloads](https://img.shields.io/pypi/dm/coarse-ink)](https://pypistats.org/packages/coarse-ink)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/github/license/Davidvandijcke/coarse)](LICENSE)
 


### PR DESCRIPTION
## Summary

Undo the pepy/dt swap from #145. The pepy \`dt\` endpoint counts exactly the same thing as pypistats \`with_mirrors\` — verified 2,544 vs 2,544 for coarse-ink on 2026-04-16 — which includes bandersnatch and other PyPI mirror replication traffic. Real \`without_mirrors\` installs are 947/month; the pepy badge was inflating that by **2.7×**.

## Data

| Source | Count | Includes mirrors? |
|---|---:|---|
| \`shields.io/pepy/dt/coarse-ink\` | 2,544 | Yes |
| \`pypistats.org with_mirrors\` | 2,544 | Yes |
| \`shields.io/pypi/dm/coarse-ink\` | 947 | **No (correct)** |
| \`pypistats.org without_mirrors\` | 947 | **No (correct)** |

## Change

\`README.md\`: \`img.shields.io/pepy/dt/coarse-ink\` → \`img.shields.io/pypi/dm/coarse-ink\`, link to \`pypistats.org/packages/coarse-ink\`.

## Tradeoff acknowledged

\`pypi/dm\` is the source of the original "rate limited by upstream service" error. It's intermittent — only when shields.io's 24h badge cache expires at the same moment pypistats is throttling. For a package with coarse-ink's traffic volume that's a rare event. If it becomes chronic later, the follow-up is a shields.io \`/endpoint\` JSON served by a Vercel function that proxies pypistats with 6h caching (fully controlled upstream).

## On v1.3.0 not showing on the chart

pepy.tech pulls from Google BigQuery's public PyPI dataset with a 1–2 day lag. v1.3.0 shipped 2026-04-15, so it would have landed on pepy's chart today/tomorrow. pypistats has a shorter lag (same-day data available), so this revert also fixes the "v1.3.0 missing" observation as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)