### PR TITLE
fix(web): stop demanding an OpenRouter key for non-PDF subscription handoffs (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **"Review with my subscription" no longer demands an OpenRouter key for non-PDF uploads (issue #186).** The handoff mechanics already ran `.tex`/`.md`/`.docx`/`.html`/`.epub`/`.txt` sources end-to-end with no OpenRouter key — only PDFs use Mistral OCR; everything else extracts locally, and the literature search quietly falls back to the free arXiv path — but every user-facing surface still demanded a key unconditionally. Worst, the agent prompt's STEP 2 instructed the coding agent to stop a key-free `.tex` review and ask the user for a key it would never use. Now PDF-conditional: `buildAgentPrompt`/`buildLaunchUrl` take an `isPdf` flag (non-PDF sources get an explicit "no OpenRouter key needed — do not ask for one" step), the web-form explainer + handoff modal (`web/src/app/page.tsx`) and the `/h/<token>` landing page render matching copy (`isPdf` is captured at handoff-mint time so swapping the dropzone file afterwards can't flip the guidance for an already-minted handoff), the `/setup` walkthrough marks its OpenRouter step "PDFs only", and the three bundled SKILL.md files gate their key section on PDF. README + `cli_review.py` docstring clarified to match. Drift coverage in `tests/test_headless_instructions.py`. The SKILL.md edits live under `src/coarse/`, so they ship with the next PyPI release; everything else is web/docs-only.
+
 ## v1.7.0 — 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ Or run `coarse setup` to store keys in `~/.coarse/config.toml`.
 If you already have a `claude`, `codex`, or `gemini` CLI logged into its subscription,
 `coarse-review` routes every pipeline LLM call through the local CLI (`claude -p`,
 `codex exec`, `gemini -p`) so reviews bill your Claude Max / ChatGPT Pro / Google AI Pro
-subscription instead of a pay-per-token API. Only the ~$0.05–0.15 Mistral OCR step still
-uses `OPENROUTER_API_KEY` (skip it with `--pre-extracted paper.md`).
+subscription instead of a pay-per-token API. Only the ~$0.05–0.15 Mistral OCR step on
+PDF sources still uses `OPENROUTER_API_KEY` (skip it with `--pre-extracted paper.md`).
+Non-PDF sources (`.tex`, `.md`, `.txt`, `.docx`, `.html`, `.epub`) extract locally, so
+they run entirely on your subscription with no OpenRouter key at all.
 
 ```bash
 coarse-review paper.pdf                          # auto-detects claude → codex → gemini
 coarse-review paper.pdf --host codex --model gpt-5.5
+coarse-review paper.tex                          # .tex/.md/...: no OpenRouter key needed
 ```
 
 Run `coarse install-skills` to register a `/coarse-review` skill in each CLI's skills
@@ -75,7 +78,8 @@ directory, so you can trigger reviews from inside the coding agent itself.
 ## Supported formats
 
 PDF, TXT, Markdown, LaTeX, DOCX, HTML, and EPUB. PDFs use Mistral OCR; other formats use
-Docling (if installed) with lightweight fallbacks. Install optional format support:
+Docling (if installed) with lightweight fallbacks. Only PDF extraction touches OpenRouter —
+every other format is parsed locally. Install optional format support:
 
 ```bash
 pip install coarse-ink[formats]   # DOCX, HTML, EPUB fallbacks

--- a/src/coarse/_skills/claude_code/SKILL.md
+++ b/src/coarse/_skills/claude_code/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 # coarse-review (Claude Code)
 
-Runs the **full coarse review pipeline** on a paper using the local `claude -p` CLI as the LLM backend. Every LLM call the pipeline makes — structure metadata, overview, per-section review, proof verification, editorial dedup — is served by a headless Claude Code subprocess using the user's Claude Max subscription. The only per-paper cost is the ~$0.05-0.15 Mistral OCR extraction, which uses the user's OpenRouter key locally.
+Runs the **full coarse review pipeline** on a paper using the local `claude -p` CLI as the LLM backend. Every LLM call the pipeline makes — structure metadata, overview, per-section review, proof verification, editorial dedup — is served by a headless Claude Code subprocess using the user's Claude Max subscription. The only per-paper cost is the ~$0.05-0.15 Mistral OCR extraction for PDF sources, which uses the user's OpenRouter key locally — non-PDF sources (.tex, .md, .txt, .docx, .html, .epub) extract locally with no OpenRouter key at all.
 
 This is the **same pipeline** that powers coarse.ink — only the LLM backend is swapped.
 
@@ -35,13 +35,13 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
-- **OpenRouter API key required** for Mistral OCR extraction (~$0.10 per paper). Prefer checking for the key with presence-only probes so you don't needlessly echo its value into the transcript, but if the user hands you the key directly just save it — don't lecture them.
+- **OpenRouter API key required for PDF papers only** — Mistral OCR extraction (~$0.10 per paper) runs on PDFs alone. Non-PDF sources (.tex, .md, .txt, .docx, .html, .epub) extract locally and need no OpenRouter key at all: skip the probes below and never block a non-PDF review on a missing key. Prefer checking for the key with presence-only probes so you don't needlessly echo its value into the transcript, but if the user hands you the key directly just save it — don't lecture them.
 
-  Before running the review, check whether `OPENROUTER_API_KEY` is already configured:
+  For PDF papers, before running the review, check whether `OPENROUTER_API_KEY` is already configured:
   - In the environment: `test -n "$OPENROUTER_API_KEY" && echo "env: set" || echo "env: missing"`
   - In a `.env` file in the current directory: `test -f .env && grep -q '^OPENROUTER_API_KEY=' .env && echo ".env: set" || echo ".env: missing"`
 
-  If neither probe reports "set", ask the user:
+  If the paper is a PDF and neither probe reports "set", ask the user:
 
   > I need an OpenRouter API key for the OCR extraction step (~$0.10 per paper). A few options:
   >

--- a/src/coarse/_skills/codex/SKILL.md
+++ b/src/coarse/_skills/codex/SKILL.md
@@ -13,7 +13,7 @@ description: >
 
 # coarse-review (Codex)
 
-Runs the **full coarse review pipeline** on a paper using the local `codex exec` CLI as the LLM backend. Every LLM call is served by a headless Codex subprocess using the user's ChatGPT Plus/Pro/Team plan. The only per-paper cost is the ~$0.05-0.15 Mistral OCR extraction, which uses the user's OpenRouter key locally.
+Runs the **full coarse review pipeline** on a paper using the local `codex exec` CLI as the LLM backend. Every LLM call is served by a headless Codex subprocess using the user's ChatGPT Plus/Pro/Team plan. The only per-paper cost is the ~$0.05-0.15 Mistral OCR extraction for PDF sources, which uses the user's OpenRouter key locally — non-PDF sources (.tex, .md, .txt, .docx, .html, .epub) extract locally with no OpenRouter key at all.
 
 ## Prerequisites
 
@@ -32,13 +32,13 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
-- **OpenRouter API key required** for Mistral OCR extraction (~$0.10 per paper). Prefer checking for the key with presence-only probes so you don't needlessly echo its value into the transcript, but if the user hands you the key directly just save it — don't lecture them.
+- **OpenRouter API key required for PDF papers only** — Mistral OCR extraction (~$0.10 per paper) runs on PDFs alone. Non-PDF sources (.tex, .md, .txt, .docx, .html, .epub) extract locally and need no OpenRouter key at all: skip the probes below and never block a non-PDF review on a missing key. Prefer checking for the key with presence-only probes so you don't needlessly echo its value into the transcript, but if the user hands you the key directly just save it — don't lecture them.
 
-  Before running the review, check whether `OPENROUTER_API_KEY` is already configured:
+  For PDF papers, before running the review, check whether `OPENROUTER_API_KEY` is already configured:
   - In the environment: `test -n "$OPENROUTER_API_KEY" && echo "env: set" || echo "env: missing"`
   - In a `.env` file in the current directory: `test -f .env && grep -q '^OPENROUTER_API_KEY=' .env && echo ".env: set" || echo ".env: missing"`
 
-  If neither probe reports "set", ask the user:
+  If the paper is a PDF and neither probe reports "set", ask the user:
 
   > I need an OpenRouter API key for the OCR extraction step (~$0.10 per paper). A few options:
   >

--- a/src/coarse/_skills/gemini_cli/SKILL.md
+++ b/src/coarse/_skills/gemini_cli/SKILL.md
@@ -13,7 +13,7 @@ description: >
 
 # coarse-review (Gemini)
 
-Runs the **full coarse review pipeline** on a paper using the local `gemini -p` CLI as the LLM backend. Every LLM call is served by a headless Gemini subprocess using the user's Google AI Pro / Ultra subscription. The only per-paper cost is the ~$0.05-0.15 Mistral OCR extraction, which uses the user's OpenRouter key locally.
+Runs the **full coarse review pipeline** on a paper using the local `gemini -p` CLI as the LLM backend. Every LLM call is served by a headless Gemini subprocess using the user's Google AI Pro / Ultra subscription. The only per-paper cost is the ~$0.05-0.15 Mistral OCR extraction for PDF sources, which uses the user's OpenRouter key locally — non-PDF sources (.tex, .md, .txt, .docx, .html, .epub) extract locally with no OpenRouter key at all.
 
 ## Prerequisites
 
@@ -32,13 +32,13 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
-- **OpenRouter API key required** for Mistral OCR extraction (~$0.10 per paper). Prefer checking for the key with presence-only probes so you don't needlessly echo its value into the transcript, but if the user hands you the key directly just save it — don't lecture them.
+- **OpenRouter API key required for PDF papers only** — Mistral OCR extraction (~$0.10 per paper) runs on PDFs alone. Non-PDF sources (.tex, .md, .txt, .docx, .html, .epub) extract locally and need no OpenRouter key at all: skip the probes below and never block a non-PDF review on a missing key. Prefer checking for the key with presence-only probes so you don't needlessly echo its value into the transcript, but if the user hands you the key directly just save it — don't lecture them.
 
-  Before running the review, check whether `OPENROUTER_API_KEY` is already configured:
+  For PDF papers, before running the review, check whether `OPENROUTER_API_KEY` is already configured:
   - In the environment: `test -n "$OPENROUTER_API_KEY" && echo "env: set" || echo "env: missing"`
   - In a `.env` file in the current directory: `test -f .env && grep -q '^OPENROUTER_API_KEY=' .env && echo ".env: set" || echo ".env: missing"`
 
-  If neither probe reports "set", ask the user:
+  If the paper is a PDF and neither probe reports "set", ask the user:
 
   > I need an OpenRouter API key for the OCR extraction step (~$0.10 per paper). A few options:
   >

--- a/src/coarse/cli_review.py
+++ b/src/coarse/cli_review.py
@@ -7,17 +7,19 @@ Usage:
 Two modes:
 
 1. **Local mode** — ``coarse-review paper.pdf`` runs the full coarse
-   pipeline on a local file. Extraction uses the user's OpenRouter
-   key (from env, ~/.coarse/config.toml, or a .env file), review
-   reasoning uses the chosen headless CLI, output is a local markdown
-   file in ``./coarse-output/``.
+   pipeline on a local file. PDF extraction uses the user's OpenRouter
+   key (from env, ~/.coarse/config.toml, or a .env file); non-PDF
+   sources (.tex, .md, .docx, …) extract locally and need no key
+   (#186). Review reasoning uses the chosen headless CLI, output is a
+   local markdown file in ``./coarse-output/``.
 
 2. **Handoff mode** — ``coarse-review --handoff <url>`` pulls a handoff
    bundle minted by the coarse.vercel.app web form (paper download URL
    + finalize token + callback URL). Extraction still happens locally
-   (faster than waiting on the server); the final review gets POSTed
-   back to ``/api/mcp-finalize`` so the user can see it at
-   ``coarse.vercel.app/review/<paper_id>`` in the normal web UI.
+   (faster than waiting on the server, same PDF-only key rule); the
+   final review gets POSTed back to ``/api/mcp-finalize`` so the user
+   can see it at ``coarse.vercel.app/review/<paper_id>`` in the normal
+   web UI.
 """
 
 from __future__ import annotations

--- a/tests/test_headless_instructions.py
+++ b/tests/test_headless_instructions.py
@@ -99,10 +99,11 @@ def test_web_handoff_assets_use_shared_uvx_prompt_flow() -> None:
 
     # page.tsx must pass logFile + attachCmd through to buildAgentPrompt
     # on every call site (handleLaunch + the collapsible manual-commands UI).
-    assert (
-        "const fullPrompt = buildAgentPrompt({ setupCmd, runCmd, attachCmd, logFile });"
-        in handoff_page
-    )
+    assert "const fullPrompt = buildAgentPrompt({" in handoff_page
+    # Every prompt/launch call site must also thread the mint-time isPdf
+    # flag (#186): two buildAgentPrompt call sites + buildLaunchUrl. See
+    # test_handoff_key_guidance_is_pdf_conditional for the branch content.
+    assert handoff_page.count("isPdf: handoffState.isPdf") >= 3
     assert "coarse.ink does not receive or store your" in handoff_page
 
     # The /h/<token> landing-page HTML renderer shares its core runCmd
@@ -131,6 +132,59 @@ def test_web_handoff_assets_use_shared_uvx_prompt_flow() -> None:
     assert '"coarse-ink==1.7.0"' in handoff_lib
     assert "@feat/mcp-server" not in handoff_lib
     assert "@feat/mcp-server" not in handoff_route
+
+
+def test_handoff_key_guidance_is_pdf_conditional() -> None:
+    """Issue #186: only PDF sources run Mistral OCR, so only PDF handoffs
+    may tell the agent (or the user) to configure an OpenRouter key.
+
+    Non-PDF sources (.tex, .md, .docx, …) extract locally with no key
+    anywhere in the pipeline — the literature search falls back to the
+    free arXiv path when no key is set. Before this gate,
+    ``buildAgentPrompt``'s STEP 2 unconditionally instructed the coding
+    agent to stop and ask the user for an OpenRouter key, blocking
+    key-free .tex reviews on a key that would never be used. Pin every
+    surface that branches on the flag so a refactor can't quietly
+    revert any of them to the unconditional key demand.
+    """
+    handoff_lib = _read("web/src/lib/mcpHandoff.ts")
+    handoff_page = _read("web/src/app/page.tsx")
+    handoff_route = _read("web/src/app/h/[token]/route.ts")
+
+    # buildAgentPrompt takes the flag and branches STEP 2 on it.
+    assert "isPdf: boolean;" in handoff_lib
+    assert "const step2 = isPdf" in handoff_lib
+    # PDF branch: the key request must still exist verbatim.
+    assert "I need an OpenRouter API key for the Mistral OCR extraction step" in handoff_lib
+    # Non-PDF branch: explicit no-key + do-not-ask instruction.
+    assert "No OpenRouter API key is needed for this review" in handoff_lib
+    assert "ask me for an OpenRouter key" in handoff_lib
+
+    # page.tsx captures isPdf at handoff-mint time — from the uploaded
+    # file's name, not the live dropzone state — so swapping the file
+    # after minting can't flip the guidance for an existing handoff.
+    assert 'isPdf: file.name.toLowerCase().endsWith(".pdf")' in handoff_page
+    # And the modal + explainer copy branch on it.
+    assert "handoffState.isPdf ?" in handoff_page
+    assert "selectedFileIsPdf" in handoff_page
+    assert "No OpenRouter key needed for this paper" in handoff_page
+
+    # The /h/<token> landing page derives the flag from the stored
+    # filename extension and renders the matching key note.
+    assert 'isPdf: ext === ".pdf"' in handoff_route
+    assert "No OpenRouter key needed:" in handoff_route
+    assert "OpenRouter key:</strong> PDF sources use Mistral OCR" in handoff_route
+
+    # The three bundled skills gate their key section on PDF too.
+    for skill in (
+        "src/coarse/_skills/claude_code/SKILL.md",
+        "src/coarse/_skills/codex/SKILL.md",
+        "src/coarse/_skills/gemini_cli/SKILL.md",
+    ):
+        text = _read(skill)
+        assert "OpenRouter API key required for PDF papers only" in text, skill
+        assert "If the paper is a PDF and neither probe reports" in text, skill
+        assert "never block a non-PDF review on a missing key" in text, skill
 
 
 def test_submit_route_handoff_retry_checks_review_status() -> None:

--- a/web/src/app/h/[token]/route.ts
+++ b/web/src/app/h/[token]/route.ts
@@ -204,6 +204,7 @@ export async function GET(
     paperTitle: reviewRow.paper_filename ?? "your paper",
     paperId: tokenRow.paper_id,
     siteUrl,
+    isPdf: ext === ".pdf",
   });
   return new NextResponse(html, {
     status: 200,
@@ -263,8 +264,9 @@ function renderLandingPage(args: {
   paperTitle: string;
   paperId: string;
   siteUrl: string;
+  isPdf: boolean;
 }): string {
-  const { handoffUrl, paperTitle, paperId, siteUrl } = args;
+  const { handoffUrl, paperTitle, paperId, siteUrl, isPdf } = args;
   const safe = (s: string) => escapeHtml(s);
   const siteHost = (() => {
     try {
@@ -285,6 +287,13 @@ function renderLandingPage(args: {
     handoffUrl,
     paperId,
   });
+
+  // Only PDF sources run Mistral OCR (and therefore need an OpenRouter
+  // key on the user's machine); every other format extracts locally with
+  // no key at all (#186).
+  const keyNote = isPdf
+    ? `<p class="note"><strong>OpenRouter key:</strong> PDF sources use Mistral OCR (~$0.10 per paper), so <code>OPENROUTER_API_KEY</code> must be available on this machine — env var, <code>.env</code>, or <code>~/.coarse/config.toml</code>. If it's missing, the run fails fast with setup instructions.</p>`
+    : `<p class="note"><strong>No OpenRouter key needed:</strong> this file is not a PDF, so extraction runs locally without the Mistral OCR step.</p>`;
 
   return `<!doctype html>
 <html lang="en">
@@ -334,6 +343,7 @@ function renderLandingPage(args: {
     <pre class="cmd" id="run"><button class="copy" onclick="copy('run')">copy</button>${safe(runCmd)}</pre>
     <p class="note">Starts a detached local review worker, writes its PID to <code>${safe(logFile)}.pid</code>, streams all output to <code>${safe(logFile)}</code>, and returns within 2 seconds. The review will appear at <code>${safe(siteHost)}/review/${safe(paperId)}?token=…</code> when it's done — the <code>view:</code> line in the log has the full tokened URL.</p>
     <p class="note"><strong>Options:</strong> edit the command before running to add <code>--host claude|codex|gemini</code> (default: first CLI found on PATH), <code>--model &lt;id&gt;</code>, and <code>--effort low|medium|high|max</code>.</p>
+    ${keyNote}
   </div>
 
   <div class="step">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -339,8 +339,11 @@ export default function Home() {
   type HandoffPhase = "idle" | "extracting" | "ready" | "failed";
   const [mcpPickerOpen, setMcpPickerOpen] = useState(false);
   const [handoffPhase, setHandoffPhase] = useState<HandoffPhase>("idle");
+  // isPdf is captured at handoff-mint time (not derived from the live
+  // `file` state) so swapping the dropzone file after minting can't
+  // flip the key guidance for an already-minted handoff (#186).
   const [handoffState, setHandoffState] = useState<{
-    paperId: string; host: ChatHost;
+    paperId: string; host: ChatHost; isPdf: boolean;
   } | null>(null);
   const [handoffMessage, setHandoffMessage] = useState<string>("");
   const [handoffBundle, setHandoffBundle] = useState<CliHandoffBundle | null>(null);
@@ -852,7 +855,11 @@ export default function Home() {
       setSelectedEffort("high");
 
       setHandoffBundle(bundle);
-      setHandoffState({ paperId: id, host });
+      setHandoffState({
+        paperId: id,
+        host,
+        isPdf: file.name.toLowerCase().endsWith(".pdf"),
+      });
       setHandoffPhase("ready");
       setHandoffMessage("");
     } catch (err) {
@@ -895,7 +902,9 @@ export default function Home() {
     // the custom URL scheme. On some browsers (notably on Windows),
     // awaiting an async clipboard write can consume user activation and
     // cause codex:// / claude:// launches to be blocked.
-    const fullPrompt = buildAgentPrompt({ setupCmd, runCmd, attachCmd, logFile });
+    const fullPrompt = buildAgentPrompt({
+      setupCmd, runCmd, attachCmd, logFile, isPdf: handoffState.isPdf,
+    });
     navigator.clipboard.writeText(fullPrompt).catch((err) => {
       console.error("clipboard write failed", err);
     });
@@ -906,7 +915,9 @@ export default function Home() {
     // timer: if the OS never switches focus to another app, the scheme
     // didn't resolve and we swap in a "didn't work — paste the commands
     // instead" hint so the user isn't stuck.
-    const launchUrl = buildLaunchUrl({ host, runCmd, setupCmd, attachCmd, logFile });
+    const launchUrl = buildLaunchUrl({
+      host, runCmd, setupCmd, attachCmd, logFile, isPdf: handoffState.isPdf,
+    });
     if (!launchUrl) {
       setLaunchStatus("Command copied to clipboard. Paste it into your terminal.");
       return;
@@ -966,6 +977,10 @@ export default function Home() {
   const handoffBusy = handoffPhase === "extracting";
   const canHandoff =
     !!file && !handoffBusy && !submitting && accepting && turnstileReadyForSubmit;
+  // Non-PDF sources (.tex, .md, .docx, …) skip Mistral OCR in the handoff
+  // flow — extraction is local, so no OpenRouter key is needed anywhere
+  // (#186). With no file selected yet, default to the PDF copy.
+  const selectedFileIsPdf = !file || file.name.toLowerCase().endsWith(".pdf");
 
   return (
     <div style={{ background: "var(--board)", minHeight: "100vh" }}>
@@ -1671,9 +1686,21 @@ export default function Home() {
                 <a href="https://claude.ai/download" target="_blank" rel="noopener noreferrer" style={{ color: "var(--blue-chalk)", textDecoration: "none" }}>Claude Code</a>,{" "}
                 <a href="https://github.com/openai/codex" target="_blank" rel="noopener noreferrer" style={{ color: "var(--blue-chalk)", textDecoration: "none" }}>Codex</a>, or{" "}
                 <a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener noreferrer" style={{ color: "var(--blue-chalk)", textDecoration: "none" }}>Gemini CLI</a>{" "}
-                subscription for the LLM reasoning. You only pay ~$0.10 for the
-                local Mistral OCR step (with your own OpenRouter key). Review
-                shows up on this page when done.
+                subscription for the LLM reasoning.{" "}
+                {selectedFileIsPdf ? (
+                  <>
+                    You only pay ~$0.10 for the local Mistral OCR step (with
+                    your own OpenRouter key); non-PDF uploads (.tex, .md,
+                    .docx, …) skip OCR and need no OpenRouter key.
+                  </>
+                ) : (
+                  <>
+                    Your file is not a PDF, so it skips the Mistral OCR step
+                    entirely — the whole run is covered by your subscription,
+                    no OpenRouter key needed.
+                  </>
+                )}{" "}
+                Review shows up on this page when done.
               </p>
               <p
                 style={{
@@ -1766,7 +1793,10 @@ export default function Home() {
                         Paste this prompt into your {HOST_LABELS[host]} terminal:
                       </div>
                       <CodeBlock
-                        text={buildAgentPrompt({ setupCmd, runCmd, attachCmd, logFile })}
+                        text={buildAgentPrompt({
+                          setupCmd, runCmd, attachCmd, logFile,
+                          isPdf: handoffState.isPdf,
+                        })}
                         maxHeight="160px"
                       />
                       <p
@@ -1782,23 +1812,39 @@ export default function Home() {
                         the full review locally, and take 10&ndash;25 minutes.
                         Your provider login stays on your machine.
                       </p>
-                      <p
-                        style={{
-                          fontFamily: "var(--font-chalk)",
-                          fontSize: "0.92rem",
-                          color: "var(--yellow-chalk)",
-                          margin: "0.5rem 0 0",
-                          lineHeight: 1.5,
-                        }}
-                      >
-                        Your OpenRouter key needs to be on your machine first
-                        — export <code style={{ fontFamily: "var(--font-space-mono), monospace", fontSize: "0.88rem" }}>OPENROUTER_API_KEY</code>,
-                        or put it in <code style={{ fontFamily: "var(--font-space-mono), monospace", fontSize: "0.88rem" }}>.env</code>{" "}
-                        or <code style={{ fontFamily: "var(--font-space-mono), monospace", fontSize: "0.88rem" }}>~/.coarse/config.toml</code>.
-                        We don&apos;t pass it through the browser because the
-                        handoff URL ends up in your agent&apos;s chat log. If
-                        it&apos;s missing, the agent will ask.
-                      </p>
+                      {handoffState.isPdf ? (
+                        <p
+                          style={{
+                            fontFamily: "var(--font-chalk)",
+                            fontSize: "0.92rem",
+                            color: "var(--yellow-chalk)",
+                            margin: "0.5rem 0 0",
+                            lineHeight: 1.5,
+                          }}
+                        >
+                          Your OpenRouter key needs to be on your machine first
+                          — export <code style={{ fontFamily: "var(--font-space-mono), monospace", fontSize: "0.88rem" }}>OPENROUTER_API_KEY</code>,
+                          or put it in <code style={{ fontFamily: "var(--font-space-mono), monospace", fontSize: "0.88rem" }}>.env</code>{" "}
+                          or <code style={{ fontFamily: "var(--font-space-mono), monospace", fontSize: "0.88rem" }}>~/.coarse/config.toml</code>.
+                          We don&apos;t pass it through the browser because the
+                          handoff URL ends up in your agent&apos;s chat log. If
+                          it&apos;s missing, the agent will ask.
+                        </p>
+                      ) : (
+                        <p
+                          style={{
+                            fontFamily: "var(--font-chalk)",
+                            fontSize: "0.92rem",
+                            color: "var(--dust)",
+                            margin: "0.5rem 0 0",
+                            lineHeight: 1.5,
+                          }}
+                        >
+                          No OpenRouter key needed for this paper — it&apos;s
+                          not a PDF, so extraction runs locally without the
+                          Mistral OCR step.
+                        </p>
+                      )}
                     </div>
 
                     {/* Review URL */}

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -953,7 +953,7 @@ function SubscriptionTab() {
         </Step>
 
         {/* Step 2 */}
-        <Step number={2} title="Put an OpenRouter key on your machine">
+        <Step number={2} title="Put an OpenRouter key on your machine (PDFs only)">
           <p
             style={{
               fontFamily: "Georgia, serif",
@@ -963,8 +963,11 @@ function SubscriptionTab() {
               margin: "0 0 0.75rem",
             }}
           >
-            coarse still needs OpenRouter for the OCR step (~$0.10 per
-            paper). Follow the{" "}
+            This step only applies to PDF papers — non-PDF sources
+            (.tex, .md, .docx, …) are extracted locally without OCR, so
+            they need no OpenRouter key anywhere and you can skip
+            straight to step 3. For PDFs, coarse still needs OpenRouter
+            for the OCR step (~$0.10 per paper). Follow the{" "}
             <strong style={{ color: "var(--chalk-bright)" }}>
               OpenRouter key
             </strong>{" "}
@@ -1039,7 +1042,8 @@ function SubscriptionTab() {
             >
               main page
             </a>
-            , drop your PDF onto the form, then click the{" "}
+            , drop your paper (PDF, .tex, .md, .docx, …) onto the form,
+            then click the{" "}
             <strong style={{ color: "var(--chalk-bright)" }}>
               Review with my subscription ▾
             </strong>{" "}

--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -1,9 +1,9 @@
 // Handoff helpers for the "Review with my subscription" button on the
 // coarse web form. The flow is:
 //
-//   1. User uploads PDF via /api/presign + direct Supabase Storage PUT
-//      (same path as the regular OpenRouter review — no extraction
-//      triggered).
+//   1. User uploads the paper (any supported format) via /api/presign +
+//      direct Supabase Storage PUT (same path as the regular OpenRouter
+//      review — no extraction triggered).
 //   2. User clicks "Review with Claude Code / Codex / Gemini CLI".
 //   3. Frontend POSTs to /api/cli-handoff which mints a short-lived
 //      finalize_token (3h, see FINALIZE_TOKEN_TTL_MINUTES) bound to
@@ -17,9 +17,12 @@
 //          [--effort ...]`
 //   5. The user's local `coarse-review` command:
 //        a. Fetches the bundle from /h/<token> as JSON
-//        b. Downloads the raw PDF from the signed URL inside the bundle
-//        c. Extracts locally with their OpenRouter key (from
-//           ~/.coarse/config.toml or .env)
+//        b. Downloads the raw source file from the signed URL inside
+//           the bundle
+//        c. Extracts locally. Only PDFs need the user's OpenRouter key
+//           (from ~/.coarse/config.toml or .env) for Mistral OCR;
+//           non-PDF sources (.tex, .md, .docx, …) parse locally with
+//           no key at all (#186)
 //        d. Runs the full coarse pipeline, routing every LLM call
 //           through the chosen headless CLI
 //        e. POSTs the rendered review back to /api/mcp-finalize with
@@ -154,15 +157,55 @@ export const HOST_LAUNCH_HINT: Record<ChatHost, string> = {
  * so Claude Code's Bash tool sees stdout activity. One agent-visible
  * Bash call covers the full 10-25min wait instead of 10-25 separate
  * per-poll approval prompts.
+ *
+ * ``isPdf`` gates STEP 2 (the OpenRouter key check). Only PDF sources
+ * run Mistral OCR; non-PDF uploads (.tex, .md, .docx, …) extract
+ * locally with no OpenRouter key, so for them STEP 2 explicitly tells
+ * the agent NOT to ask for or configure a key (#186). Without this
+ * gate, agents stopped a key-free .tex review to demand a key it
+ * would never use.
  */
 export function buildAgentPrompt(args: {
   setupCmd: string;
   runCmd: string;
   attachCmd: string;
   logFile: string;
+  isPdf: boolean;
 }): string {
-  const { setupCmd, runCmd, attachCmd, logFile } = args;
+  const { setupCmd, runCmd, attachCmd, logFile, isPdf } = args;
   const configCmd = setupCmd.replace("coarse install-skills --all --force", "coarse setup");
+  const step2 = isPdf
+    ? `STEP 2 — Check for an OpenRouter API key without printing its ` +
+      `value. Prefer presence-only probes so the key doesn't needlessly ` +
+      `show up in the chat transcript:\n\n` +
+      `  test -n "$OPENROUTER_API_KEY" && echo "env: set" || echo "env: missing"\n` +
+      `  test -f .env && grep -q '^OPENROUTER_API_KEY=' .env && echo ".env: set" || echo ".env: missing"\n\n` +
+      `If neither probe reports "set", tell me:\n\n` +
+      `  "I need an OpenRouter API key for the Mistral OCR extraction step ` +
+      `(~$0.10 per paper). A few options:\n` +
+      `   1. Paste the key here and I'll save it to ~/.coarse/config.toml ` +
+      `via \`${configCmd}\`. Heads up that whatever you paste here passes ` +
+      `through the LLM provider (Anthropic / OpenAI / Google), so treat ` +
+      `the key as slightly less private than one you typed into a local ` +
+      `terminal — rotate at https://openrouter.ai/settings/keys if that ` +
+      `worries you.\n` +
+      `   2. Set it yourself in a separate terminal and come back: ` +
+      `\`export OPENROUTER_API_KEY=sk-or-v1-...\` or add it to a \`.env\` ` +
+      `file in your current directory.\n` +
+      `   3. Run \`${configCmd}\` in a separate terminal yourself and ` +
+      `paste the key into its interactive prompt — the key lands in ` +
+      `~/.coarse/config.toml without touching this chat at all.\n` +
+      `   Which do you want?"\n\n` +
+      `If I paste the key into chat, just save it — run \`${configCmd}\` ` +
+      `with the pasted value and confirm it's stored. No need to lecture ` +
+      `me about it; I already know what I'm doing.`
+    : `STEP 2 — No OpenRouter API key is needed for this review. The ` +
+      `paper is not a PDF, so coarse-review extracts it locally without ` +
+      `the Mistral OCR step. (If a key happens to be configured it is ` +
+      `only used opportunistically for the ~$0.03 Perplexity literature ` +
+      `search; without one, a free arXiv fallback runs instead.) Do NOT ` +
+      `ask me for an OpenRouter key and do NOT pause the workflow to ` +
+      `configure one.`;
   return (
     `Please review an academic paper for me using the coarse-review skill. ` +
     `The paper is a REMOTE resource — its source URL is already embedded ` +
@@ -187,30 +230,7 @@ export function buildAgentPrompt(args: {
     `either way because uvx is already loading the coarse bundle via ` +
     `\`--from\`.\n\n` +
     `${setupCmd}\n\n` +
-    `STEP 2 — Check for an OpenRouter API key without printing its ` +
-    `value. Prefer presence-only probes so the key doesn't needlessly ` +
-    `show up in the chat transcript:\n\n` +
-    `  test -n "$OPENROUTER_API_KEY" && echo "env: set" || echo "env: missing"\n` +
-    `  test -f .env && grep -q '^OPENROUTER_API_KEY=' .env && echo ".env: set" || echo ".env: missing"\n\n` +
-    `If neither probe reports "set", tell me:\n\n` +
-    `  "I need an OpenRouter API key for the Mistral OCR extraction step ` +
-    `(~$0.10 per paper). A few options:\n` +
-    `   1. Paste the key here and I'll save it to ~/.coarse/config.toml ` +
-    `via \`${configCmd}\`. Heads up that whatever you paste here passes ` +
-    `through the LLM provider (Anthropic / OpenAI / Google), so treat ` +
-    `the key as slightly less private than one you typed into a local ` +
-    `terminal — rotate at https://openrouter.ai/settings/keys if that ` +
-    `worries you.\n` +
-    `   2. Set it yourself in a separate terminal and come back: ` +
-    `\`export OPENROUTER_API_KEY=sk-or-v1-...\` or add it to a \`.env\` ` +
-    `file in your current directory.\n` +
-    `   3. Run \`${configCmd}\` in a separate terminal yourself and ` +
-    `paste the key into its interactive prompt — the key lands in ` +
-    `~/.coarse/config.toml without touching this chat at all.\n` +
-    `   Which do you want?"\n\n` +
-    `If I paste the key into chat, just save it — run \`${configCmd}\` ` +
-    `with the pasted value and confirm it's stored. No need to lecture ` +
-    `me about it; I already know what I'm doing.\n\n` +
+    `${step2}\n\n` +
     `STEP 3 — Launch the detached review. Run the EXACT command below, ` +
     `verbatim. Do not substitute, rewrite, or interpret any argument — ` +
     `every piece is already filled in. The \`--handoff\` URL is the ` +
@@ -309,9 +329,10 @@ export function buildLaunchUrl(args: {
   setupCmd: string;
   attachCmd: string;
   logFile: string;
+  isPdf: boolean;
 }): string {
-  const { host, runCmd, setupCmd, attachCmd, logFile } = args;
-  const prompt = buildAgentPrompt({ setupCmd, runCmd, attachCmd, logFile });
+  const { host, runCmd, setupCmd, attachCmd, logFile, isPdf } = args;
+  const prompt = buildAgentPrompt({ setupCmd, runCmd, attachCmd, logFile, isPdf });
 
   if (host === "codex") {
     // Codex supports codex://new?prompt=<text> deep links that pre-fill


### PR DESCRIPTION
Closes the remaining piece of #186 (the deferred web-flow work from triage).

## Problem

The "Review with my subscription" handoff already ran `.tex`/`.md`/`.docx`/`.html`/`.epub`/`.txt` sources end-to-end with **no OpenRouter key**: only PDFs hit Mistral OCR (`extract_file` routes non-PDF through Docling/regex locally), the `cli_review` preflight only gates `.pdf`, and the literature search falls back to the free arXiv path when no key is set. But every user-facing surface still demanded a key unconditionally. Worst of all, `buildAgentPrompt`'s STEP 2 instructed the coding agent to **stop the review and ask the user for an OpenRouter key** it would never use — exactly the friction the issue reporter described for `.tex` uploads.

## Changes

- **`web/src/lib/mcpHandoff.ts`** — `buildAgentPrompt` / `buildLaunchUrl` take an `isPdf` flag. PDF prompts keep the existing presence-probe + ask-user step verbatim; non-PDF prompts get an explicit "no OpenRouter key is needed — do NOT ask me for one / do NOT pause" STEP 2 (with the Perplexity-vs-arXiv lit-search nuance noted).
- **`web/src/app/page.tsx`** — `handoffState` captures `isPdf` at mint time (so swapping the dropzone file after minting can't flip the guidance for an already-minted handoff); both `buildAgentPrompt` call sites + `buildLaunchUrl` thread it; the subscription explainer and the modal's yellow key warning branch on it.
- **`web/src/app/h/[token]/route.ts`** — landing page renders a per-format key note (PDF: have the key on this machine; non-PDF: no key needed).
- **`src/coarse/_skills/{claude_code,codex,gemini_cli}/SKILL.md`** — key section is now "required for PDF papers only", probes + ask-user text gated on PDF, "never block a non-PDF review on a missing key". Presence-only probe strings unchanged (pinned by `test_web_security_invariants.py`).
- **Docs** — README (subscription + supported-formats sections), `/setup` step 2 ("PDFs only") + step 3, `cli_review.py` docstring.
- **Tests** — `tests/test_headless_instructions.py`: updated the pinned `buildAgentPrompt` call-site assertion and added `test_handoff_key_guidance_is_pdf_conditional` pinning every surface above.

No pipeline behavior change. The SKILL.md/`cli_review.py` edits are under `src/coarse/` (docstrings/markdown only) and ship with the next PyPI release; the rest is web/docs.

## Validation

- `uv run pytest tests/ -q` → 1043 passed
- `uv run ruff check src/ tests/` → clean
- `python3 scripts/security_scanner.py` → clean
- `bash scripts/doc-sync-check.sh` → OK
- `npx tsc --noEmit` in `web/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)