### PR TITLE
feat(models): add Claude Fable 5 + gate its missing temperature param (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **Claude Fable 5 in the model picker (`anthropic/claude-fable-5`, issue #214).** New Anthropic model ($10/$50 per M, 1M context, 128K max output), added as the lead Anthropic option on the web form. Like the recent Opus models it drops the `temperature` param (verified on OpenRouter — `supported_parameters` has no `temperature`), so it's also added to `TEMPERATURE_UNSUPPORTED_PREFIXES` in `models.py`; without that gate coarse would pass `temperature` and 400 on every call (the #162 failure mode). Static smoke tests confirmed the rest is fine — it's not classified as a reasoning model, uses tool-calling (supported), and its 128K max output clears coarse's largest request (32,768). Coverage in `tests/test_models.py`.
+
 ### Fixed
 
 - **The pre-flight cost estimate no longer wildly over-quotes reasoning models (issue #212).** GPT-5.5 quoted ~$81 for a 30k-token paper. The prices were correct ($5/$30 per M); the inflation came from two compounding conservatisms: (1) the per-stage output budgets in `pipeline_spec.STAGE_OUTPUT_TOKENS` were the agents' `max_tokens` *ceilings* (e.g. `section`=10000) rather than expected output, and (2) reasoning models multiplied output by 5× (`reasoningOverheadMultiplier=4`). Recalibrated: the review-model output budgets are trimmed to expected output (`section` 10000→4000, `proof_verify` 16384→6000, `editorial` 24000→12000, `overview` 8192→4096, `completeness` 4096→3072, `cross_section` 8192→4096), and the reasoning overhead multiplier drops 4→1.5 in **both** `pipeline_spec.py` (web estimate, via the regenerated `web/src/data/pipelineSpec.json`) and `llm._REASONING_OVERHEAD_MULTIPLIER` (Python pre-flight gate). GPT-5.5 now estimates ~$20. `STAGE_OUTPUT_TOKENS` is cost-estimate-only — it does **not** bound runtime `max_tokens`, so real outputs are unaffected. The trade-off is a slimmer "never under-quote" margin (chosen deliberately). Coverage updated in `tests/test_cost.py`.

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -241,6 +241,13 @@ TEMPERATURE_UNSUPPORTED_PREFIXES: tuple[str, ...] = (
     # routes that accept it; it only prevents a 400 on routes that don't.
     "openai/gpt-5",  # OpenRouter / litellm OpenAI form (covers all gpt-5*)
     "gpt-5",  # bare OpenAI SDK ID
+    # Claude Fable 5 — like the recent Opus models it drops `temperature`
+    # (verified OpenRouter /api/v1/models 2026-06-09: supported_parameters has
+    # no `temperature`). The name has no version dot, so the OpenRouter and
+    # litellm Anthropic forms are identical.
+    "anthropic/claude-fable-5",  # OpenRouter / litellm Anthropic form
+    "vertex_ai/claude-fable-5",  # Vertex AI form
+    "claude-fable-5",  # bare Anthropic SDK / Bedrock-style ID
 )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -261,6 +261,16 @@ def test_supports_temperature_false_for_gpt_5_family():
     assert supports_temperature("gpt-5.4") is False
 
 
+def test_supports_temperature_false_for_claude_fable_5():
+    """Claude Fable 5 drops temperature like the recent Opus models (issue
+    #214; verified on OpenRouter — supported_parameters has no temperature).
+    The name has no version dot, so all ID forms are identical."""
+    assert supports_temperature("anthropic/claude-fable-5") is False
+    assert supports_temperature("openrouter/anthropic/claude-fable-5") is False
+    assert supports_temperature("vertex_ai/claude-fable-5") is False
+    assert supports_temperature("claude-fable-5") is False
+
+
 def test_supports_temperature_true_for_opus_4_6():
     assert supports_temperature("anthropic/claude-opus-4.6") is True
 

--- a/web/src/components/ModelPicker.tsx
+++ b/web/src/components/ModelPicker.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 
 /* ── Default model options ─────────────────────────────────── */
 const DEFAULT_MODELS = [
+  { id: "anthropic/claude-fable-5", label: "Fable 5", provider: "Anthropic" },
   { id: "anthropic/claude-opus-4.8", label: "Opus 4.8", provider: "Anthropic" },
   { id: "anthropic/claude-sonnet-4.6", label: "Sonnet 4.6", provider: "Anthropic" },
   { id: "openai/gpt-5.5", label: "GPT-5.5", provider: "OpenAI" },


### PR DESCRIPTION
Closes #214.

## What
- Adds **`anthropic/claude-fable-5`** ($10/$50 per M, 1M ctx, 128K max output) to the web model picker as the lead Anthropic option.
- Gates its missing `temperature` param in `TEMPERATURE_UNSUPPORTED_PREFIXES`.

## Why the gate is required
Smoke-testing the model against coarse (no inference needed) surfaced a hard blocker: OpenRouter reports `claude-fable-5` has **no `temperature`** in `supported_parameters` (like Opus 4.7/4.8), but `supports_temperature()` returned `True`, so coarse would send `temperature` and **400 on every call** (the #162 cascade). Now correctly `False` across all ID forms.

## Smoke-test findings (static, free)
| Check | Result |
|---|---|
| temperature param | ❌ unsupported → **gated** (was the blocker) |
| reasoning model | no (tool-calling path, like Opus 4.8) — fine |
| structured output | `structured_outputs`/`tools` supported — fine |
| max output (128K) vs coarse's largest request (32,768) | clears it — fine |
| context (1M) | fine |

So temperature was the only integration blocker; with it gated the pipeline should run.

## Verification
ruff clean · full suite **1042 pass** (+1 `test_models.py` test) · web `tsc` clean · security + doc-sync clean. `src/coarse` change → next release.

**Note:** I couldn't run a *live* inference smoke (no OpenRouter key configured in this environment) — see PR thread for a cheap command to run with your key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)