### PR TITLE
chore: mirror v1.4.1 hotfix from main to dev (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v1.4.1 — 2026-04-21
+
+### Fixed
+
+- **Unhelpful `Invalid API key` error when a user pastes an OpenRouter provisioning/management key into `coarse setup` or the web form.** OpenRouter exposes two key types: regular API keys (used to call `/v1/chat/completions`) and provisioning keys (used programmatically to create/list API keys). Pasting a provisioning key into coarse surfaces as a `401 Unauthorized` from OpenRouter with body `{"error":{"message":"User not found.","code":401}}` — but `src/coarse/extraction_openrouter.py::_classify_api_error` mapped every 401 to the generic `"Invalid API key. Check that your key is correct and active."` copy, which sends users to check-is-my-key-typed-correctly rather than the real issue. Diagnosed from Modal logs on 2026-04-20: three consecutive submissions for one user failed with exactly this pattern while their OpenRouter key length (73 chars, `sk-or-v1-…` prefix) looked correct to them. Fix: `_classify_api_error` now inspects the response body summary via the existing `_describe_api_error` helper and — when it contains `User not found` on a 401 — returns a management-key-specific message that names the problem and links to `https://openrouter.ai/settings/keys` with the exact button to click. Generic 401s without that body fragment keep the existing copy.
+
+### Changed
+
+- **`web/src/app/setup/page.tsx` Step 3 now warns against provisioning keys.** One-paragraph note under the "Create Key" instruction explaining that provisioning/management keys from the integrations section can create and list other keys but can't run inference, and that coarse will fail with `User not found` if pasted. Paired with the classifier fix above so users who hit the error in Modal get redirected to the same guidance that now lives on the setup page.
+
 ### Removed
 
 - **Google Analytics 4 dropped from coarse.ink (web-only hotfix).** The previous setup loaded `googletagmanager.com/gtag/js` unconditionally for every visitor in `web/src/app/layout.tsx` and set `_ga` / `_ga_*` cookies before any user interaction. Under EU/UK ePrivacy + GDPR this is a non-essential tracker that requires prior informed consent via a banner, and the site has no such banner. Rather than add a banner for an audience (academic / dev-tool users) where GA's data was never going to drive product decisions, GA is removed entirely: the two `<Script>` tags and the `GA_ID` constant deleted from `layout.tsx`, the `googletagmanager.com` origin dropped from the `script-src` CSP directive in `web/next.config.ts`, and `www.google-analytics.com` + `analytics.google.com` dropped from `connect-src` so the CSP stops whitelisting dead endpoints. `web/src/app/privacy/page.tsx` "What we collect", "Analytics", and "Third-party services" sections updated to reflect the new no-third-party-analytics posture and note that Turnstile is the only external JS (strictly necessary). No cookie banner needed as a result — the site now only sets strictly-necessary cookies (Cloudflare `__cf_bm`, Turnstile challenge, Vercel edge protection). Delivered as a hotfix directly on `main` per maintainer request; mirrored back to `dev` immediately after to prevent drift.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure,
 
 ## Version
 
-1.4.0
+1.4.1
 
 ## License
 

--- a/deploy/modal_worker.py
+++ b/deploy/modal_worker.py
@@ -380,6 +380,33 @@ def _classify_hosted_key_error(api_key: str | None) -> str | None:
     )
 
 
+def _extract_response_body_message(exc: BaseException) -> str:
+    """Pull the provider-returned error body `message` field, lowercased.
+
+    Mirrors the body inspection that ``coarse.extraction_openrouter.
+    _describe_api_error`` does, minus the formatting — the worker-side
+    classifier needs the same signal but doesn't emit a scrubbed summary
+    line because the raw classifier output is what lands in
+    ``reviews.error_message`` on the status page.
+    """
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return ""
+    try:
+        body = resp.json()
+    except Exception:
+        return (getattr(resp, "text", "") or "").lower()
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict):
+            message = err.get("message")
+            if isinstance(message, str):
+                return message.lower()
+        elif isinstance(err, str):
+            return err.lower()
+    return ""
+
+
 def _classify_api_error(exc: BaseException) -> str | None:
     """Return a clear, user-facing message for common API errors.
 
@@ -391,8 +418,24 @@ def _classify_api_error(exc: BaseException) -> str | None:
     if resp is not None and not isinstance(status, int):
         status = getattr(resp, "status_code", None)
     msg = str(exc).lower()
+    body_msg = _extract_response_body_message(exc)
 
     if status == 401 or ("invalid" in msg and "key" in msg) or "unauthorized" in msg:
+        # OpenRouter returns 401 with body "User not found" when a
+        # provisioning/management key is presented on the inference
+        # endpoint — those keys create/list API keys but don't identify
+        # an inference user. This is the terminal classifier (see
+        # do_review's except BaseException) that writes the message
+        # into reviews.error_message, so it must stay in lockstep with
+        # the extraction-side fix in coarse/extraction_openrouter.py.
+        if "user not found" in body_msg:
+            return (
+                "OpenRouter rejected this key with 'User not found' — that "
+                "fires when a provisioning/management key is used on the "
+                "inference endpoint. Create a regular API key at "
+                "https://openrouter.ai/settings/keys (the 'Create Key' "
+                "button, not the provisioning section) and paste that one."
+            )
         return "Invalid API key. Check that your key is correct and active."
     if status == 402 or any(
         kw in msg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coarse-ink"
-version = "1.4.0"
+version = "1.4.1"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
 license = "MIT"

--- a/src/coarse/__init__.py
+++ b/src/coarse/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from coarse.pipeline import extract_and_structure, review_paper  # noqa: F401

--- a/src/coarse/_skills/claude_code/SKILL.md
+++ b/src/coarse/_skills/claude_code/SKILL.md
@@ -31,7 +31,7 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -45,13 +45,13 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
 
   > I need an OpenRouter API key for the OCR extraction step (~$0.10 per paper). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `claude` CLI logged in.
 
 ## How to run
@@ -69,12 +69,12 @@ Use a **per-review unique log file** so parallel runs in the same shell don't cl
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns within 2 seconds with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host claude [--model claude-opus-4-6] [--effort high]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --attach "$LOG"
 ```
 
@@ -100,12 +100,12 @@ If the user came from the coarse web form, they'll paste a handoff URL instead o
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host claude [--model ...] [--effort ...]
 
 # STEP 2b — wait (same long-timeout discipline as local mode)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/codex/SKILL.md
+++ b/src/coarse/_skills/codex/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
 
   > I need an OpenRouter API key for the OCR extraction step (~$0.10 per paper). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `codex` CLI logged in: `codex login`.
 
 ## How to run
@@ -61,12 +61,12 @@ Step 1 detaches the worker (~2 seconds) and writes `<log>.pid`. Step 2 uses `--a
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns in ~2s)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host codex [--model gpt-5.4] [--effort high]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --attach "$LOG"
 ```
 
@@ -96,12 +96,12 @@ These map to Codex's internal reasoning effort:
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host codex
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/gemini_cli/SKILL.md
+++ b/src/coarse/_skills/gemini_cli/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
 
   > I need an OpenRouter API key for the OCR extraction step (~$0.10 per paper). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.4.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.4.1' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `gemini` CLI signed in (first run prompts for OAuth).
 
 ## How to run
@@ -63,12 +63,12 @@ Use a **per-review unique log file** so parallel runs don't clobber each other's
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch (returns in ~2s with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path_or_handoff_url> --host gemini [--model gemini-3.1-pro-preview] [--effort high]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --attach "$LOG"
 ```
 
@@ -92,12 +92,12 @@ Available effort levels: `low`, `medium`, `high` (default), `max`.
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host gemini
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.4.0' \
+uvx --python 3.12 --from 'coarse-ink==1.4.1' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/extraction_openrouter.py
+++ b/src/coarse/extraction_openrouter.py
@@ -103,8 +103,23 @@ def _classify_api_error(exc: Exception) -> str | None:
     """Return a user-facing message if this is a user-actionable API error."""
     status = _get_api_error_status(exc)
     msg = str(exc).lower()
+    summary = (_describe_api_error(exc) or "").lower()
 
     if status == 401 or ("invalid" in msg and "key" in msg) or "unauthorized" in msg:
+        # OpenRouter returns 401 with body "User not found" when a
+        # provisioning/management key is presented on the inference
+        # endpoint — those keys create/list API keys but don't identify
+        # an inference user, so /v1/chat/completions rejects them before
+        # billing. Match against the parsed body (summary) since the
+        # plain exception string never carries provider error text.
+        if "user not found" in summary:
+            return (
+                "OpenRouter rejected this key with 'User not found' — that "
+                "fires when a provisioning/management key is used on the "
+                "inference endpoint. Create a regular API key at "
+                "https://openrouter.ai/settings/keys (the 'Create Key' "
+                "button, not the provisioning section) and paste that one."
+            )
         return "Invalid API key. Check that your key is correct and active."
     if status == 402 or any(
         kw in msg

--- a/tests/test_extraction_openrouter.py
+++ b/tests/test_extraction_openrouter.py
@@ -23,6 +23,89 @@ def test_classify_api_error_maps_spend_limit_message() -> None:
     assert "spend limit" in (_classify_api_error(exc) or "")
 
 
+def test_classify_api_error_detects_management_key_user_not_found() -> None:
+    """OpenRouter returns 401 + body 'User not found' for provisioning keys.
+
+    Generic 'Invalid API key' copy doesn't help the user — they need to
+    know it's the wrong *kind* of key. Reproduces the friend's
+    2026-04-20 submission where a pasted management key hit the inference
+    endpoint.
+    """
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.json.return_value = {"error": {"message": "User not found.", "code": 401}}
+    exc = RuntimeError(
+        "401 Client Error: Unauthorized for url: https://openrouter.ai/api/v1/chat/completions"
+    )
+    exc.response = resp  # type: ignore[attr-defined]
+
+    msg = _classify_api_error(exc) or ""
+    assert "provisioning" in msg.lower() or "management" in msg.lower()
+    assert "openrouter.ai/settings/keys" in msg
+
+
+def test_classify_api_error_keeps_generic_401_message_without_user_not_found() -> None:
+    """A plain 401 with no 'User not found' body keeps the existing copy."""
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.json.return_value = {"error": {"message": "Unauthorized", "code": 401}}
+    exc = RuntimeError("401 Unauthorized")
+    exc.response = resp  # type: ignore[attr-defined]
+
+    msg = _classify_api_error(exc) or ""
+    assert msg == "Invalid API key. Check that your key is correct and active."
+
+
+def test_setup_page_warns_about_provisioning_keys() -> None:
+    """The setup page must surface the same guidance the Python
+    classifier points users to.
+
+    ``_classify_api_error``'s management-key branch tells the user to
+    create a regular API key at openrouter.ai/settings/keys; the setup
+    page's Step 3 must echo that guidance so a user who hits the error
+    in Modal sees matching UI copy. A future edit that drops either
+    half breaks the cross-reference silently — this test pins both the
+    name of the wrong key type and the exact error string the
+    classifier returns, so the drift surfaces at CI time rather than
+    in a confused user's status page.
+    """
+    setup = Path(__file__).resolve().parents[1] / "web" / "src" / "app" / "setup" / "page.tsx"
+    assert setup.exists(), "web/src/app/setup/page.tsx must exist"
+    src = setup.read_text(encoding="utf-8")
+
+    assert "provisioning" in src.lower(), (
+        "setup page Step 3 must name the wrong key type ('provisioning' / "
+        "'management') so users can self-diagnose. See the classifier "
+        "message in src/coarse/extraction_openrouter.py."
+    )
+    assert "User not found" in src, (
+        "setup page Step 3 must quote the exact 'User not found' error "
+        "string users will see if they paste a provisioning key; drops "
+        "the cross-reference with _classify_api_error otherwise."
+    )
+
+
+def test_classify_api_error_does_not_leak_management_key_copy_on_403() -> None:
+    """A 403 with 'User not found' body must hit the 403 branch, not the
+    401 management-key branch.
+
+    Pins the scope of the management-key detection to 401 only so a
+    later edit that widens the outer ``if`` can't silently misroute a
+    legitimate forbidden response into provisioning-key remediation
+    copy.
+    """
+    resp = MagicMock()
+    resp.status_code = 403
+    resp.json.return_value = {"error": {"message": "User not found.", "code": 403}}
+    exc = RuntimeError("403 Forbidden")
+    exc.response = resp  # type: ignore[attr-defined]
+
+    msg = _classify_api_error(exc) or ""
+    assert "provisioning" not in msg.lower()
+    assert "management" not in msg.lower()
+    assert "403" in msg
+
+
 def test_can_fall_through_api_error_for_openrouter_403() -> None:
     exc = RuntimeError("forbidden")
     exc.status_code = 403  # type: ignore[attr-defined]

--- a/tests/test_headless_instructions.py
+++ b/tests/test_headless_instructions.py
@@ -30,11 +30,11 @@ def test_bundled_skill_assets_use_ephemeral_uvx_flow() -> None:
         # that lands this branch on main. See CHANGELOG.md ## Unreleased
         # "RELEASE BLOCKER" note — DEFAULT_MCP_UVX_FROM and these SKILL.md
         # files must all flip from the temporary git-ref pin to
-        # ``coarse-ink==1.4.0`` as part of the release cut. The `[mcp]`
+        # ``coarse-ink==1.4.1`` as part of the release cut. The `[mcp]`
         # extra was dropped to cut the uvx install from ~114 to ~60
         # packages — the handoff flow does not need fastmcp or
         # pymupdf4llm.
-        assert "uvx --python 3.12 --from 'coarse-ink==1.4.0'" in text
+        assert "uvx --python 3.12 --from 'coarse-ink==1.4.1'" in text
         assert "coarse install-skills --all --force" in text
         # Per-review unique log file: every skill uses a LOG env var
         # derived from a per-paper suffix so parallel runs in the same
@@ -128,7 +128,7 @@ def test_web_handoff_assets_use_shared_uvx_prompt_flow() -> None:
     # as part of the release cut. The release-blocker coupling test
     # in `test_release_blocker_pin_is_coupled_to_unreleased_version`
     # enforces that this pin matches `__version__`.
-    assert '"coarse-ink==1.4.0"' in handoff_lib
+    assert '"coarse-ink==1.4.1"' in handoff_lib
     assert "@feat/mcp-server" not in handoff_lib
     assert "@feat/mcp-server" not in handoff_route
 

--- a/tests/test_modal_worker.py
+++ b/tests/test_modal_worker.py
@@ -267,6 +267,64 @@ def test_classify_hosted_key_error_ignores_unknown_prefix(modal_worker) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _classify_api_error — worker-side terminal classifier
+# ---------------------------------------------------------------------------
+#
+# This is the classifier that writes into reviews.error_message on the
+# status page (see do_review's except BaseException branch). It must
+# stay in lockstep with coarse.extraction_openrouter._classify_api_error
+# because one catches the error at the extraction stage and the other
+# catches it at the Modal worker's outer boundary — a fix in only one
+# leaves the user-facing message wrong on the status page.
+
+
+def test_classify_api_error_detects_management_key_user_not_found(modal_worker) -> None:
+    """Worker classifier must match the extraction-side management-key
+    detection. Regression guard for PR #173's two-classifier split."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.json.return_value = {"error": {"message": "User not found.", "code": 401}}
+    exc = RuntimeError("401 Unauthorized")
+    exc.response = resp  # type: ignore[attr-defined]
+
+    msg = modal_worker._classify_api_error(exc) or ""
+    assert "provisioning" in msg.lower() or "management" in msg.lower()
+    assert "openrouter.ai/settings/keys" in msg
+
+
+def test_classify_api_error_generic_401_keeps_invalid_key_message(modal_worker) -> None:
+    """Plain 401s without 'User not found' still return the generic copy."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.json.return_value = {"error": {"message": "Unauthorized", "code": 401}}
+    exc = RuntimeError("401 Unauthorized")
+    exc.response = resp  # type: ignore[attr-defined]
+
+    msg = modal_worker._classify_api_error(exc) or ""
+    assert msg == "Invalid API key. Check that your key is correct and active."
+
+
+def test_classify_api_error_survives_unparseable_body(modal_worker) -> None:
+    """resp.json() raising must not crash the classifier — falls through
+    to the generic branch."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.json.side_effect = ValueError("not JSON")
+    resp.text = "<html>Bad Gateway</html>"
+    exc = RuntimeError("401 Unauthorized")
+    exc.response = resp  # type: ignore[attr-defined]
+
+    msg = modal_worker._classify_api_error(exc) or ""
+    assert msg == "Invalid API key. Check that your key is correct and active."
+
+
+# ---------------------------------------------------------------------------
 # _strip_nul_bytes — Postgres 22P05 defense (#62)
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "coarse-ink"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -518,6 +518,22 @@ function OpenRouterTab() {
             <p
               style={{
                 fontFamily: "Georgia, serif",
+                fontSize: "1.05rem",
+                lineHeight: 1.6,
+                color: "var(--dust)",
+                margin: "0 0 0.75rem",
+              }}
+            >
+              Make sure it&apos;s a regular API key — not a
+              provisioning/management key from the integrations section.
+              Provisioning keys can create and list other keys but
+              can&apos;t run inference, and coarse will fail with
+              &ldquo;User not found&rdquo; if you paste one.
+            </p>
+
+            <p
+              style={{
+                fontFamily: "Georgia, serif",
                 fontSize: "1.1rem",
                 lineHeight: 1.7,
                 color: "var(--red-chalk)",

--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -83,13 +83,13 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 // The variable is still called `DEFAULT_MCP_UVX_FROM` for backward
 // compatibility with the `test_release_blocker_pin_is_coupled_to_unreleased_version`
 // drift test that enforces the pin matches `__version__`.
-const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.4.0";
+const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.4.1";
 
 export function resolvePinnedUvFrom(): string {
   const raw = (process.env.NEXT_PUBLIC_COARSE_UVX_FROM ?? "").trim();
   if (!raw) return DEFAULT_MCP_UVX_FROM;
   // Allowlist for `NEXT_PUBLIC_COARSE_UVX_FROM` overrides. Accepts:
-  //   1. Plain semver pin: `coarse-ink==1.4.0` (production default).
+  //   1. Plain semver pin: `coarse-ink==1.4.1` (production default).
   //   2. `[mcp]` extra form for operators who want the MCP path.
   //   3. Commit-sha git ref for pinned dev testing.
   //   4. `@dev` or `@main` branch ref — self-updating Preview default,


### PR DESCRIPTION
## Summary

Mirrors PR #173 (v1.4.1 — OpenRouter management-key detection + setup-page warning) from \`main\` onto \`dev\` so the two branches don't drift, matching the \`(#169) (#170)\` pattern used for the v1.4.0 GA4 hotfix.

Cherry-pick of \`83839b5\` (the squash-merge commit from #173). No content changes.

## Test plan

- [x] \`uv run pytest tests/ -q\` — 965 pass
- [x] No merge conflicts (cherry-pick applied cleanly)
- [x] CHANGELOG and version files already aligned (main was the source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)