### PR TITLE
feat(mcp): coarse chat MCP server with literature search

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ print(review.detailed_comments[0].feedback)  # access structured fields
 rendered markdown, and the extracted paper text. The `pdf_path` parameter accepts any
 supported file format (PDF, TXT, MD, TeX, DOCX, HTML, EPUB).
 
+### MCP server
+
+`coarse` ships with an MCP server (`coarse-mcp`) that exposes the chat reviewer as tools usable from Claude Code and other MCP clients. See [docs/mcp.md](docs/mcp.md) for setup.
+
 ## Configuration
 
 Settings are stored in `~/.coarse/config.toml`:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,11 +13,13 @@ The `coarse-mcp` console script runs an [MCP](https://modelcontextprotocol.io) s
 
 ## Setup (Claude Code, project-scoped)
 
-1. Install `coarse` from the local checkout (or PyPI when published):
+1. Install the `coarse-ink` package (which ships the `coarse-mcp` script) from the local checkout, or from PyPI once published:
 
    ```bash
    uv tool install --from /Users/you/coarse coarse-ink
    ```
+
+   The install creates several console scripts (`coarse`, `coarse-ink`, `coarse-review`, `coarse-mcp`); the MCP server entry point is `coarse-mcp`.
 
 2. Add a `.mcp.json` at your project root:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,53 @@
+# Coarse MCP Server
+
+The `coarse-mcp` console script runs an [MCP](https://modelcontextprotocol.io) server that exposes `coarse chat` as a set of tools. Use it from any MCP client (Claude Code, Claude Desktop, Cursor, etc.) to hold a multi-turn conversation with the coarse reviewer over a paper and a prior review.
+
+## Tools exposed
+
+| Tool | Purpose |
+| --- | --- |
+| `start_chat(paper_path, review_path, model?)` | Open a session; returns a `session_id`. |
+| `ask(session_id, question)` | Send one turn; returns the reviewer's reply. |
+| `list_sessions()` | List active sessions with paper, review, model, turn count. |
+| `end_session(session_id)` | Drop a session from memory. |
+
+## Setup (Claude Code, project-scoped)
+
+1. Install `coarse` from the local checkout (or PyPI when published):
+
+   ```bash
+   uv tool install --from /Users/you/coarse coarse-ink
+   ```
+
+2. Add a `.mcp.json` at your project root:
+
+   ```json
+   {
+     "mcpServers": {
+       "coarse-chat": {
+         "command": "uv",
+         "args": ["run", "--directory", "/Users/you/coarse", "coarse-mcp"]
+       }
+     }
+   }
+   ```
+
+3. Confirm the launcher's environment carries `OPENROUTER_API_KEY` (or the equivalent for whichever provider your default model uses). MCP servers inherit env from the process that launches them, so if you start Claude Code from a shell that has the key exported, the server gets it. If your key lives only in `~/.zshrc`, launch Claude Code from an interactive zsh shell.
+
+4. Restart Claude Code. Run `/mcp` to verify `coarse-chat` is connected.
+
+## Usage example
+
+```
+You: Use coarse-chat to start a session over /tmp/paper.md and /tmp/review.md.
+Claude: [calls start_chat] Session abc123... started.
+You: Ask the reviewer which fix they recommend for §6.3.
+Claude: [calls ask] The reviewer recommends option (b) because ...
+```
+
+## Limitations (v1)
+
+- Sessions live only in memory. Restarting the MCP server (or Claude Code) drops them.
+- Concurrent `ask` calls on the same session can interleave history; use one client at a time per session.
+- No streaming. Long replies arrive as a single string when the model finishes.
+- Each `ask` resends the full history, so token costs grow over a long conversation. `list_sessions` reports the turn count to help you judge when to start fresh.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,3 @@ testpaths = ["tests"]
 addopts = "-m 'not slow'"
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = ["pytest>=8.0", "ruff>=0.4"]
 [project.scripts]
 coarse = "coarse.cli:app"
 coarse-ink = "coarse.cli:app"
+coarse-mcp = "coarse.mcp_server:main"
 coarse-review = "coarse.cli_review:main"
 
 [tool.hatch.build.targets.wheel]
@@ -62,3 +63,8 @@ select = ["E", "F", "I", "W"]
 testpaths = ["tests"]
 addopts = "-m 'not slow'"
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "litellm>=1.83.0",
     "instructor>=1.15.1",
+    "mcp>=1.0",
     "pydantic>=2.0",
     "typer>=0.12",
     "rich>=13.0",

--- a/src/coarse/chat.py
+++ b/src/coarse/chat.py
@@ -8,12 +8,33 @@ for the REPL wrapper.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from coarse.extraction import extract_file
 from coarse.llm import LLMClient
-from coarse.prompts import CHAT_SYSTEM, chat_user_initial
+from coarse.models import LITERATURE_SEARCH_MODEL
+from coarse.prompts import CHAT_SYSTEM, PERPLEXITY_SYSTEM, chat_user_initial
+
+_SEARCH_SENTINEL_RE = re.compile(r"<<SEARCH:\s*(.+?)\s*>>", re.DOTALL)
+_MAX_SEARCHES_PER_TURN = 3
+
+
+def _extract_search_query(reply: str) -> str | None:
+    """Return the first <<SEARCH: ...>> query, or None."""
+    match = _SEARCH_SENTINEL_RE.search(reply)
+    return match.group(1).strip() if match else None
+
+
+def _run_literature_query(query: str) -> str:
+    """One-shot Perplexity Sonar Pro lookup. Returns the raw markdown reply."""
+    lit_client = LLMClient(model=LITERATURE_SEARCH_MODEL)
+    messages = [
+        {"role": "system", "content": PERPLEXITY_SYSTEM},
+        {"role": "user", "content": query},
+    ]
+    return lit_client.complete_text(messages, max_tokens=4096, temperature=0.3, timeout=60)
 
 
 @dataclass
@@ -46,9 +67,28 @@ class ChatSession:
         return self._client
 
     def ask(self, question: str) -> str:
-        """Send a user question and return the assistant reply (no tool use yet)."""
+        """Send a user question. Honor up to N search-sentinel hops before returning."""
         self.history.append({"role": "user", "content": question})
         client = self._client_or_create()
-        reply = client.complete_text(self.history, max_tokens=4096, temperature=0.3)
-        self.history.append({"role": "assistant", "content": reply})
+
+        for _ in range(_MAX_SEARCHES_PER_TURN + 1):  # +1 so we get one final non-search reply
+            reply = client.complete_text(self.history, max_tokens=4096, temperature=0.3)
+            self.history.append({"role": "assistant", "content": reply})
+
+            query = _extract_search_query(reply)
+            if query is None:
+                return reply
+
+            results = _run_literature_query(query)
+            self.history.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"Literature search results for `{query}`:\n\n{results}\n\n"
+                        "Continue your answer using these results."
+                    ),
+                }
+            )
+
+        # Hit the search cap — return whatever the model said last.
         return reply

--- a/src/coarse/chat.py
+++ b/src/coarse/chat.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from coarse.extraction import extract_file
+from coarse.llm import LLMClient
 from coarse.prompts import CHAT_SYSTEM, chat_user_initial
 
 
@@ -22,13 +23,32 @@ class ChatSession:
     model: str | None = None
     paper_text: str = field(init=False)
     review_text: str = field(init=False)
+    history: list[dict] = field(init=False, default_factory=list)
+    _client: LLMClient | None = field(init=False, default=None, repr=False)
 
     def __post_init__(self) -> None:
         self.paper_text = extract_file(self.paper_path).full_markdown
         self.review_text = self.review_path.read_text(encoding="utf-8")
+        self.history = [
+            {"role": "system", "content": self.system_prompt()},
+            {"role": "user", "content": self.initial_user_message()},
+        ]
 
     def system_prompt(self) -> str:
         return CHAT_SYSTEM
 
     def initial_user_message(self) -> str:
         return chat_user_initial(self.paper_text, self.review_text)
+
+    def _client_or_create(self) -> LLMClient:
+        if self._client is None:
+            self._client = LLMClient(model=self.model)
+        return self._client
+
+    def ask(self, question: str) -> str:
+        """Send a user question and return the assistant reply (no tool use yet)."""
+        self.history.append({"role": "user", "content": question})
+        client = self._client_or_create()
+        reply = client.complete_text(self.history, max_tokens=4096, temperature=0.3)
+        self.history.append({"role": "assistant", "content": reply})
+        return reply

--- a/src/coarse/chat.py
+++ b/src/coarse/chat.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from coarse.extraction import extract_file
+from coarse.prompts import CHAT_SYSTEM, chat_user_initial
 
 
 @dataclass
@@ -25,3 +26,9 @@ class ChatSession:
     def __post_init__(self) -> None:
         self.paper_text = extract_file(self.paper_path).full_markdown
         self.review_text = self.review_path.read_text(encoding="utf-8")
+
+    def system_prompt(self) -> str:
+        return CHAT_SYSTEM
+
+    def initial_user_message(self) -> str:
+        return chat_user_initial(self.paper_text, self.review_text)

--- a/src/coarse/chat.py
+++ b/src/coarse/chat.py
@@ -1,0 +1,27 @@
+"""Chat-mode reviewer: interactive Q&A over a paper + prior review.
+
+Stateless from the LLM's perspective on each turn — we resend the full
+message history every call. The system prompt names the literature-search
+sentinel; the chat loop intercepts it and calls Perplexity. See cli_chat.py
+for the REPL wrapper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from coarse.extraction import extract_file
+
+
+@dataclass
+class ChatSession:
+    paper_path: Path
+    review_path: Path
+    model: str | None = None
+    paper_text: str = field(init=False)
+    review_text: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.paper_text = extract_file(self.paper_path).full_markdown
+        self.review_text = self.review_path.read_text(encoding="utf-8")

--- a/src/coarse/chat.py
+++ b/src/coarse/chat.py
@@ -27,7 +27,7 @@ def _extract_search_query(reply: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def _run_literature_query(query: str) -> str:
+def run_literature_query(query: str) -> str:
     """One-shot Perplexity Sonar Pro lookup. Returns the raw markdown reply."""
     lit_client = LLMClient(model=LITERATURE_SEARCH_MODEL)
     messages = [
@@ -79,7 +79,7 @@ class ChatSession:
             if query is None:
                 return reply
 
-            results = _run_literature_query(query)
+            results = run_literature_query(query)
             self.history.append(
                 {
                     "role": "user",

--- a/src/coarse/cli.py
+++ b/src/coarse/cli.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.status import Status
 
 from coarse import __version__
+from coarse.cli_chat import chat as _chat_fn
 from coarse.config import (
     PROVIDER_ENV_VARS,
     CoarseConfig,
@@ -103,6 +104,9 @@ def main(
     ),
 ) -> None:
     """coarse command group."""
+
+
+app.command()(_chat_fn)
 
 
 @app.command()

--- a/src/coarse/cli_chat.py
+++ b/src/coarse/cli_chat.py
@@ -8,7 +8,11 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from coarse.chat import ChatSession
+
 console = Console()
+
+_QUIT_COMMANDS = {"/quit", "/exit", "/q"}
 
 
 def chat(
@@ -27,4 +31,23 @@ def chat(
     ),
 ) -> None:
     """Chat with the reviewer about a paper and its prior review."""
-    console.print(f"[bold]chat stub[/bold]: paper={paper.name} review={review.name} model={model}")
+    session = ChatSession(paper_path=paper, review_path=review, model=model)
+    console.print(
+        f"[bold]coarse chat[/bold]  paper={paper.name}  review={review.name}\n"
+        f"[dim]Type {' or '.join(sorted(_QUIT_COMMANDS))} to exit.[/dim]\n"
+    )
+
+    while True:
+        try:
+            question = typer.prompt("you", prompt_suffix=" > ").strip()
+        except (EOFError, KeyboardInterrupt):
+            console.print()
+            return
+
+        if not question:
+            continue
+        if question.lower() in _QUIT_COMMANDS:
+            return
+
+        reply = session.ask(question)
+        console.print(f"\n[bold]reviewer[/bold]:\n{reply}\n")

--- a/src/coarse/cli_chat.py
+++ b/src/coarse/cli_chat.py
@@ -1,0 +1,30 @@
+"""Interactive chat with the reviewer persona over a paper + prior review."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def chat(
+    paper: Path = typer.Argument(
+        ...,
+        exists=True,
+        help="Path to the paper file (PDF, MD, TXT, TeX, DOCX, HTML, EPUB).",
+    ),
+    review: Path = typer.Argument(
+        ...,
+        exists=True,
+        help="Path to the existing review markdown produced by `coarse review`.",
+    ),
+    model: Optional[str] = typer.Option(
+        None, "--model", "-m", help="LiteLLM model string. Defaults to config default_model."
+    ),
+) -> None:
+    """Chat with the reviewer about a paper and its prior review."""
+    console.print(f"[bold]chat stub[/bold]: paper={paper.name} review={review.name} model={model}")

--- a/src/coarse/llm.py
+++ b/src/coarse/llm.py
@@ -597,6 +597,12 @@ class LLMClient:
         content = response.choices[0].message.content
         if not content or not content.strip():
             raise ValueError(f"Model {self._model} returned empty response")
+        citations = getattr(response, "citations", None) or []
+        if citations:
+            sources = "\n\n**Sources:**\n" + "\n".join(
+                f"{i + 1}. {url}" for i, url in enumerate(citations)
+            )
+            content = content + sources
         return content.strip()
 
     def add_cost(self, cost_usd: float) -> None:

--- a/src/coarse/mcp_server.py
+++ b/src/coarse/mcp_server.py
@@ -7,15 +7,47 @@ Sessions are in-memory only and do not persist across server restarts.
 
 from __future__ import annotations
 
+import uuid
+from pathlib import Path
+
 from mcp.server.fastmcp import FastMCP
 
+from coarse.chat import ChatSession
+
 mcp = FastMCP("coarse-chat")
+
+_sessions: dict[str, ChatSession] = {}
 
 
 @mcp.tool()
 def ping() -> str:
     """Health check. Returns the literal string 'pong'."""
     return "pong"
+
+
+@mcp.tool()
+def start_chat(paper_path: str, review_path: str, model: str | None = None) -> str:
+    """Start a chat session with the coarse reviewer over a paper and a prior review.
+
+    Args:
+        paper_path: Absolute path to the paper file (PDF, MD, TXT, TeX, DOCX, HTML, EPUB).
+        review_path: Absolute path to the markdown review previously produced by `coarse review`.
+        model: Optional LiteLLM model string. Defaults to the user's coarse config default.
+
+    Returns:
+        A session id string. Use it with `ask` and `end_session`.
+    """
+    paper = Path(paper_path)
+    review = Path(review_path)
+    if not paper.exists():
+        raise FileNotFoundError(f"paper not found: {paper}")
+    if not review.exists():
+        raise FileNotFoundError(f"review not found: {review}")
+
+    session = ChatSession(paper_path=paper, review_path=review, model=model)
+    session_id = uuid.uuid4().hex
+    _sessions[session_id] = session
+    return session_id
 
 
 def main() -> None:

--- a/src/coarse/mcp_server.py
+++ b/src/coarse/mcp_server.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-from coarse.chat import ChatSession
+from coarse.chat import ChatSession, run_literature_query
 
 mcp = FastMCP("coarse-chat")
 
@@ -101,6 +101,24 @@ def list_sessions() -> list[dict]:
             }
         )
     return out
+
+
+@mcp.tool()
+def search_literature(query: str) -> str:
+    """Run a one-shot literature search via Perplexity Sonar Pro.
+
+    Unlike `ask`, this does not require a session or a paper — it is a direct
+    pass-through to the web-grounded search model. Use it when you want to look
+    something up in the literature without attaching a paper context.
+
+    Args:
+        query: Free-text search query (e.g. "recent work on regression
+            discontinuity with distribution-valued outcomes").
+
+    Returns:
+        Markdown text with findings and citations, as returned by the model.
+    """
+    return run_literature_query(query)
 
 
 @mcp.tool()

--- a/src/coarse/mcp_server.py
+++ b/src/coarse/mcp_server.py
@@ -50,6 +50,26 @@ def start_chat(paper_path: str, review_path: str, model: str | None = None) -> s
     return session_id
 
 
+@mcp.tool()
+def ask(session_id: str, question: str) -> str:
+    """Send a question to a running chat session and return the reviewer's reply.
+
+    The session may transparently consult Perplexity Sonar Pro for literature
+    lookups (up to 3 hops per turn) before composing the final reply.
+
+    Args:
+        session_id: Id returned by `start_chat`.
+        question: The user's question for this turn.
+
+    Returns:
+        The reviewer's reply as plain markdown text.
+    """
+    session = _sessions.get(session_id)
+    if session is None:
+        raise KeyError(f"unknown session: {session_id}")
+    return session.ask(question)
+
+
 def main() -> None:
     """Entry point for the `coarse-mcp` console script."""
     mcp.run()

--- a/src/coarse/mcp_server.py
+++ b/src/coarse/mcp_server.py
@@ -103,6 +103,22 @@ def list_sessions() -> list[dict]:
     return out
 
 
+@mcp.tool()
+def end_session(session_id: str) -> str:
+    """Drop a chat session from memory. Frees its history.
+
+    Args:
+        session_id: Id returned by `start_chat`.
+
+    Returns:
+        A short confirmation string.
+    """
+    if session_id not in _sessions:
+        raise KeyError(f"unknown session: {session_id}")
+    del _sessions[session_id]
+    return f"Session {session_id} ended."
+
+
 def main() -> None:
     """Entry point for the `coarse-mcp` console script."""
     mcp.run()

--- a/src/coarse/mcp_server.py
+++ b/src/coarse/mcp_server.py
@@ -1,0 +1,23 @@
+"""MCP server exposing coarse.chat.ChatSession as tools.
+
+Launched as a subprocess by an MCP client (e.g. Claude Code) per .mcp.json.
+Holds a module-level registry of active ChatSession objects keyed by UUID.
+Sessions are in-memory only and do not persist across server restarts.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("coarse-chat")
+
+
+@mcp.tool()
+def ping() -> str:
+    """Health check. Returns the literal string 'pong'."""
+    return "pong"
+
+
+def main() -> None:
+    """Entry point for the `coarse-mcp` console script."""
+    mcp.run()

--- a/src/coarse/mcp_server.py
+++ b/src/coarse/mcp_server.py
@@ -70,6 +70,39 @@ def ask(session_id: str, question: str) -> str:
     return session.ask(question)
 
 
+@mcp.tool()
+def list_sessions() -> list[dict]:
+    """List all active chat sessions and their metadata.
+
+    Returns:
+        A list of dicts with keys: session_id, paper_path, review_path, model, turns.
+        `turns` counts the user questions asked so far in the session (excludes the
+        initial bootstrap user message and any literature-search injection messages).
+    """
+    out = []
+    for sid, sess in _sessions.items():
+        # Initial history is [system, user_initial]; subsequent user messages are
+        # either turn questions or literature-search results. Turn questions are
+        # the ones that did NOT come from the search-result injection, which
+        # always begins with the literal "Literature search results for `".
+        turn_questions = sum(
+            1
+            for m in sess.history[2:]
+            if m["role"] == "user"
+            and not m["content"].startswith("Literature search results for `")
+        )
+        out.append(
+            {
+                "session_id": sid,
+                "paper_path": str(sess.paper_path),
+                "review_path": str(sess.review_path),
+                "model": sess.model,
+                "turns": turn_questions,
+            }
+        )
+    return out
+
+
 def main() -> None:
     """Entry point for the `coarse-mcp` console script."""
     mcp.run()

--- a/src/coarse/prompts.py
+++ b/src/coarse/prompts.py
@@ -2451,3 +2451,56 @@ def get_prompt(
         )
 
     raise ValueError(f"unknown stage {stage!r}; expected one of {_MCP_STAGES}")
+
+
+# ---------------------------------------------------------------------------
+# Chat-mode reviewer (interactive Q&A over a paper + prior review)
+# ---------------------------------------------------------------------------
+
+CHAT_SYSTEM = (
+    """\
+You are an expert peer reviewer continuing a conversation with the paper's \
+author. You have already produced a written review (which the user will \
+include in the first message). Your job now is to answer the author's \
+follow-up questions about your own review and about the paper's methods, \
+results, and literature context. Be specific. Cite sections, equations, and \
+quoted text where relevant.
+"""
+    + _TONE_BLOCK
+    + _HUMANIZER_BLOCK
+    + """
+## Literature search
+
+When a question is best answered by referencing published literature you do \
+not already have in context, emit exactly this token on its own line and \
+STOP your response there:
+
+    <<SEARCH: your search query here>>
+
+The harness will run a Perplexity Sonar Pro literature search with that \
+query and re-prompt you with the results. Do not invent citations. If a \
+search returns nothing relevant, say so and answer from first principles.
+
+Use at most 3 searches per user turn. Each search costs the user money.
+"""
+)
+
+
+def chat_user_initial(paper_text: str, review_text: str) -> str:
+    """First user message: hand the model the paper and the prior review."""
+    return f"""\
+I am the author. Here is the paper you reviewed and the review you wrote. \
+I want to ask follow-up questions.
+
+## Paper text
+<paper>
+{paper_text}
+</paper>
+
+## Your prior review
+<review>
+{review_text}
+</review>
+
+Acknowledge that you have both, then wait for my first question.
+"""

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -62,3 +62,37 @@ def test_ask_returns_model_reply(fake_paper: Path, fake_review: Path) -> None:
     assert reply == "Hello, author."
     # Subsequent turns should reuse history — the message list grows.
     assert len(session.history) >= 2  # initial user + assistant + new user + assistant
+
+
+def test_ask_intercepts_search_sentinel(fake_paper: Path, fake_review: Path) -> None:
+    """Model emits <<SEARCH: q>>, harness calls literature search, re-prompts."""
+    session = ChatSession(paper_path=fake_paper, review_path=fake_review, model="openai/gpt-4o-mini")
+
+    main_client = MagicMock()
+    # First call: model asks for a search. Second call: model gives the final answer.
+    main_client.complete_text.side_effect = [
+        "I should look this up.\n<<SEARCH: weighted Cohen's d for survey data>>",
+        "Based on the literature, here is the answer.",
+    ]
+
+    lit_client = MagicMock()
+    lit_client.complete_text.return_value = "MOCK_LIT_RESULTS"
+
+    def client_factory(model: str | None = None):
+        # First instantiation in ask() -> main client.
+        # Second instantiation (for literature search) -> lit client.
+        if model and "perplexity" in (model or "").lower():
+            return lit_client
+        return main_client
+
+    with patch("coarse.chat.LLMClient", side_effect=client_factory):
+        reply = session.ask("Why not a t-test?")
+
+    assert reply == "Based on the literature, here is the answer."
+    # Search was actually invoked
+    lit_client.complete_text.assert_called_once()
+    lit_call_args = lit_client.complete_text.call_args
+    lit_messages = lit_call_args.args[0] if lit_call_args.args else lit_call_args.kwargs["messages"]
+    assert any("weighted Cohen's d for survey data" in m["content"] for m in lit_messages)
+    # Search results were folded back into the main conversation
+    assert any("MOCK_LIT_RESULTS" in m["content"] for m in session.history if m["role"] == "user")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -47,3 +48,17 @@ def test_chatsession_initial_user_message_includes_paper_and_review(
     initial = session.initial_user_message()
     assert "studies X" in initial          # paper body
     assert "The paper is about X" in initial  # review body
+
+
+def test_ask_returns_model_reply(fake_paper: Path, fake_review: Path) -> None:
+    session = ChatSession(paper_path=fake_paper, review_path=fake_review, model="openai/gpt-4o-mini")
+
+    fake_client = MagicMock()
+    fake_client.complete_text.return_value = "Hello, author."
+
+    with patch("coarse.chat.LLMClient", return_value=fake_client):
+        reply = session.ask("What did you mean by section 3?")
+
+    assert reply == "Hello, author."
+    # Subsequent turns should reuse history — the message list grows.
+    assert len(session.history) >= 2  # initial user + assistant + new user + assistant

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -27,3 +27,23 @@ def test_chatsession_loads_paper_and_review(fake_paper: Path, fake_review: Path)
     session = ChatSession(paper_path=fake_paper, review_path=fake_review, model="openai/gpt-4o-mini")
     assert "studies X" in session.paper_text
     assert "The paper is about X" in session.review_text
+
+
+def test_chatsession_builds_system_prompt(fake_paper: Path, fake_review: Path) -> None:
+    session = ChatSession(paper_path=fake_paper, review_path=fake_review, model="openai/gpt-4o-mini")
+    sys_prompt = session.system_prompt()
+    # Persona markers
+    assert "peer reviewer" in sys_prompt.lower()
+    # Literature-search sentinel must be documented
+    assert "<<SEARCH:" in sys_prompt
+    # Tone block fragment from coarse.prompts._TONE_BLOCK
+    assert "constructive but direct colleague" in sys_prompt
+
+
+def test_chatsession_initial_user_message_includes_paper_and_review(
+    fake_paper: Path, fake_review: Path
+) -> None:
+    session = ChatSession(paper_path=fake_paper, review_path=fake_review, model="openai/gpt-4o-mini")
+    initial = session.initial_user_message()
+    assert "studies X" in initial          # paper body
+    assert "The paper is about X" in initial  # review body

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,29 @@
+"""Tests for ChatSession (chat-mode logic, no CLI)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from coarse.chat import ChatSession
+
+
+@pytest.fixture
+def fake_paper(tmp_path: Path) -> Path:
+    p = tmp_path / "paper.md"
+    p.write_text("# Title\n\nThis paper studies X.\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def fake_review(tmp_path: Path) -> Path:
+    r = tmp_path / "review.md"
+    r.write_text("## Overview\n\nThe paper is about X.\n", encoding="utf-8")
+    return r
+
+
+def test_chatsession_loads_paper_and_review(fake_paper: Path, fake_review: Path) -> None:
+    session = ChatSession(paper_path=fake_paper, review_path=fake_review, model="openai/gpt-4o-mini")
+    assert "studies X" in session.paper_text
+    assert "The paper is about X" in session.review_text

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 from typer.testing import CliRunner
 
 from coarse.cli import app
@@ -14,3 +17,24 @@ def test_chat_subcommand_is_registered() -> None:
     result = runner.invoke(app, ["chat", "--help"])
     assert result.exit_code == 0, result.output
     assert "chat" in result.output.lower()
+
+
+def test_chat_repl_runs_one_question_then_quits(tmp_path: Path) -> None:
+    paper = tmp_path / "paper.md"
+    paper.write_text("# Title\n\nbody\n", encoding="utf-8")
+    review = tmp_path / "review.md"
+    review.write_text("## Overview\n\nreview body\n", encoding="utf-8")
+
+    fake_session = MagicMock()
+    fake_session.ask.return_value = "Reviewer reply."
+
+    with patch("coarse.cli_chat.ChatSession", return_value=fake_session):
+        result = runner.invoke(
+            app,
+            ["chat", str(paper), str(review)],
+            input="What did you mean?\n/quit\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Reviewer reply." in result.output
+    fake_session.ask.assert_called_once_with("What did you mean?")

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1,0 +1,16 @@
+"""Tests for the `coarse chat` CLI subcommand."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from coarse.cli import app
+
+runner = CliRunner()
+
+
+def test_chat_subcommand_is_registered() -> None:
+    """`coarse chat --help` exits 0 and mentions chat."""
+    result = runner.invoke(app, ["chat", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "chat" in result.output.lower()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -704,6 +704,7 @@ def test_complete_text_returns_raw_content(mock_instructor_client):
     mock_response = MagicMock()
     mock_response.choices = [MagicMock()]
     mock_response.choices[0].message.content = "  some perplexity citations  "
+    mock_response.citations = None
 
     with (
         patch("coarse.llm._sanitized_completion", return_value=mock_response),
@@ -716,6 +717,29 @@ def test_complete_text_returns_raw_content(mock_instructor_client):
 
     assert result == "some perplexity citations"
     assert abs(client.cost_usd - 0.042) < 1e-9
+
+
+def test_complete_text_appends_perplexity_citations(mock_instructor_client):
+    """Citations returned by Perplexity are appended as a numbered sources section."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Covariate balance matters [1][2]."
+    mock_response.citations = [
+        "https://example.com/paper1",
+        "https://example.com/paper2",
+    ]
+
+    with (
+        patch("coarse.llm._sanitized_completion", return_value=mock_response),
+        patch("coarse.llm.litellm.completion_cost", return_value=0.01),
+    ):
+        client = LLMClient(model=TEST_MODEL, config=CoarseConfig())
+        result = client.complete_text(messages=[{"role": "user", "content": "hi"}])
+
+    assert "**Sources:**" in result
+    assert "1. https://example.com/paper1" in result
+    assert "2. https://example.com/paper2" in result
+    assert result.startswith("Covariate balance matters [1][2].")
 
 
 def test_complete_text_raises_on_empty_response(mock_instructor_client):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -97,3 +97,33 @@ def test_ask_appends_user_question_to_history(fake_paper: Path, fake_review: Pat
 def test_ask_raises_for_unknown_session_id() -> None:
     with pytest.raises(KeyError, match="unknown session"):
         ask("nonexistent-id", "Hi.")
+
+
+from coarse.mcp_server import list_sessions
+
+
+def test_list_sessions_empty_by_default() -> None:
+    assert list_sessions() == []
+
+
+def test_list_sessions_returns_metadata(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review), model="openai/gpt-4o-mini")
+    sessions = list_sessions()
+    assert len(sessions) == 1
+    entry = sessions[0]
+    assert entry["session_id"] == session_id
+    assert entry["paper_path"].endswith("paper.md")
+    assert entry["review_path"].endswith("review.md")
+    assert entry["model"] == "openai/gpt-4o-mini"
+    assert entry["turns"] == 0
+
+
+def test_list_sessions_turns_counts_user_questions(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    _sessions[session_id]._client = MagicMock(
+        complete_text=MagicMock(return_value="reply")
+    )
+    ask(session_id, "Q1?")
+    ask(session_id, "Q2?")
+    [entry] = list_sessions()
+    assert entry["turns"] == 2

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,6 +15,7 @@ from coarse.mcp_server import (
     list_sessions,
     mcp,
     ping,
+    search_literature,
     start_chat,
 )
 
@@ -148,9 +149,29 @@ def test_end_session_raises_for_unknown_id() -> None:
         end_session("nonexistent-id")
 
 
+def test_search_literature_calls_run_literature_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_run(query: str) -> str:
+        captured["query"] = query
+        return "## Findings\n\n- Paper A (2024) shows..."
+
+    monkeypatch.setattr("coarse.mcp_server.run_literature_query", fake_run)
+    reply = search_literature("recent work on RDD with distribution outcomes")
+    assert captured["query"] == "recent work on RDD with distribution outcomes"
+    assert "Findings" in reply
+
+
 def test_all_tools_registered_on_mcp() -> None:
     """Every public tool function should be exposed by the MCP server."""
-    expected = {"ping", "start_chat", "ask", "list_sessions", "end_session"}
+    expected = {
+        "ping",
+        "start_chat",
+        "ask",
+        "list_sessions",
+        "end_session",
+        "search_literature",
+    }
     # FastMCP exposes registered tools via list_tools(). The exact accessor
     # may differ across mcp SDK versions; try the documented async API first
     # and fall back to the internal registry if needed.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,13 @@
+"""Tests for the coarse MCP server."""
+
+from __future__ import annotations
+
+from coarse.mcp_server import mcp, ping
+
+
+def test_ping_returns_pong() -> None:
+    assert ping() == "pong"
+
+
+def test_server_name_is_coarse_chat() -> None:
+    assert mcp.name == "coarse-chat"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,3 +11,61 @@ def test_ping_returns_pong() -> None:
 
 def test_server_name_is_coarse_chat() -> None:
     assert mcp.name == "coarse-chat"
+
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from coarse.mcp_server import _sessions, start_chat
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions():
+    _sessions.clear()
+    yield
+    _sessions.clear()
+
+
+@pytest.fixture
+def fake_paper(tmp_path: Path) -> Path:
+    p = tmp_path / "paper.md"
+    p.write_text("# Title\n\nThis paper studies X.\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def fake_review(tmp_path: Path) -> Path:
+    r = tmp_path / "review.md"
+    r.write_text("## Overview\n\nThe paper is about X.\n", encoding="utf-8")
+    return r
+
+
+def test_start_chat_returns_uuid_string(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    assert isinstance(session_id, str)
+    assert len(session_id) >= 32  # uuid4 hex is 32+ chars
+
+
+def test_start_chat_stores_session_in_registry(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    assert session_id in _sessions
+    assert "studies X" in _sessions[session_id].paper_text
+
+
+def test_start_chat_passes_model_through(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review), model="openai/gpt-4o-mini")
+    assert _sessions[session_id].model == "openai/gpt-4o-mini"
+
+
+def test_start_chat_raises_when_paper_missing(tmp_path: Path, fake_review: Path) -> None:
+    missing = tmp_path / "does_not_exist.md"
+    with pytest.raises(FileNotFoundError, match="paper"):
+        start_chat(str(missing), str(fake_review))
+
+
+def test_start_chat_raises_when_review_missing(fake_paper: Path, tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.md"
+    with pytest.raises(FileNotFoundError, match="review"):
+        start_chat(str(fake_paper), str(missing))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -149,3 +149,21 @@ def test_end_session_returns_confirmation_string(fake_paper: Path, fake_review: 
 def test_end_session_raises_for_unknown_id() -> None:
     with pytest.raises(KeyError, match="unknown session"):
         end_session("nonexistent-id")
+
+
+import asyncio
+
+
+def test_all_tools_registered_on_mcp() -> None:
+    """Every public tool function should be exposed by the MCP server."""
+    expected = {"ping", "start_chat", "ask", "list_sessions", "end_session"}
+    # FastMCP exposes registered tools via list_tools(). The exact accessor
+    # may differ across mcp SDK versions; try the documented async API first
+    # and fall back to the internal registry if needed.
+    try:
+        tools = asyncio.run(mcp.list_tools())
+        names = {t.name for t in tools}
+    except AttributeError:
+        # Fallback for older/newer SDK shapes: dig into the tool manager.
+        names = set(mcp._tool_manager._tools.keys())  # type: ignore[attr-defined]
+    assert expected.issubset(names), f"missing tools: {expected - names}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,7 +2,21 @@
 
 from __future__ import annotations
 
-from coarse.mcp_server import mcp, ping
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from coarse.mcp_server import (
+    _sessions,
+    ask,
+    end_session,
+    list_sessions,
+    mcp,
+    ping,
+    start_chat,
+)
 
 
 def test_ping_returns_pong() -> None:
@@ -11,14 +25,6 @@ def test_ping_returns_pong() -> None:
 
 def test_server_name_is_coarse_chat() -> None:
     assert mcp.name == "coarse-chat"
-
-
-from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
-
-from coarse.mcp_server import _sessions, start_chat
 
 
 @pytest.fixture(autouse=True)
@@ -71,9 +77,6 @@ def test_start_chat_raises_when_review_missing(fake_paper: Path, tmp_path: Path)
         start_chat(str(fake_paper), str(missing))
 
 
-from coarse.mcp_server import ask
-
-
 def test_ask_returns_assistant_reply(fake_paper: Path, fake_review: Path) -> None:
     session_id = start_chat(str(fake_paper), str(fake_review))
     _sessions[session_id]._client = MagicMock(
@@ -97,9 +100,6 @@ def test_ask_appends_user_question_to_history(fake_paper: Path, fake_review: Pat
 def test_ask_raises_for_unknown_session_id() -> None:
     with pytest.raises(KeyError, match="unknown session"):
         ask("nonexistent-id", "Hi.")
-
-
-from coarse.mcp_server import list_sessions
 
 
 def test_list_sessions_empty_by_default() -> None:
@@ -129,9 +129,6 @@ def test_list_sessions_turns_counts_user_questions(fake_paper: Path, fake_review
     assert entry["turns"] == 2
 
 
-from coarse.mcp_server import end_session
-
-
 def test_end_session_removes_session(fake_paper: Path, fake_review: Path) -> None:
     session_id = start_chat(str(fake_paper), str(fake_review))
     assert session_id in _sessions
@@ -149,9 +146,6 @@ def test_end_session_returns_confirmation_string(fake_paper: Path, fake_review: 
 def test_end_session_raises_for_unknown_id() -> None:
     with pytest.raises(KeyError, match="unknown session"):
         end_session("nonexistent-id")
-
-
-import asyncio
 
 
 def test_all_tools_registered_on_mcp() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,3 +127,25 @@ def test_list_sessions_turns_counts_user_questions(fake_paper: Path, fake_review
     ask(session_id, "Q2?")
     [entry] = list_sessions()
     assert entry["turns"] == 2
+
+
+from coarse.mcp_server import end_session
+
+
+def test_end_session_removes_session(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    assert session_id in _sessions
+    end_session(session_id)
+    assert session_id not in _sessions
+
+
+def test_end_session_returns_confirmation_string(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    msg = end_session(session_id)
+    assert session_id in msg
+    assert "ended" in msg.lower()
+
+
+def test_end_session_raises_for_unknown_id() -> None:
+    with pytest.raises(KeyError, match="unknown session"):
+        end_session("nonexistent-id")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -69,3 +69,31 @@ def test_start_chat_raises_when_review_missing(fake_paper: Path, tmp_path: Path)
     missing = tmp_path / "does_not_exist.md"
     with pytest.raises(FileNotFoundError, match="review"):
         start_chat(str(fake_paper), str(missing))
+
+
+from coarse.mcp_server import ask
+
+
+def test_ask_returns_assistant_reply(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    _sessions[session_id]._client = MagicMock(
+        complete_text=MagicMock(return_value="Hello, author.")
+    )
+    reply = ask(session_id, "What is the paper about?")
+    assert reply == "Hello, author."
+
+
+def test_ask_appends_user_question_to_history(fake_paper: Path, fake_review: Path) -> None:
+    session_id = start_chat(str(fake_paper), str(fake_review))
+    _sessions[session_id]._client = MagicMock(
+        complete_text=MagicMock(return_value="Reply.")
+    )
+    ask(session_id, "Question one?")
+    history = _sessions[session_id].history
+    user_messages = [m["content"] for m in history if m["role"] == "user"]
+    assert any("Question one?" in m for m in user_messages)
+
+
+def test_ask_raises_for_unknown_session_id() -> None:
+    with pytest.raises(KeyError, match="unknown session"):
+        ask("nonexistent-id", "Hi.")

--- a/uv.lock
+++ b/uv.lock
@@ -204,6 +204,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +352,7 @@ source = { editable = "." }
 dependencies = [
     { name = "instructor" },
     { name = "litellm" },
+    { name = "mcp" },
     { name = "pydantic" },
     { name = "pymupdf" },
     { name = "python-dotenv" },
@@ -336,6 +394,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.83.0" },
     { name = "mammoth", marker = "extra == 'formats'", specifier = ">=1.6" },
     { name = "markdownify", marker = "extra == 'formats'", specifier = ">=0.12" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pymupdf", specifier = ">=1.24" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -377,6 +436,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
 
 [[package]]
@@ -873,6 +985,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1291,6 +1412,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]
@@ -2036,6 +2182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2146,6 +2301,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2329,6 +2498,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -2881,6 +3059,32 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3259,6 +3463,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -384,11 +384,6 @@ formats = [
     { name = "markdownify" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "coarse-ink", extras = ["docling"], marker = "extra == 'all'" },
@@ -412,9 +407,6 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["docling", "formats", "all", "dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "cobble"

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,11 @@ formats = [
     { name = "markdownify" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "coarse-ink", extras = ["docling"], marker = "extra == 'all'" },
@@ -407,6 +412,9 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["docling", "formats", "all", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "cobble"


### PR DESCRIPTION
## Summary

- Adds `ChatSession` for interactive Q&A over a paper + prior review, with sentinel-based Perplexity literature lookups (up to 3 hops per turn)
- Adds `coarse chat` CLI subcommand REPL
- Adds full MCP server (`coarse-mcp`) exposing `ping`, `start_chat`, `ask`, `list_sessions`, `end_session`, and `search_literature` tools
- Fixes `complete_text` to surface Perplexity's `citations` array as a numbered `**Sources:**` section so URLs are no longer silently dropped

## Test plan

- [ ] `uv run pytest tests/test_chat.py tests/test_mcp_server.py tests/test_llm.py -v` passes
- [ ] Reconnect the `coarse-chat` MCP server in Claude Code and confirm `search_literature` appears as an available tool
- [ ] Run a `search_literature` query and verify a `**Sources:**` section with numbered URLs appears in the result
- [ ] `start_chat` → `ask` → `end_session` round-trip works with a real paper + review

🤖 Generated with [Claude Code](https://claude.com/claude-code)