### PR TITLE
chore(web): flip web form default model to Opus 4.7

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -278,7 +278,7 @@ export default function Home() {
   const [file, setFile] = useState<File | null>(null);
   const [email, setEmail] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [model, setModel] = useState("anthropic/claude-opus-4.6");
+  const [model, setModel] = useState("anthropic/claude-opus-4.7");
   const [authorNotes, setAuthorNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

One-line follow-up to the v1.4.0 release (issue #162, PR #164): flip the homepage form default from `anthropic/claude-opus-4.6` to `anthropic/claude-opus-4.7`. 4.7 has been a selectable option in the ModelPicker since v1.4.0 and is the same price as 4.6 ($5/$25 per 1M tok); this just promotes it to the preselected choice.

## Test plan

- [x] `useState` default only seeds the initial render, so users with a previously selected model in an open session keep their choice until they reload.
- [ ] Vercel preview: open homepage, confirm Opus 4.7 is preselected in the model dropdown; submit a short PDF to preview Modal and confirm it routes correctly.
- [ ] Post-merge on main: same smoke in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)