### PR TITLE
fix(models): cover hyphen-form Opus 4.7 IDs in temperature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`anthropic/claude-opus-4-7` (hyphen form) now hits the temperature gate that was added in v1.4.0 for issue #162.** The v1.4.0 fix added `TEMPERATURE_UNSUPPORTED_PREFIXES` + `supports_temperature(model_id)` in `src/coarse/models.py` so the `temperature` kwarg is omitted for Opus 4.7, but the tuple only contained the OpenRouter ID form `anthropic/claude-opus-4.7` (dot). The same backend ships under hyphen-form IDs on every non-OpenRouter route: `anthropic/claude-opus-4-7` (litellm direct-Anthropic), `vertex_ai/claude-opus-4-7`, and bare `claude-opus-4-7`. Invocations like `uv run coarse-ink review paper.pdf --model anthropic/claude-opus-4-7 --yes` therefore slipped past the gate and 400'd on the first LLM call. Fix: extend `TEMPERATURE_UNSUPPORTED_PREFIXES` with the three hyphen variants; no logic change to `supports_temperature` itself (its existing `startswith` + `removeprefix("openrouter/")` matcher already resolves `openrouter/anthropic/claude-opus-4-7` once the bare prefix is registered). New parametric coverage in `tests/test_models.py` (hyphen direct + OpenRouter-prefixed + Vertex + bare) and a mirrored integration assert in `tests/test_llm.py` proving `complete()` actually drops the kwarg for the hyphen ID. The existing 4.6 test (`test_supports_temperature_true_for_opus_4_6`) remains green — we widened the gate, not slammed it open.
+
 ## v1.4.1 — 2026-04-21
 
 ### Fixed

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -179,9 +179,22 @@ def is_reasoning_model(model_id: str) -> bool:
 # 'stop', 'structured_outputs', 'tool_choice', 'tools', 'verbosity'] — no
 # temperature. The matching 4.6 entry does list it.
 #
+# The same backend ships under two ID conventions depending on the route:
+# OpenRouter uses dots (``anthropic/claude-opus-4.7``), while litellm's
+# direct-Anthropic and Vertex routes use hyphens
+# (``anthropic/claude-opus-4-7``, ``vertex_ai/claude-opus-4-7``, bare
+# ``claude-opus-4-7``). Both hit the same model, so both forms must be
+# listed — the v1.4.0 fix for #162 only registered the dot form, which
+# let ``--model anthropic/claude-opus-4-7`` slip past the gate and 400.
+#
 # Keep this tuple tight — only add a model once a passed-temperature
 # request is confirmed to fail.
-TEMPERATURE_UNSUPPORTED_PREFIXES: tuple[str, ...] = ("anthropic/claude-opus-4.7",)
+TEMPERATURE_UNSUPPORTED_PREFIXES: tuple[str, ...] = (
+    "anthropic/claude-opus-4.7",  # OpenRouter form
+    "anthropic/claude-opus-4-7",  # litellm direct-Anthropic form
+    "vertex_ai/claude-opus-4-7",  # Vertex AI form
+    "claude-opus-4-7",  # bare Anthropic SDK / Bedrock-style ID
+)
 
 
 def supports_temperature(model_id: str) -> bool:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -565,6 +565,27 @@ def test_complete_omits_temperature_for_openrouter_opus_4_7(mock_instructor_clie
     assert "temperature" not in call.kwargs
 
 
+def test_complete_omits_temperature_for_opus_4_7_hyphen(mock_instructor_client):
+    """Hyphen form (litellm direct-Anthropic) must also omit temperature.
+
+    Regression: the v1.4.0 fix only registered the dot form
+    (``anthropic/claude-opus-4.7``) so a user invoking the model via the
+    direct-Anthropic ID slipped past the gate and hit a 400.
+    """
+    client = _build_client("anthropic/claude-opus-4-7", mock_instructor_client)
+
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        client.complete(
+            messages=[{"role": "user", "content": "x"}],
+            response_model=_SimpleModel,
+            max_tokens=256,
+            temperature=0.5,
+        )
+
+    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    assert "temperature" not in call.kwargs
+
+
 def test_complete_forwards_temperature_for_opus_4_6(mock_instructor_client):
     """Opus 4.6 still accepts temperature — make sure we don't over-strip."""
     client = _build_client("anthropic/claude-opus-4.6", mock_instructor_client)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -177,6 +177,27 @@ def test_supports_temperature_false_for_openrouter_opus_4_7():
     assert supports_temperature("openrouter/anthropic/claude-opus-4.7") is False
 
 
+def test_supports_temperature_false_for_opus_4_7_hyphen():
+    """litellm direct-Anthropic ships the hyphen form — must also gate."""
+    assert supports_temperature("anthropic/claude-opus-4-7") is False
+
+
+def test_supports_temperature_false_for_openrouter_opus_4_7_hyphen():
+    """``openrouter/`` prefix is stripped before matching, so the hyphen form
+    routed via OpenRouter still resolves to the gated prefix."""
+    assert supports_temperature("openrouter/anthropic/claude-opus-4-7") is False
+
+
+def test_supports_temperature_false_for_vertex_opus_4_7():
+    """Vertex AI uses the hyphen form with a ``vertex_ai/`` prefix."""
+    assert supports_temperature("vertex_ai/claude-opus-4-7") is False
+
+
+def test_supports_temperature_false_for_bare_opus_4_7():
+    """Bare Anthropic SDK / Bedrock-style ID without a provider prefix."""
+    assert supports_temperature("claude-opus-4-7") is False
+
+
 def test_supports_temperature_true_for_opus_4_6():
     assert supports_temperature("anthropic/claude-opus-4.6") is True
 


### PR DESCRIPTION
## Summary

- The v1.4.0 fix for #162 added `TEMPERATURE_UNSUPPORTED_PREFIXES` + `supports_temperature()` so `temperature` is omitted for Opus 4.7, but the tuple only contained the **OpenRouter** ID form `anthropic/claude-opus-4.7` (dot).
- Invocations using the **direct-Anthropic / Vertex** ID form (hyphen) — e.g. `uv run coarse-ink review paper.pdf --model anthropic/claude-opus-4-7 --yes` — slipped past the gate and 400'd on the first LLM call.
- Fix: extend the tuple with the three hyphen variants (`anthropic/claude-opus-4-7`, `vertex_ai/claude-opus-4-7`, bare `claude-opus-4-7`). No logic change to `supports_temperature` itself — its existing `startswith` + `removeprefix("openrouter/")` matcher already resolves the `openrouter/anthropic/claude-opus-4-7` route once the bare prefix is registered.

## Reproduction (before this PR)

```python
>>> from coarse.models import supports_temperature
>>> supports_temperature("anthropic/claude-opus-4-7")
True   # WRONG — claims temperature is supported, request 400s downstream
>>> supports_temperature("anthropic/claude-opus-4.7")
False  # correct
```

## Tests added

- `tests/test_models.py` — four new asserts: hyphen direct, hyphen via OpenRouter prefix, Vertex form, bare ID.
- `tests/test_llm.py` — mirror of the existing `test_complete_omits_temperature_for_opus_4_7`, using the hyphen ID, to prove `LLMClient.complete()` actually drops the kwarg (not just that the gate function returns False).
- The existing `test_supports_temperature_true_for_opus_4_6` remains green — we widened the gate, not slammed it open for the whole Anthropic family.

## Test plan

- [x] `uv run pytest tests/test_models.py -k temperature -v` — 15 passed
- [x] `uv run pytest tests/test_llm.py -k temperature -v` — 5 passed
- [ ] Reviewer end-to-end repro: `uv run coarse-ink review paper.pdf --model anthropic/claude-opus-4-7 --yes` no longer 400s on the first call (requires `ANTHROPIC_API_KEY`).

Refs #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)