### PR TITLE
hotfix(web): drop Google Analytics 4 from coarse.ink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Removed
+
+- **Google Analytics 4 dropped from coarse.ink (web-only hotfix).** The previous setup loaded `googletagmanager.com/gtag/js` unconditionally for every visitor in `web/src/app/layout.tsx` and set `_ga` / `_ga_*` cookies before any user interaction. Under EU/UK ePrivacy + GDPR this is a non-essential tracker that requires prior informed consent via a banner, and the site has no such banner. Rather than add a banner for an audience (academic / dev-tool users) where GA's data was never going to drive product decisions, GA is removed entirely: the two `<Script>` tags and the `GA_ID` constant deleted from `layout.tsx`, the `googletagmanager.com` origin dropped from the `script-src` CSP directive in `web/next.config.ts`, and `www.google-analytics.com` + `analytics.google.com` dropped from `connect-src` so the CSP stops whitelisting dead endpoints. `web/src/app/privacy/page.tsx` "What we collect", "Analytics", and "Third-party services" sections updated to reflect the new no-third-party-analytics posture and note that Turnstile is the only external JS (strictly necessary). No cookie banner needed as a result — the site now only sets strictly-necessary cookies (Cloudflare `__cf_bm`, Turnstile challenge, Vercel edge protection). Delivered as a hotfix directly on `main` per maintainer request; mirrored back to `dev` immediately after to prevent drift.
+
 ## v1.4.0 — 2026-04-19
 
 ### Fixed

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -8,7 +8,6 @@ const scriptSrc = [
   "'self'",
   "'unsafe-inline'",
   isDev ? "'unsafe-eval'" : null,
-  "https://www.googletagmanager.com",
   "https://cdnjs.cloudflare.com",
   // Cloudflare Turnstile api.js. Without this, the CSP silently
   // blocks the widget from loading and every user hits the "please
@@ -29,7 +28,7 @@ const cspDirectives = [
   // blob: entry, so cost estimation silently errors on strict browsers.
   "worker-src 'self' blob:",
   "font-src 'self'",
-  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai https://www.google-analytics.com https://analytics.google.com",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai",
   // Turnstile renders its challenge UI inside an iframe served from
   // challenges.cloudflare.com; default-src 'self' would otherwise
   // block it, leaving a blank box in the form.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,8 +4,6 @@ import { Young_Serif, Caveat, Space_Mono } from "next/font/google";
 import "katex/dist/katex.min.css";
 import "./globals.css";
 
-const GA_ID = "G-VLYKK7RQTZ";
-
 const youngSerif = Young_Serif({
   subsets: ["latin"],
   variable: "--font-young-serif",
@@ -37,13 +35,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${youngSerif.variable} ${caveat.variable} ${spaceMono.variable}`} suppressHydrationWarning>
       <head>
-        <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} strategy="afterInteractive" />
-        <Script id="ga-init" strategy="afterInteractive">
-          {`window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '${GA_ID}');`}
-        </Script>
         {process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY && (
           <Script
             src="https://challenges.cloudflare.com/turnstile/v0/api.js"

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -130,7 +130,6 @@ export default function PrivacyPage() {
               <li>Your email address (to notify you when the review is done)</li>
               <li>Your uploaded paper (processed and then deleted)</li>
               <li>The generated review (stored for 90 days)</li>
-              <li>Standard web analytics via Google Analytics (GA4)</li>
             </ul>
           </div>
 
@@ -214,9 +213,10 @@ export default function PrivacyPage() {
           <div style={sectionStyle}>
             <h2 style={h2Style}>Analytics</h2>
             <p style={pStyle}>
-              We use Google Analytics 4 to understand how people use the site
-              (page views, traffic sources). No personally identifiable
-              information is sent to Google Analytics.
+              We do not run third-party analytics, tracking pixels, or
+              advertising scripts on this site. No cookies beyond those
+              strictly necessary to run the review flow (bot gate, session,
+              hosting edge) are set, so we do not ask for a cookie consent.
             </p>
           </div>
 
@@ -226,7 +226,7 @@ export default function PrivacyPage() {
               <li><strong style={{ color: "var(--chalk-bright)" }}>Supabase</strong> &mdash; database and file storage (EU/US)</li>
               <li><strong style={{ color: "var(--chalk-bright)" }}>OpenRouter</strong> &mdash; LLM API (your own key, your own account; routed with <code style={{ fontFamily: "var(--font-mono, monospace)" }}>data_collection: deny</code>)</li>
               <li><strong style={{ color: "var(--chalk-bright)" }}>Vercel</strong> &mdash; website hosting</li>
-              <li><strong style={{ color: "var(--chalk-bright)" }}>Google Analytics</strong> &mdash; web analytics</li>
+              <li><strong style={{ color: "var(--chalk-bright)" }}>Cloudflare Turnstile</strong> &mdash; bot gate on the submit form (strictly necessary)</li>
             </ul>
           </div>
 


### PR DESCRIPTION
## Summary

Direct-to-main hotfix per maintainer request. GA4 loaded unconditionally and set `_ga` / `_ga_*` cookies without consent — non-compliant with EU/UK ePrivacy + GDPR. Dropping GA entirely avoids adding a cookie banner.

- `web/src/app/layout.tsx` — delete two `<Script>` tags and `GA_ID`.
- `web/next.config.ts` — drop `googletagmanager.com` from script-src and `google-analytics.com` / `analytics.google.com` from connect-src.
- `web/src/app/privacy/page.tsx` — update "What we collect" / "Analytics" / "Third-party services" sections to the new no-third-party-analytics posture.

Remaining third-party JS on the site is Turnstile (strictly necessary bot gate); remaining cookies are all strictly necessary (Cloudflare `__cf_bm`, Turnstile, Vercel edge). No consent banner required.

## Test plan

- [x] `make security` / pre-commit hooks clean.
- [ ] Vercel preview: open homepage in a fresh browser profile, confirm no `googletagmanager.com` requests in DevTools Network tab, confirm no `_ga*` cookies set.
- [ ] Post-merge on production (coarse.ink): same network/cookie check.
- [ ] Mirror merge commit back to `dev` so branches don't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)