### PR TITLE
fix(security): escape paper-controlled section titles in the progress bar (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### Security
 
+- **Paper-controlled section titles are now sanitized before rendering in the CLI progress bar (issue #190).** The live progress bar (added this cycle) embeds section titles parsed from document headings into the Rich progress description, which has markup enabled and passes raw escape bytes to the terminal — so a crafted heading could inject ANSI/CSI control sequences (color, cursor moves, screen clear, OSC-8 hyperlinks) or Rich markup (`[red]`, `[link=...]`) and spoof/hijack the terminal during a review. A new `_safe_progress_text()` in `src/coarse/cli.py` strips C0/C1 control bytes and escapes Rich markup so titles render as inert literal text; it is applied to both the task-creation and update paths, and the user-supplied filename in the "Reviewing …" line is escaped too. The control-strip must run before the markup escape (escape alone leaves ESC bytes intact). Severity is low — the injected text is the user's own paper in their own terminal during a review they started, and it never reaches the saved `paper_review.md` (synthesis is separate and deterministic). Unit coverage in `tests/test_cli.py`.
+
 - **Cleared all `npm audit` advisories in the `web/` app.** `npm audit fix` bumped `next` to 15.5.18 (resolving the Next.js DoS / middleware-bypass / XSS / cache-poisoning advisories), `ws`, and `@xmldom/xmldom`; an npm `overrides` pin in `web/package.json` forces `next`'s bundled `postcss` to the patched `^8.5.10`, clearing the last moderate advisory. `npm audit --omit=dev` (the CI gate in `.github/workflows/security.yml`) is now clean and `next build` passes.
 
 ## v1.4.1 — 2026-04-21

--- a/src/coarse/cli.py
+++ b/src/coarse/cli.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+import rich.markup
 import typer
 from rich.console import Console
 from rich.progress import (
@@ -102,6 +104,23 @@ def _supports_pipeline_progress() -> bool:
     return console.is_terminal
 
 
+# C0 control chars (except tab/newline/CR), DEL, and C1 control chars. Pipeline
+# stage labels embed paper-controlled section titles (parsed from document
+# headings, otherwise unsanitized), so they can carry raw ANSI/CSI escape bytes
+# (color, cursor moves, screen clear, OSC-8 hyperlinks) and Rich markup tags
+# like [red] / [link=...]. The progress column has markup enabled and passes
+# ESC bytes straight to the terminal, so both must be neutralized.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+def _safe_progress_text(s: str) -> str:
+    """Make a paper-controlled string safe for a Rich progress description:
+    strip control/escape bytes, then escape Rich markup so tags like ``[red]``
+    render as inert literal text instead of being interpreted. The strip must
+    run before the escape — ``markup.escape`` does not remove ESC bytes."""
+    return rich.markup.escape(_CONTROL_CHARS_RE.sub("", s))
+
+
 class _PipelineProgressDisplay:
     """Render live pipeline progress, ETA, and cumulative actual spend."""
 
@@ -140,7 +159,7 @@ class _PipelineProgressDisplay:
         spent = f"${update.actual_cost_usd:.4f}"
         if self._task_id is None:
             self._task_id = self._progress.add_task(
-                update.stage_label,
+                _safe_progress_text(update.stage_label),
                 total=max(1, update.total_stages),
                 completed=update.completed_stages,
                 spent=spent,
@@ -149,7 +168,7 @@ class _PipelineProgressDisplay:
 
         self._progress.update(
             self._task_id,
-            description=update.stage_label,
+            description=_safe_progress_text(update.stage_label),
             total=max(1, update.total_stages),
             completed=update.completed_stages,
             spent=spent,
@@ -280,7 +299,7 @@ def review(
     else:
         out_path = Path(f"{pdf.stem}_review.md")
 
-    console.print(f"[bold]Reviewing[/bold] {pdf.name} with {resolved_model}")
+    console.print(f"[bold]Reviewing[/bold] {rich.markup.escape(pdf.name)} with {resolved_model}")
 
     progress_context = (
         _PipelineProgressDisplay(console) if _supports_pipeline_progress() else nullcontext(None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 import coarse
-from coarse.cli import _PipelineProgressDisplay, app
+from coarse.cli import _PipelineProgressDisplay, _safe_progress_text, app
 from coarse.config import CoarseConfig
 from coarse.progress import PipelineProgress
 from coarse.types import DetailedComment, OverviewFeedback, OverviewIssue, Review
@@ -413,6 +413,26 @@ def test_pipeline_progress_display_starts_lazily():
 
     assert entered == [True]
     assert exited == [True]
+
+
+def test_safe_progress_text_strips_control_chars_and_escapes_markup():
+    """Issue #190: paper-controlled section titles must not inject ANSI/CSI
+    escapes or Rich markup into the live progress bar."""
+    evil = (
+        "Reviewed section 1/3: \x1b[31mRED\x1b[2J"  # SGR color + clear-screen
+        "[red]bold[/red]"  # Rich markup
+        "\x1b]8;;http://evil\x07"  # OSC-8 hyperlink
+    )
+    out = _safe_progress_text(evil)
+
+    assert "\x1b" not in out  # no ESC / ANSI / OSC bytes survive
+    assert "\x07" not in out  # no BEL
+    assert "\\[red]bold\\[/red]" in out  # markup escaped -> renders literally
+    assert "Reviewed section 1/3:" in out  # benign text preserved
+
+
+def test_safe_progress_text_preserves_plain_titles():
+    assert _safe_progress_text("Reviewed section 2/5: Methods") == "Reviewed section 2/5: Methods"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,22 +417,100 @@ def test_pipeline_progress_display_starts_lazily():
 
 def test_safe_progress_text_strips_control_chars_and_escapes_markup():
     """Issue #190: paper-controlled section titles must not inject ANSI/CSI
-    escapes or Rich markup into the live progress bar."""
+    escapes or Rich markup into the live progress bar. Covers the full declared
+    control range: C0 (ESC/BEL), DEL, and 8-bit C1 (CSI \\x9b, DCS \\x90)."""
     evil = (
-        "Reviewed section 1/3: \x1b[31mRED\x1b[2J"  # SGR color + clear-screen
+        "Reviewed section 1/3: \x1b[31mRED\x1b[2J"  # ESC SGR color + clear-screen
         "[red]bold[/red]"  # Rich markup
-        "\x1b]8;;http://evil\x07"  # OSC-8 hyperlink
+        "\x1b]8;;http://evil\x07"  # OSC-8 hyperlink + BEL
+        "\x7f\x9b31m\x90q"  # DEL + 8-bit CSI + DCS (the \x7f-\x9f range)
     )
     out = _safe_progress_text(evil)
 
-    assert "\x1b" not in out  # no ESC / ANSI / OSC bytes survive
-    assert "\x07" not in out  # no BEL
+    for ctrl in ("\x1b", "\x07", "\x7f", "\x9b", "\x90"):
+        assert ctrl not in out, f"control byte {ctrl!r} survived sanitization"
     assert "\\[red]bold\\[/red]" in out  # markup escaped -> renders literally
     assert "Reviewed section 1/3:" in out  # benign text preserved
 
 
 def test_safe_progress_text_preserves_plain_titles():
     assert _safe_progress_text("Reviewed section 2/5: Methods") == "Reviewed section 2/5: Methods"
+    # Empty input and the intentional tab/newline/CR carve-out are preserved.
+    assert _safe_progress_text("") == ""
+    assert _safe_progress_text("a\tb\nc\r") == "a\tb\nc\r"
+
+
+def test_pipeline_progress_display_sanitizes_stage_label():
+    """Issue #190: the callback must route paper-controlled stage labels through
+    _safe_progress_text on BOTH the add_task (first event) and update (later
+    events) paths — guards the wiring, not just the helper."""
+    descriptions: list = []
+
+    class _RecordingProgress:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def add_task(self, description, **kwargs):
+            descriptions.append(description)
+            return 1
+
+        def update(self, task_id, description=None, **kwargs):
+            descriptions.append(description)
+
+    evil = "Reviewed section 1/2: \x1b[2J[red]X[/red]"
+    with patch("coarse.cli.Progress", _RecordingProgress):
+        display = _PipelineProgressDisplay(MagicMock())
+        with display:
+            for completed in (1, 2):  # first event -> add_task, second -> update
+                display.callback(
+                    PipelineProgress(
+                        event="completed",
+                        stage_key="section",
+                        stage_label=evil,
+                        completed_stages=completed,
+                        total_stages=2,
+                        actual_cost_usd=0.0,
+                    )
+                )
+
+    assert len(descriptions) == 2  # both add_task and update were exercised
+    for d in descriptions:
+        assert "\x1b" not in d  # control bytes stripped on both paths
+        assert "\\[red]X\\[/red]" in d  # markup escaped on both paths
+
+
+def test_review_escapes_markup_in_filename(tmp_path, monkeypatch):
+    """Issue #190: a filename containing Rich markup must render as literal text
+    in the "Reviewing …" line, not be interpreted as styling."""
+    monkeypatch.chdir(tmp_path)
+    # No slash (illegal in filenames); an unclosed [red] tag still distinguishes
+    # escaped (renders literally) from unescaped (Rich consumes it as styling).
+    pdf = tmp_path / "[red]paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    def fake(pdf_path, model=None, skip_cost_gate=False, config=None, progress_callback=None):
+        from coarse.types import PaperText
+
+        return _make_review(), "# Test\n", PaperText(full_markdown="", token_estimate=0)
+
+    with (
+        patch("coarse.cli.resolve_api_key", return_value="sk-test"),
+        patch("coarse.cli.load_config", return_value=CoarseConfig()),
+        patch("coarse.cli.review_paper", side_effect=fake),
+        patch("coarse.cli._supports_pipeline_progress", return_value=False),
+    ):
+        result = runner.invoke(app, ["review", str(pdf), "--yes"])
+
+    assert result.exit_code == 0, result.output
+    # Escaped markup survives as literal text. Without the escape, Rich would
+    # consume "[red]" as a style tag and it would vanish from the output.
+    assert "[red]paper.pdf" in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes **#190** — paper-controlled section titles reached the Rich progress bar unescaped, so a crafted heading could inject terminal-control sequences or Rich markup.

## Issue

The live progress bar (new this cycle, #143) embeds section titles — parsed from document headings, otherwise unsanitized — into `TextColumn("[progress.description]{task.description}")`, which has **markup enabled** and passes raw ESC bytes to the terminal. A malicious heading could:
- inject ANSI/CSI escapes (color, cursor moves, `\x1b[2J` screen clear, OSC-8 hyperlinks), or
- inject Rich markup (`[red]`, `[link=...]`) — e.g. to spoof the `spent $` figure or overwrite the real line.

Severity **low**: it's the user's own paper, in their own terminal, during a review they started; it never reaches the saved `paper_review.md` (synthesis is separate and deterministic).

## Fix (`src/coarse/cli.py`, CLI-side — `pipeline.py` keeps no Rich dependency)

New `_safe_progress_text(s)` strips C0/C1 control bytes then `rich.markup.escape`s the result, applied to the `add_task` and `update` descriptions. **Order is load-bearing** — `markup.escape` does not remove ESC bytes, so the control-strip runs first (verified empirically during planning by rendering a malicious label through a real `Console`: `Text(...)` alone does *not* work because `TextColumn` re-stringifies and re-parses markup). The user-supplied filename in the "Reviewing …" line is escaped too.

## Tests

`make check` green (lint + security + 996 passed). New unit tests in `tests/test_cli.py`: a label with `\x1b[31m`, `\x1b[2J`, OSC-8, and `[red]…[/red]` → no ESC/BEL bytes survive, markup renders literally (`\[red]`), benign text preserved; plain titles round-trip unchanged.

Closes #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)