### PR TITLE
chore(web): promote Opus 4.7 default to production

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -278,7 +278,7 @@ export default function Home() {
   const [file, setFile] = useState<File | null>(null);
   const [email, setEmail] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [model, setModel] = useState("anthropic/claude-opus-4.6");
+  const [model, setModel] = useState("anthropic/claude-opus-4.7");
   const [authorNotes, setAuthorNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Promote one web-only commit from `dev` to `main`: the homepage model default flipped from Opus 4.6 → Opus 4.7 (#167). No `src/coarse/` change — no PyPI release needed (per CLAUDE.md, changes outside `src/coarse/` ship through their own deploy path).

Merge triggers Vercel production redeploy and the `modal-deploy.yml` workflow (which will be a no-op since no Modal source changed).

## Test plan

- [x] CI green on #167 (scan, test, version-check, Vercel preview).
- [ ] Post-merge: confirm https://coarse.ink preselects Opus 4.7 on a fresh visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)