### PR TITLE
feat(i18n): localize setup + compare pages; follow site language (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-### Changed
+### Added
+
+- **The setup (configuration) and compare (side-by-side) pages now follow the selected site language (issue #239).** These were the last two routes still rendering hardcoded English after a language switch. Both are now wired to the existing site-i18n layer (each wraps its client tree in `SiteLanguageProvider` via a `*Body` split; the choice persists in `localStorage`). 140 new keys (108 for `setup/page.tsx`, 32 for `ComparePage.tsx`) were externalized into the catalog and translated into all 11 non-English locales by per-language Opus-4.8 agents (additive-only — the existing 292 audited values are untouched), bringing every catalog to **432 keys**. Localized **UI chrome only**: the embedded example reviews/papers on the compare page and the LLM-judge prompt constants stay as data/English. English render is byte-identical (en values copy the prior literals verbatim). Coverage: `tests/test_web_site_i18n.py` updated to assert 432 keys; the `test_setup_page_warns_about_provisioning_keys` drift guard repointed to the catalog (where the "User not found" provisioning-key copy now lives). With this, **every** user-facing page — submit, status, review, setup, compare — follows the site language. Web-only; Vercel build is the TS gate.
 
 - **Dutch (`nl`) site-UI wording refinements** (issue #235). A pass over the Dutch site-UI catalog to make a handful of strings read more naturally — e.g. `spammap`→`spamfolder`, `We e-mailen je`→`We mailen je`, and a couple of smoother phrasings. Word-choice only: all 292 keys, fragment spacing, and brand tokens unchanged. `web/src/lib/i18n/nl.ts` only — web-only, no PyPI release.
 

--- a/tests/test_extraction_openrouter.py
+++ b/tests/test_extraction_openrouter.py
@@ -69,19 +69,29 @@ def test_setup_page_warns_about_provisioning_keys() -> None:
     classifier returns, so the drift surfaces at CI time rather than
     in a confused user's status page.
     """
-    setup = Path(__file__).resolve().parents[1] / "web" / "src" / "app" / "setup" / "page.tsx"
+    root = Path(__file__).resolve().parents[1]
+    setup = root / "web" / "src" / "app" / "setup" / "page.tsx"
     assert setup.exists(), "web/src/app/setup/page.tsx must exist"
     src = setup.read_text(encoding="utf-8")
 
-    assert "provisioning" in src.lower(), (
-        "setup page Step 3 must name the wrong key type ('provisioning' / "
-        "'management') so users can self-diagnose. See the classifier "
-        "message in src/coarse/extraction_openrouter.py."
+    # The Step-3 provisioning-key guidance was externalized to the site-UI i18n
+    # catalog when the setup page was localized; setup/page.tsx now renders it via
+    # t("setupOrStep3Provisioning"). Assert the page still surfaces that key AND
+    # the English catalog still carries the exact cross-referenced copy.
+    assert "setupOrStep3Provisioning" in src, (
+        "setup page Step 3 must still render the provisioning-key warning via "
+        "t('setupOrStep3Provisioning')."
     )
-    assert "User not found" in src, (
-        "setup page Step 3 must quote the exact 'User not found' error "
-        "string users will see if they paste a provisioning key; drops "
-        "the cross-reference with _classify_api_error otherwise."
+    en_catalog = (root / "web" / "src" / "lib" / "i18n" / "en.ts").read_text(encoding="utf-8")
+    assert "provisioning" in en_catalog.lower(), (
+        "en.ts must name the wrong key type ('provisioning' / 'management') so "
+        "users can self-diagnose. See the classifier message in "
+        "src/coarse/extraction_openrouter.py."
+    )
+    assert "User not found" in en_catalog, (
+        "en.ts must quote the exact 'User not found' error string users will see "
+        "if they paste a provisioning key; drops the cross-reference with "
+        "_classify_api_error otherwise."
     )
 
 

--- a/tests/test_web_site_i18n.py
+++ b/tests/test_web_site_i18n.py
@@ -52,9 +52,9 @@ def test_all_locale_catalogs_exist():
 
 
 def test_english_catalog_has_expected_key_count():
-    # 292 keys after the status/review-page localization follow-up (was 139 for
-    # the submit page + chrome alone). Guards an accidental key drop in en.
-    assert len(_keys(_read("en"))) == 292
+    # 432 keys after the setup + compare pages were localized (292 for submit +
+    # status + review chrome, + 140 for setup/compare). Guards a key drop in en.
+    assert len(_keys(_read("en"))) == 432
 
 
 def test_every_locale_defines_exactly_the_english_keys():

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -3,11 +3,13 @@
 import { useState } from "react";
 
 import { CharcoalRule } from "@/components/charcoal";
+import { SiteLanguageProvider, useSiteLanguageContext } from "@/lib/i18n";
 
 type SetupTab = "openrouter" | "subscription";
 
 /* ── Header (matching landing page) ──────────────────────── */
 function Header() {
+  const { t } = useSiteLanguageContext();
   return (
     <header
       style={{
@@ -39,7 +41,7 @@ function Header() {
             color: "var(--dust)",
           }}
         >
-          peer review is a public good.
+          {t("headerTagline")}
         </span>
       </div>
       <div style={{ display: "flex", alignItems: "baseline", gap: "1.5rem" }}>
@@ -50,7 +52,7 @@ function Header() {
             color: "var(--chalk)",
           }}
         >
-          setup
+          {t("navSetup")}
         </span>
         <a
           href="/compare"
@@ -62,7 +64,7 @@ function Header() {
             transition: "color 0.2s",
           }}
         >
-          side-by-side
+          {t("navSideBySide")}
         </a>
         <a
           href="https://github.com/Davidvandijcke/coarse"
@@ -76,7 +78,7 @@ function Header() {
             transition: "color 0.2s",
           }}
         >
-          github ↗
+          {t("navGithub")}
         </a>
       </div>
     </header>
@@ -239,6 +241,7 @@ function TabSwitcher({
   active: SetupTab;
   onChange: (tab: SetupTab) => void;
 }) {
+  const { t } = useSiteLanguageContext();
   const tabStyle = (isActive: boolean): React.CSSProperties => ({
     padding: "0.625rem 1.25rem",
     fontFamily: "var(--font-chalk)",
@@ -255,7 +258,7 @@ function TabSwitcher({
   return (
     <div
       role="tablist"
-      aria-label="Setup path"
+      aria-label={t("setupTablistAriaLabel")}
       style={{
         display: "flex",
         gap: "0.75rem",
@@ -271,7 +274,7 @@ function TabSwitcher({
         onClick={() => onChange("openrouter")}
         style={tabStyle(active === "openrouter")}
       >
-        OpenRouter key
+        {t("setupTabOpenRouter")}
       </button>
       <button
         role="tab"
@@ -280,7 +283,7 @@ function TabSwitcher({
         onClick={() => onChange("subscription")}
         style={tabStyle(active === "subscription")}
       >
-        Use my subscription
+        {t("setupTabSubscription")}
       </button>
     </div>
   );
@@ -288,6 +291,7 @@ function TabSwitcher({
 
 /* ── OpenRouter tab (direct key flow) ────────────────────── */
 function OpenRouterTab() {
+  const { t } = useSiteLanguageContext();
   return (
     <>
       <section style={{ padding: "1.5rem 0 2.5rem" }}>
@@ -302,7 +306,7 @@ function OpenRouterTab() {
             color: "var(--chalk-bright)",
           }}
         >
-          Get your OpenRouter key
+          {t("setupOrHeading")}
         </h1>
         <p
           style={{
@@ -313,8 +317,7 @@ function OpenRouterTab() {
             fontSize: "1.05rem",
           }}
         >
-          Takes about 2 minutes. You&apos;ll need a credit card for ~$1 in
-          credits to get started &mdash; you&apos;ll top up to $20 in step 2.
+          {t("setupOrIntro")}
         </p>
           <div
             style={{
@@ -334,12 +337,10 @@ function OpenRouterTab() {
                 margin: 0,
               }}
             >
-              <strong style={{ color: "var(--chalk-bright)" }}>Faster option:</strong>{" "}
-              on the main form you can click{" "}
-              <strong style={{ color: "var(--chalk-bright)" }}>&ldquo;Log in with OpenRouter&rdquo;</strong>{" "}
-              to authorize coarse and skip manual key creation. You still need an
-              OpenRouter account with credits (steps 1 and 2 below), and we still
-              recommend setting a per-key spend limit (step 4).
+              <strong style={{ color: "var(--chalk-bright)" }}>{t("setupOrFasterLabel")}</strong>
+              {t("setupOrFasterMid1")}
+              <strong style={{ color: "var(--chalk-bright)" }}>{t("setupOrFasterLogIn")}</strong>
+              {t("setupOrFasterSuffix")}
             </p>
           </div>
         </section>
@@ -348,7 +349,7 @@ function OpenRouterTab() {
 
         <div style={{ paddingTop: "2.5rem" }}>
           {/* Step 1 */}
-          <Step number={1} title="Create an account">
+          <Step number={1} title={t("setupOrStep1Title")}>
             <p
               style={{
                 fontFamily: "Georgia, serif",
@@ -358,7 +359,7 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              Go to{" "}
+              {t("setupOrStep1BodyPrefix")}
               <a
                 href="https://openrouter.ai"
                 target="_blank"
@@ -370,11 +371,11 @@ function OpenRouterTab() {
                 }}
               >
                 openrouter.ai
-              </a>{" "}
-              and click &ldquo;Get API Key&rdquo; or sign up with Google / GitHub.
+              </a>
+              {t("setupOrStep1BodySuffix")}
             </p>
 
-            <ChalkSketch annotation="homepage">
+            <ChalkSketch annotation={t("setupOrStep1Annotation")}>
               <div
                 style={{
                   display: "flex",
@@ -391,7 +392,7 @@ function OpenRouterTab() {
                 >
                   openrouter.ai
                 </span>
-                <MockButton highlight>Get API Key</MockButton>
+                <MockButton highlight>{t("setupOrStep1MockButton")}</MockButton>
               </div>
               <div
                 style={{
@@ -402,13 +403,13 @@ function OpenRouterTab() {
                   lineHeight: 1.6,
                 }}
               >
-                A unified API for LLMs — one key, many models.
+                {t("setupOrStep1MockTagline")}
               </div>
             </ChalkSketch>
           </Step>
 
           {/* Step 2 */}
-          <Step number={2} title="Add credits">
+          <Step number={2} title={t("setupOrStep2Title")}>
             <p
               style={{
                 fontFamily: "Georgia, serif",
@@ -418,7 +419,7 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              Navigate to{" "}
+              {t("setupOrStep2BodyPrefix")}
               <a
                 href="https://openrouter.ai/settings/credits"
                 target="_blank"
@@ -429,18 +430,13 @@ function OpenRouterTab() {
                   textUnderlineOffset: "2px",
                 }}
               >
-                Settings → Credits
+                {t("setupOrStep2BodyLink")}
               </a>
-              . Add at least $20. Cheap open-source models cost
-              ~$0.25 per review; SOTA models like Claude Opus or GPT-5 can
-              run $5&ndash;$10 on a long paper. The cost estimate shown
-              before submission is a ballpark, not a ceiling. Leave headroom
-              or the review can exhaust the key halfway and fail. Unused
-              credits don&apos;t expire.
+              {t("setupOrStep2BodySuffix")}
             </p>
 
-            <ChalkSketch annotation="credits page">
-              <MockLabel>Settings → Credits</MockLabel>
+            <ChalkSketch annotation={t("setupOrStep2Annotation")}>
+              <MockLabel>{t("setupOrStep2MockSettings")}</MockLabel>
               <div
                 style={{
                   display: "flex",
@@ -450,7 +446,7 @@ function OpenRouterTab() {
                 }}
               >
                 <div style={{ flex: 1 }}>
-                  <MockLabel>Amount</MockLabel>
+                  <MockLabel>{t("setupOrStep2MockAmount")}</MockLabel>
                   <div
                     style={{
                       borderBottom: "1px solid var(--tray)",
@@ -463,7 +459,7 @@ function OpenRouterTab() {
                     $20.00
                   </div>
                 </div>
-                <MockButton highlight>Add credits</MockButton>
+                <MockButton highlight>{t("setupOrStep2MockButton")}</MockButton>
               </div>
               <div
                 style={{
@@ -473,13 +469,13 @@ function OpenRouterTab() {
                   color: "var(--dust)",
                 }}
               >
-                Balance: $0.00
+                {t("setupOrStep2MockBalance")}
               </div>
             </ChalkSketch>
           </Step>
 
           {/* Step 3 */}
-          <Step number={3} title="Create an API key">
+          <Step number={3} title={t("setupOrStep3Title")}>
             <p
               style={{
                 fontFamily: "Georgia, serif",
@@ -489,7 +485,7 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              Go to{" "}
+              {t("setupOrStep3BodyPrefix")}
               <a
                 href="https://openrouter.ai/settings/keys"
                 target="_blank"
@@ -500,9 +496,9 @@ function OpenRouterTab() {
                   textUnderlineOffset: "2px",
                 }}
               >
-                Settings → Keys
+                {t("setupOrStep3BodyLink")}
               </a>
-              , click &ldquo;Create Key&rdquo;, and name it{" "}
+              {t("setupOrStep3BodyMid")}
               <span
                 style={{
                   fontFamily: "var(--font-space-mono), monospace",
@@ -512,7 +508,7 @@ function OpenRouterTab() {
               >
                 coarse
               </span>
-              .
+              {t("setupOrStep3BodySuffix")}
             </p>
 
             <p
@@ -524,11 +520,7 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              Make sure it&apos;s a regular API key — not a
-              provisioning/management key from the integrations section.
-              Provisioning keys can create and list other keys but
-              can&apos;t run inference, and coarse will fail with
-              &ldquo;User not found&rdquo; if you paste one.
+              {t("setupOrStep3Provisioning")}
             </p>
 
             <p
@@ -541,10 +533,10 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              Copy the key now — you won&apos;t see it again.
+              {t("setupOrStep3CopyWarning")}
             </p>
 
-            <ChalkSketch annotation="keys page">
+            <ChalkSketch annotation={t("setupOrStep3Annotation")}>
               <div
                 style={{
                   display: "flex",
@@ -552,11 +544,11 @@ function OpenRouterTab() {
                   alignItems: "center",
                 }}
               >
-                <MockLabel>Settings → Keys</MockLabel>
-                <MockButton highlight>Create Key</MockButton>
+                <MockLabel>{t("setupOrStep3MockSettings")}</MockLabel>
+                <MockButton highlight>{t("setupOrStep3MockButton")}</MockButton>
               </div>
               <div style={{ marginTop: "1rem" }}>
-                <MockLabel>Key name</MockLabel>
+                <MockLabel>{t("setupOrStep3MockKeyName")}</MockLabel>
                 <MockInput placeholder="coarse" />
               </div>
               <div
@@ -567,7 +559,7 @@ function OpenRouterTab() {
                   borderRadius: "2px",
                 }}
               >
-                <MockLabel>Your key</MockLabel>
+                <MockLabel>{t("setupOrStep3MockYourKey")}</MockLabel>
                 <span
                   style={{
                     fontFamily: "var(--font-space-mono), monospace",
@@ -583,7 +575,7 @@ function OpenRouterTab() {
           </Step>
 
           {/* Step 4 — Per-key spend limit */}
-          <Step number={4} title="Set a spending limit on the key">
+          <Step number={4} title={t("setupOrStep4Title")}>
             <p
               style={{
                 fontFamily: "Georgia, serif",
@@ -593,7 +585,7 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              On the{" "}
+              {t("setupOrStep4BodyPrefix")}
               <a
                 href="https://openrouter.ai/settings/keys"
                 target="_blank"
@@ -604,21 +596,18 @@ function OpenRouterTab() {
                   textUnderlineOffset: "2px",
                 }}
               >
-                Keys page
+                {t("setupOrStep4BodyLink")}
               </a>
-              , click the{" "}
+              {t("setupOrStep4BodyMid1")}
               <strong style={{ color: "var(--chalk-bright)" }}>&#8942;</strong>
-              {" "}menu next to your new key, choose &ldquo;Edit&rdquo;, and
-              set the credit limit to{" "}
+              {t("setupOrStep4BodyMid2")}
               <strong style={{ color: "var(--chalk-bright)" }}>
-                at least $20
+                {t("setupOrStep4BodyAtLeast")}
               </strong>
-              . The key stops working once the limit is hit, so surprise
-              charges are impossible. But set it too tight and a single
-              expensive review can exhaust it mid-run.
+              {t("setupOrStep4BodySuffix")}
             </p>
 
-            <ChalkSketch annotation="key menu">
+            <ChalkSketch annotation={t("setupOrStep4Annotation")}>
               <div
                 style={{
                   display: "flex",
@@ -666,13 +655,13 @@ function OpenRouterTab() {
                         color: "var(--yellow-chalk)",
                       }}
                     >
-                      Edit
+                      {t("setupOrStep4MockEdit")}
                     </div>
                   </div>
                 </div>
               </div>
               <div style={{ marginTop: "1rem" }}>
-                <MockLabel>Credit limit for this key</MockLabel>
+                <MockLabel>{t("setupOrStep4MockLimitLabel")}</MockLabel>
                 <div
                   style={{
                     display: "flex",
@@ -693,7 +682,7 @@ function OpenRouterTab() {
                   >
                     $20.00
                   </div>
-                  <MockButton highlight>Save</MockButton>
+                  <MockButton highlight>{t("setupOrStep4MockButton")}</MockButton>
                 </div>
               </div>
             </ChalkSketch>
@@ -717,9 +706,9 @@ function OpenRouterTab() {
                 }}
               >
                 <strong style={{ color: "var(--chalk-bright)" }}>
-                  Why this matters:
-                </strong>{" "}
-                coarse is open-source — you can{" "}
+                  {t("setupOrStep4WhyLabel")}
+                </strong>
+                {t("setupOrStep4WhyMid1")}
                 <a
                   href="https://github.com/Davidvandijcke/coarse"
                   target="_blank"
@@ -730,12 +719,9 @@ function OpenRouterTab() {
                     textUnderlineOffset: "2px",
                   }}
                 >
-                  read every line of code
+                  {t("setupOrStep4WhyLink")}
                 </a>
-                . Your key is sent directly to OpenRouter to run the review, then
-                discarded — it is never stored. But you don&apos;t have to trust
-                us: the per-key limit guarantees it can never spend more than you
-                allow, even in the worst case.
+                {t("setupOrStep4WhySuffix")}
               </p>
             </div>
 
@@ -758,20 +744,15 @@ function OpenRouterTab() {
                 }}
               >
                 <strong style={{ color: "var(--chalk-bright)" }}>
-                  A note on cost estimates:
-                </strong>{" "}
-                the estimate shown before submission is a heuristic with a
-                ~15% buffer, not a hard ceiling. Actual cost on SOTA models
-                with long papers can run up to ~2&times; the estimate once
-                proof-verification and critique rewrites kick in. If the
-                per-key cap sits right at the estimate, one tough review can
-                drain it and fail mid-run. Always leave headroom.
+                  {t("setupOrStep4CostLabel")}
+                </strong>
+                {t("setupOrStep4CostBody")}
               </p>
             </div>
           </Step>
 
           {/* Step 5 */}
-          <Step number={5} title="Paste into coarse">
+          <Step number={5} title={t("setupOrStep5Title")}>
             <p
               style={{
                 fontFamily: "Georgia, serif",
@@ -781,10 +762,10 @@ function OpenRouterTab() {
                 margin: "0 0 0.75rem",
               }}
             >
-              Come back here, paste your key into the form, and upload your PDF.
+              {t("setupOrStep5Body")}
             </p>
 
-            <ChalkSketch annotation="coarse form">
+            <ChalkSketch annotation={t("setupOrStep5Annotation")}>
               <div
                 style={{
                   display: "grid",
@@ -793,11 +774,11 @@ function OpenRouterTab() {
                 }}
               >
                 <div>
-                  <MockLabel>Email</MockLabel>
+                  <MockLabel>{t("setupOrStep5MockEmail")}</MockLabel>
                   <MockInput placeholder="you@university.edu" />
                 </div>
                 <div>
-                  <MockLabel>OpenRouter key</MockLabel>
+                  <MockLabel>{t("setupOrStep5MockKey")}</MockLabel>
                   <div
                     style={{
                       borderBottom: "1px solid var(--yellow-chalk)",
@@ -812,7 +793,7 @@ function OpenRouterTab() {
                 </div>
               </div>
               <div style={{ marginTop: "1rem" }}>
-                <MockButton highlight>Review my paper</MockButton>
+                <MockButton highlight>{t("setupOrStep5MockButton")}</MockButton>
               </div>
             </ChalkSketch>
           </Step>
@@ -830,7 +811,7 @@ function OpenRouterTab() {
             textDecoration: "none",
           }}
         >
-          Ready? Review your paper →
+          {t("setupReadyCta")}
         </a>
       </section>
     </>
@@ -839,6 +820,7 @@ function OpenRouterTab() {
 
 /* ── Subscription tab (Claude Code / Codex / Gemini CLI) ─── */
 function SubscriptionTab() {
+  const { t } = useSiteLanguageContext();
   return (
     <>
       <section style={{ padding: "1.5rem 0 2.5rem" }}>
@@ -853,7 +835,7 @@ function SubscriptionTab() {
             color: "var(--chalk-bright)",
           }}
         >
-          Use your coding-agent subscription
+          {t("setupSubHeading")}
         </h1>
         <p
           style={{
@@ -864,9 +846,7 @@ function SubscriptionTab() {
             fontSize: "1.05rem",
           }}
         >
-          For users already paying for Claude Code, Codex, or Gemini CLI.
-          The review runs on your subscription and bills there. You only
-          pay OpenRouter ~$0.15 for the OCR pass.
+          {t("setupSubIntro1")}
         </p>
         <p
           style={{
@@ -878,11 +858,7 @@ function SubscriptionTab() {
             maxWidth: "620px",
           }}
         >
-          Runs locally on your machine using your own Claude Code, Codex,
-          or Gemini CLI account. coarse.ink does not receive or store your
-          provider login. Your provider&apos;s terms and usage limits still
-          apply. coarse.ink is not affiliated with Anthropic, OpenAI, or
-          Google.
+          {t("setupSubIntro2")}
         </p>
       </section>
 
@@ -890,7 +866,7 @@ function SubscriptionTab() {
 
       <div style={{ paddingTop: "2.5rem" }}>
         {/* Step 1 */}
-        <Step number={1} title="Install a coding agent">
+        <Step number={1} title={t("setupSubStep1Title")}>
           <p
             style={{
               fontFamily: "Georgia, serif",
@@ -900,9 +876,7 @@ function SubscriptionTab() {
               margin: "0 0 0.75rem",
             }}
           >
-            Pick whichever one you pay for. Gemini CLI has a free tier if
-            you don&apos;t. Install it from the vendor&apos;s own page &mdash;
-            their docs stay up to date.
+            {t("setupSubStep1Body")}
           </p>
 
           <div
@@ -914,25 +888,25 @@ function SubscriptionTab() {
           >
             <AgentCard
               name="Claude Code"
-              price="Anthropic Pro or Max"
+              price={t("setupSubStep1ClaudePrice")}
               installHref="https://docs.claude.com/en/docs/claude-code/setup"
-              installLabel="Install instructions ↗"
+              installLabel={t("setupSubStep1InstallLabel")}
               loginCmd="claude login"
               testCmd="claude -p 'say hi'"
             />
             <AgentCard
               name="Codex"
-              price="ChatGPT Plus, Pro, or Business"
+              price={t("setupSubStep1CodexPrice")}
               installHref="https://developers.openai.com/codex/cli"
-              installLabel="Install instructions ↗"
+              installLabel={t("setupSubStep1InstallLabel")}
               loginCmd="codex login"
               testCmd="codex exec 'say hi'"
             />
             <AgentCard
               name="Gemini CLI"
-              price="Free tier works for most papers"
+              price={t("setupSubStep1GeminiPrice")}
               installHref="https://github.com/google-gemini/gemini-cli#quickstart"
-              installLabel="Install instructions ↗"
+              installLabel={t("setupSubStep1InstallLabel")}
               loginCmd="gemini"
               testCmd="gemini -p 'say hi'"
             />
@@ -947,13 +921,12 @@ function SubscriptionTab() {
               color: "var(--chalk)",
             }}
           >
-            Run the test command to verify install + login. If it prints a
-            response, you&apos;re set.
+            {t("setupSubStep1Verify")}
           </p>
         </Step>
 
         {/* Step 2 */}
-        <Step number={2} title="Put an OpenRouter key on your machine (PDFs only)">
+        <Step number={2} title={t("setupSubStep2Title")}>
           <p
             style={{
               fontFamily: "Georgia, serif",
@@ -963,18 +936,11 @@ function SubscriptionTab() {
               margin: "0 0 0.75rem",
             }}
           >
-            This step only applies to PDF papers — non-PDF sources
-            (.tex, .md, .docx, …) are extracted locally without OCR, so
-            they need no OpenRouter key anywhere and you can skip
-            straight to step 3. For PDFs, coarse still needs OpenRouter
-            for the OCR step (~$0.10 per paper). Follow the{" "}
+            {t("setupSubStep2BodyPrefix")}
             <strong style={{ color: "var(--chalk-bright)" }}>
-              OpenRouter key
-            </strong>{" "}
-            tab to create an account, add $1 of credit, and set a $2
-            per-key limit. The $20 buffer from the OpenRouter-only path
-            isn&apos;t needed here because the review itself runs on
-            your coding-agent subscription.
+              {t("setupSubStep2BodyTab")}
+            </strong>
+            {t("setupSubStep2BodySuffix")}
           </p>
           <p
             style={{
@@ -985,7 +951,7 @@ function SubscriptionTab() {
               margin: 0,
             }}
           >
-            Then put the key on your own machine: run{" "}
+            {t("setupSubStep2KeyPrefix")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -995,7 +961,7 @@ function SubscriptionTab() {
             >
               export OPENROUTER_API_KEY=sk-or-v1-...
             </code>
-            , drop it in a{" "}
+            {t("setupSubStep2KeyMid1")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -1005,7 +971,7 @@ function SubscriptionTab() {
             >
               .env
             </code>
-            , or save it to{" "}
+            {t("setupSubStep2KeyMid2")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -1015,13 +981,12 @@ function SubscriptionTab() {
             >
               ~/.coarse/config.toml
             </code>
-            . Your CLI reads it locally when it runs the extraction;
-            coarse.ink never sees it.
+            {t("setupSubStep2KeySuffix")}
           </p>
         </Step>
 
         {/* Step 3 */}
-        <Step number={3} title="Upload your paper and pick a CLI">
+        <Step number={3} title={t("setupSubStep3Title")}>
           <p
             style={{
               fontFamily: "Georgia, serif",
@@ -1031,7 +996,7 @@ function SubscriptionTab() {
               margin: 0,
             }}
           >
-            On the{" "}
+            {t("setupSubStep3BodyPrefix")}
             <a
               href="/"
               style={{
@@ -1040,22 +1005,18 @@ function SubscriptionTab() {
                 textUnderlineOffset: "2px",
               }}
             >
-              main page
+              {t("setupSubStep3BodyLink")}
             </a>
-            , drop your paper (PDF, .tex, .md, .docx, …) onto the form,
-            then click the{" "}
+            {t("setupSubStep3BodyMid")}
             <strong style={{ color: "var(--chalk-bright)" }}>
-              Review with my subscription ▾
-            </strong>{" "}
-            dropdown and pick your CLI. coarse uploads the file, mints a
-            handoff token, and shows the prompt you&apos;ll paste in the
-            next step. You don&apos;t paste your OpenRouter key on the
-            form here; the CLI reads it from your machine (step 2).
+              {t("setupSubStep3BodyButton")}
+            </strong>
+            {t("setupSubStep3BodySuffix")}
           </p>
         </Step>
 
         {/* Step 4 */}
-        <Step number={4} title="Paste the prompt into your CLI">
+        <Step number={4} title={t("setupSubStep4Title")}>
           <p
             style={{
               fontFamily: "Georgia, serif",
@@ -1065,8 +1026,7 @@ function SubscriptionTab() {
               margin: "0 0 0.75rem",
             }}
           >
-            coarse gives you one natural-language prompt. Copy it from
-            the panel, paste it into your{" "}
+            {t("setupSubStep4BodyPrefix")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -1076,7 +1036,7 @@ function SubscriptionTab() {
             >
               claude -p
             </code>
-            ,{" "}
+            {t("setupSubStep4BodyMid1")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -1086,7 +1046,7 @@ function SubscriptionTab() {
             >
               codex exec
             </code>
-            , or{" "}
+            {t("setupSubStep4BodyMid2")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -1095,10 +1055,8 @@ function SubscriptionTab() {
               }}
             >
               gemini -p
-            </code>{" "}
-            session, and hit send. The agent refreshes its skill bundle,
-            runs the full coarse pipeline on its own subprocess calls,
-            and prints a{" "}
+            </code>
+            {t("setupSubStep4BodyMid3")}
             <code
               style={{
                 fontFamily: "var(--font-space-mono), monospace",
@@ -1107,9 +1065,8 @@ function SubscriptionTab() {
               }}
             >
               view:
-            </code>{" "}
-            URL when it&apos;s done. 10&ndash;25 minutes. Click the URL
-            to open the finished review on coarse.ink.
+            </code>
+            {t("setupSubStep4BodySuffix")}
           </p>
 
           <div
@@ -1131,35 +1088,24 @@ function SubscriptionTab() {
               }}
             >
               <strong style={{ color: "var(--chalk-bright)" }}>
-                If you&apos;re pasting into a coding agent
-              </strong>{" "}
-              (not a plain terminal), bump its bash-tool timeout to at
-              least 45 min before you send the prompt. Default agent
-              timeouts can be as low as 2 min, way under the 10&ndash;25
-              min review runtime.
+                {t("setupSubStep4TimeoutLabel")}
+              </strong>
+              {t("setupSubStep4TimeoutSuffix")}
             </p>
           </div>
         </Step>
 
         {/* Step 5 — Troubleshooting */}
-        <Step number={5} title="If something goes wrong">
+        <Step number={5} title={t("setupSubStep5Title")}>
           <Trouble
-            symptom="The &ldquo;Try opening Claude Code / Codex&rdquo; button does nothing."
-            fix={
-              <>
-                The button only works if you have the desktop app
-                installed. With a CLI-only install, the browser
-                can&apos;t launch a terminal for you. Copy the prompt
-                from the panel and paste it into your CLI manually.
-              </>
-            }
+            symptom={t("setupSubTrouble1Symptom")}
+            fix={t("setupSubTrouble1Fix")}
           />
           <Trouble
-            symptom="&ldquo;No such command &lsquo;install-skills&rsquo;&rdquo; inside the agent run."
+            symptom={t("setupSubTrouble2Symptom")}
             fix={
               <>
-                Safe to ignore. The skill bundle still loads directly
-                through{" "}
+                {t("setupSubTrouble2FixPrefix")}
                 <code
                   style={{
                     fontFamily: "var(--font-space-mono), monospace",
@@ -1169,15 +1115,15 @@ function SubscriptionTab() {
                 >
                   uvx --from
                 </code>
-                ; the agent will continue to the review step.
+                {t("setupSubTrouble2FixSuffix")}
               </>
             }
           />
           <Trouble
-            symptom="My Anthropic / OpenAI / Google bill went up after a review."
+            symptom={t("setupSubTrouble3Symptom")}
             fix={
               <>
-                Check for{" "}
+                {t("setupSubTrouble3FixPrefix")}
                 <code
                   style={{
                     fontFamily: "var(--font-space-mono), monospace",
@@ -1187,7 +1133,7 @@ function SubscriptionTab() {
                 >
                   ANTHROPIC_API_KEY
                 </code>
-                ,{" "}
+                {t("setupSubTrouble3FixMid1")}
                 <code
                   style={{
                     fontFamily: "var(--font-space-mono), monospace",
@@ -1197,7 +1143,7 @@ function SubscriptionTab() {
                 >
                   OPENAI_API_KEY
                 </code>
-                , or{" "}
+                {t("setupSubTrouble3FixMid2")}
                 <code
                   style={{
                     fontFamily: "var(--font-space-mono), monospace",
@@ -1206,19 +1152,16 @@ function SubscriptionTab() {
                   }}
                 >
                   GOOGLE_API_KEY
-                </code>{" "}
-                in your shell environment. If set, the host CLI bills the
-                API account instead of your subscription. v1.3.0+ strips
-                these automatically, but older versions didn&apos;t.
+                </code>
+                {t("setupSubTrouble3FixSuffix")}
               </>
             }
           />
           <Trouble
-            symptom="Fewer comments than usual (~10 instead of 15&ndash;25)."
+            symptom={t("setupSubTrouble4Symptom")}
             fix={
               <>
-                A section hit the 30-min timeout and got dropped. Rare on
-                default effort, more common with{" "}
+                {t("setupSubTrouble4FixPrefix")}
                 <code
                   style={{
                     fontFamily: "var(--font-space-mono), monospace",
@@ -1227,9 +1170,8 @@ function SubscriptionTab() {
                   }}
                 >
                   --effort max
-                </code>{" "}
-                on long papers. Re-run; drop effort one notch if it
-                happens twice.
+                </code>
+                {t("setupSubTrouble4FixSuffix")}
               </>
             }
           />
@@ -1248,7 +1190,7 @@ function SubscriptionTab() {
             textDecoration: "none",
           }}
         >
-          Ready? Review your paper →
+          {t("setupReadyCta")}
         </a>
       </section>
     </>
@@ -1271,6 +1213,7 @@ function AgentCard({
   loginCmd: string;
   testCmd: string;
 }) {
+  const { t } = useSiteLanguageContext();
   return (
     <div
       style={{
@@ -1339,11 +1282,11 @@ function AgentCard({
         }}
       >
         <div>
-          <span style={{ color: "var(--dust)" }}>login: </span>
+          <span style={{ color: "var(--dust)" }}>{t("setupSubStep1CardLogin")}</span>
           {loginCmd}
         </div>
         <div>
-          <span style={{ color: "var(--dust)" }}>test: </span>
+          <span style={{ color: "var(--dust)" }}>{t("setupSubStep1CardTest")}</span>
           {testCmd}
         </div>
       </div>
@@ -1394,6 +1337,17 @@ function Trouble({
 
 /* ── Page ──────────────────────────────────────────────────── */
 export default function SetupPage() {
+  // The site-language context must sit ABOVE every consumer, so the provider
+  // wraps the body here and the page content lives in SetupBody, whose
+  // descendants read the context (mirrors status/[id]/page.tsx's pattern).
+  return (
+    <SiteLanguageProvider>
+      <SetupBody />
+    </SiteLanguageProvider>
+  );
+}
+
+function SetupBody() {
   const [tab, setTab] = useState<SetupTab>("openrouter");
   return (
     <div style={{ background: "var(--board)", minHeight: "100vh" }}>

--- a/web/src/components/ComparePage.tsx
+++ b/web/src/components/ComparePage.tsx
@@ -8,14 +8,15 @@ import rehypeKatex from "rehype-katex";
 import type { PaperId, ModelId, ComparisonId, PaperData } from "@/data/compare-types";
 import { MODEL_LABELS, COMPARISON_LABELS, COMPARISON_URLS } from "@/data/compare-types";
 import type { Components } from "react-markdown";
+import { SiteLanguageProvider, useSiteLanguageContext, type MessageKey } from "@/lib/i18n";
 
 const katexOptions = { strict: false, throwOnError: false };
 
 class PanelErrorBoundary extends React.Component<
-  { children: React.ReactNode },
+  { children: React.ReactNode; message: string },
   { hasError: boolean }
 > {
-  constructor(props: { children: React.ReactNode }) {
+  constructor(props: { children: React.ReactNode; message: string }) {
     super(props);
     this.state = { hasError: false };
   }
@@ -26,7 +27,7 @@ class PanelErrorBoundary extends React.Component<
     if (this.state.hasError) {
       return (
         <div style={{ padding: "2rem", color: "var(--dust)", fontFamily: "var(--font-chalk)", fontSize: "1.1rem" }}>
-          Couldn&apos;t render this one. Try another model or comparison.
+          {this.props.message}
         </div>
       );
     }
@@ -34,11 +35,11 @@ class PanelErrorBoundary extends React.Component<
   }
 }
 
-const PAPER_LABELS: Record<PaperId, string> = {
-  cortical_circuits: "Cortical Circuits",
-  coset_codes: "Coset Codes",
-  population_genetics: "Population Genetics",
-  targeting_interventions: "Targeting Interventions",
+const PAPER_LABEL_KEYS: Record<PaperId, MessageKey> = {
+  cortical_circuits: "comparePaperCorticalCircuits",
+  coset_codes: "comparePaperCosetCodes",
+  population_genetics: "comparePaperPopulationGenetics",
+  targeting_interventions: "comparePaperTargetingInterventions",
 };
 
 const OVERVIEW_MODEL_ORDER = ["gpt5mini", "gpt54", "claude", "kimi"] as const;
@@ -159,6 +160,7 @@ function parseOverallScore(score: string): number | null {
 }
 
 function ScoresOverviewTable({ papers }: { papers: Record<PaperId, PaperData> }) {
+  const { t } = useSiteLanguageContext();
   const [open, setOpen] = useState(false);
   const rows = OVERVIEW_PAPER_ORDER.flatMap((paperId) => {
     const paper = papers[paperId];
@@ -231,19 +233,19 @@ function ScoresOverviewTable({ papers }: { papers: Record<PaperId, PaperData> })
           textUnderlineOffset: "2px",
         }}
       >
-        {open ? "Hide" : "Show"} all scores across papers {open ? "▴" : "▾"}
+        {open ? t("compareScoresHide") : t("compareScoresShow")}{t("compareScoresToggleSuffix")}{open ? "▴" : "▾"}
       </button>
       {open && (
         <div style={{ marginTop: "0.5rem", marginBottom: "0.25rem", overflowX: "auto" }}>
           <table style={{ borderCollapse: "collapse", width: "100%", minWidth: "520px" }}>
             <thead>
               <tr>
-                <th style={{ ...headerStyle, textAlign: "left" }}>Paper</th>
-                <th style={{ ...headerStyle, textAlign: "left" }}>Reference</th>
-                <th style={headerStyle}>GPT-5 Mini</th>
-                <th style={headerStyle}>GPT-5.4</th>
-                <th style={headerStyle}>Sonnet 4.6</th>
-                <th style={headerStyle}>Kimi K2.5</th>
+                <th style={{ ...headerStyle, textAlign: "left" }}>{t("compareScoresColPaper")}</th>
+                <th style={{ ...headerStyle, textAlign: "left" }}>{t("compareScoresColReference")}</th>
+                <th style={headerStyle}>{t("compareScoresColGpt5Mini")}</th>
+                <th style={headerStyle}>{t("compareScoresColGpt54")}</th>
+                <th style={headerStyle}>{t("compareScoresColSonnet")}</th>
+                <th style={headerStyle}>{t("compareScoresColKimi")}</th>
               </tr>
             </thead>
             <tbody>
@@ -297,7 +299,7 @@ function ScoresOverviewTable({ papers }: { papers: Record<PaperId, PaperData> })
               fontStyle: "italic",
             }}
           >
-            Evaluated by Gemini 3.1 Pro with PDF multimodal input. 5.0/5 = matches reference quality. 5.5+/5 = exceeds it.
+            {t("compareScoresFootnote")}
           </p>
         </div>
       )}
@@ -306,6 +308,7 @@ function ScoresOverviewTable({ papers }: { papers: Record<PaperId, PaperData> })
 }
 
 function JudgePromptCollapsible() {
+  const { t } = useSiteLanguageContext();
   const [open, setOpen] = useState(false);
   const preStyle: CSSProperties = {
     fontFamily: "var(--font-space-mono), monospace",
@@ -339,19 +342,19 @@ function JudgePromptCollapsible() {
           textUnderlineOffset: "2px",
         }}
       >
-        {open ? "Hide" : "Show"} judge prompt sent to Gemini 3.1 Pro {open ? "▴" : "▾"}
+        {open ? t("compareJudgeHide") : t("compareJudgeShow")}{t("compareJudgeToggleSuffix")}{open ? "▴" : "▾"}
       </button>
       {open && (
         <div style={{ marginTop: "0.5rem", marginBottom: "0.25rem" }}>
           <p style={{ fontFamily: "var(--font-chalk)", fontSize: "1rem", color: "var(--chalk)", lineHeight: 1.6, margin: "0 0 0.75rem", maxWidth: "640px" }}>
-            To mitigate known LLM-as-judge biases, the judge is run twice per evaluation with the two reviews swapped in presentation order, and scores are averaged across both orderings. This counteracts positional bias, where judges systematically favor whichever review appears first. The prompt also includes specific instructions to counteract verbosity bias (not rewarding length over substance), confidence bias (not rewarding assertive language over correct hedging), authority bias (not rewarding jargon or citation count over accuracy), and leniency bias (using the full 1-6 scoring range rather than clustering in the middle). Reviews are labeled neutrally as {'"'}Review A{'"'} and {'"'}Review B{'"'} rather than {'"'}reference{'"'} and {'"'}generated{'"'} to prevent provenance-based scoring.
+            {t("compareJudgeExplain")}
           </p>
           <p style={{ fontFamily: "var(--font-chalk)", fontSize: "1rem", color: "var(--dust)", margin: "0 0 0.25rem" }}>
-            System prompt
+            {t("compareJudgeSystemPromptLabel")}
           </p>
           <pre style={preStyle}>{JUDGE_SYSTEM_PROMPT}</pre>
           <p style={{ fontFamily: "var(--font-chalk)", fontSize: "1rem", color: "var(--dust)", margin: "0.75rem 0 0.25rem" }}>
-            User prompt (paper + reviews injected at runtime)
+            {t("compareJudgeUserPromptLabel")}
           </p>
           <pre style={preStyle}>{JUDGE_USER_TEMPLATE}</pre>
         </div>
@@ -362,6 +365,18 @@ function JudgePromptCollapsible() {
 
 /* ── Main component ─────────────────────────────────────────── */
 export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) {
+  // The site-language context must sit ABOVE every consumer, so the provider
+  // wraps the body here and the page content lives in ComparePageBody, whose
+  // descendants read the context (mirrors status/[id]/page.tsx's pattern).
+  return (
+    <SiteLanguageProvider>
+      <ComparePageBody papers={papers} />
+    </SiteLanguageProvider>
+  );
+}
+
+function ComparePageBody({ papers }: { papers: Record<PaperId, PaperData> }) {
+  const { t } = useSiteLanguageContext();
   const [paperId, setPaperId] = useState<PaperId>("targeting_interventions");
   const [modelId, setModelId] = useState<ModelId>("claude");
   const [comparisonId, setComparisonId] = useState<ComparisonId>("refine");
@@ -433,7 +448,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
               transition: "color 0.2s",
             }}
           >
-            setup
+            {t("navSetup")}
           </a>
           <span
             style={{
@@ -442,7 +457,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
               color: "var(--chalk)",
             }}
           >
-            side-by-side
+            {t("navSideBySide")}
           </span>
           <a
             href="https://github.com/Davidvandijcke/coarse"
@@ -456,7 +471,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
               transition: "color 0.2s",
             }}
           >
-            github ↗
+            {t("navGithub")}
           </a>
         </div>
       </header>
@@ -478,7 +493,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
                 if (!papers[pid].models[modelId]) setModelId("claude");
               }}
             >
-              {PAPER_LABELS[pid]}
+              {t(PAPER_LABEL_KEYS[pid])}
             </button>
           ))}
         </div>
@@ -503,7 +518,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
                 margin: "0 0 0.125rem",
               }}
             >
-              {MODEL_LABELS[effectiveModelId]} vs <a href={COMPARISON_URLS[comparisonId]} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", textDecoration: "underline", textUnderlineOffset: "2px" }}>{COMPARISON_LABELS[comparisonId]}</a>
+              {MODEL_LABELS[effectiveModelId]}{t("compareVsMid")}<a href={COMPARISON_URLS[comparisonId]} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", textDecoration: "underline", textUnderlineOffset: "2px" }}>{COMPARISON_LABELS[comparisonId]}</a>
             </p>
             <span
               style={{
@@ -515,7 +530,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
               }}
             >
               {activeScores.overall.replace(/\/[\d.]+$/, "")}
-              <span style={{ fontSize: "1.25rem", fontWeight: 400, color: "var(--dust)" }}>/5</span>
+              <span style={{ fontSize: "1.25rem", fontWeight: 400, color: "var(--dust)" }}>{t("compareScoreOutOf")}</span>
             </span>
           </div>
 
@@ -534,13 +549,13 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
             </p>
             <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap" }}>
               {([
-                ["Coverage", activeScores.coverage],
-                ["Specificity", activeScores.specificity],
-                ["Depth", activeScores.depth],
-              ] as const).map(([label, val]) => (
-                <span key={label} style={{ fontSize: "0.92rem" }}>
+                ["compareMetricCoverage", activeScores.coverage],
+                ["compareMetricSpecificity", activeScores.specificity],
+                ["compareMetricDepth", activeScores.depth],
+              ] as const).map(([labelKey, val]) => (
+                <span key={labelKey} style={{ fontSize: "0.92rem" }}>
                   <span style={{ fontFamily: "var(--font-chalk)", color: "var(--dust)" }}>
-                    {label}
+                    {t(labelKey)}
                   </span>{" "}
                   <span style={{ fontFamily: "var(--font-chalk)", color: "var(--chalk-bright)", fontWeight: 600 }}>
                     {val}
@@ -565,15 +580,18 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
           alignItems: "baseline",
         }}
       >
-        <span style={{ fontFamily: "var(--font-chalk)", fontSize: "1.05rem", color: "var(--dust)" }}>Jump to</span>
-        {["Overall Feedback", "Detailed Comments"].map((section) => (
+        <span style={{ fontFamily: "var(--font-chalk)", fontSize: "1.05rem", color: "var(--dust)" }}>{t("compareJumpTo")}</span>
+        {([
+          ["Overall Feedback", "compareSectionOverallFeedback"],
+          ["Detailed Comments", "compareSectionDetailedComments"],
+        ] as const).map(([section, labelKey]) => (
           <button
             key={section}
             className="chalk-tab"
             style={{ fontSize: "0.9rem" }}
             onClick={() => scrollBothTo(section)}
           >
-            {section}
+            {t(labelKey)}
           </button>
         ))}
       </div>
@@ -625,7 +643,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
               minHeight: 0,
             }}
           >
-            <PanelErrorBoundary>
+            <PanelErrorBoundary message={t("comparePanelErrorBody")}>
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[[rehypeKatex, katexOptions]]}
@@ -665,7 +683,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
                   href={COMPARISON_URLS[cid]}
                   target="_blank"
                   rel="noopener noreferrer"
-                  title={`Visit ${COMPARISON_LABELS[cid]}`}
+                  title={`${t("compareVisitPrefix")}${COMPARISON_LABELS[cid]}`}
                   style={{ color: "var(--dust)", fontSize: "1.05rem", textDecoration: "none", lineHeight: 1 }}
                 >
                   ↗
@@ -686,7 +704,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
                 minHeight: 0,
               }}
             >
-              <PanelErrorBoundary>
+              <PanelErrorBoundary message={t("comparePanelErrorBody")}>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm, remarkMath]}
                   rehypePlugins={[[rehypeKatex, katexOptions]]}
@@ -700,7 +718,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
             <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0, padding: "0.75rem 1.5rem" }}>
               <iframe
                 src={comparison.pdfPath}
-                title={`${COMPARISON_LABELS[comparisonId]} review`}
+                title={`${COMPARISON_LABELS[comparisonId]}${t("comparePdfReviewSuffix")}`}
                 style={{
                   flex: 1,
                   width: "100%",
@@ -721,7 +739,7 @@ export function ComparePage({ papers }: { papers: Record<PaperId, PaperData> }) 
                   textUnderlineOffset: "2px",
                 }}
               >
-                Download PDF if iframe doesn&apos;t render ↓
+                {t("comparePdfFallback")}
               </a>
             </div>
           ) : null}

--- a/web/src/lib/i18n/ar.ts
+++ b/web/src/lib/i18n/ar.ts
@@ -395,4 +395,184 @@ export const ar: Messages = {
   paperPanelDownload: "تنزيل",
   paperPanelDownloadAriaLabel: "تنزيل ملف Markdown الخاص بالورقة",
   paperPanelCloseAriaLabel: "إغلاق لوحة الورقة",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "مسار الإعداد",
+  setupTabOpenRouter: "مفتاح OpenRouter",
+  setupTabSubscription: "استخدام اشتراكي",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "احصل على مفتاح OpenRouter",
+  setupOrIntro:
+    "يستغرق نحو دقيقتين. ستحتاج إلى بطاقة ائتمان بقيمة نحو $1 من الرصيد للبدء — وسترفع الرصيد إلى $20 في الخطوة 2.",
+  setupOrFasterLabel: "خيار أسرع:",
+  setupOrFasterMid1: " في النموذج الرئيسي يمكنك النقر على ",
+  setupOrFasterLogIn: "“سجّل الدخول عبر OpenRouter”",
+  setupOrFasterSuffix:
+    " لتفويض coarse وتخطّي إنشاء المفتاح يدويًا. ستظل تحتاج إلى حساب OpenRouter به رصيد (الخطوتان 1 و2 أدناه)، وما زلنا ننصح بضبط حد إنفاق لكل مفتاح (الخطوة 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "أنشئ حسابًا",
+  setupOrStep1BodyPrefix: "اذهب إلى ",
+  setupOrStep1BodySuffix: " وانقر على “Get API Key” أو سجّل عبر Google / GitHub.",
+  setupOrStep1Annotation: "الصفحة الرئيسية",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "واجهة برمجة موحّدة لنماذج اللغة الكبيرة — مفتاح واحد، نماذج كثيرة.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "أضف رصيدًا",
+  setupOrStep2BodyPrefix: "انتقل إلى ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". أضف $20 على الأقل. تكلّف النماذج المفتوحة المصدر الرخيصة نحو $0.25 لكل مراجعة؛ أما النماذج الأحدث مثل Claude Opus أو GPT-5 فقد تصل إلى $5–$10 على ورقة طويلة. تقدير التكلفة المعروض قبل الإرسال تقريبي وليس سقفًا. اترك هامشًا وإلا فقد تستنفد المراجعة المفتاح في منتصفها وتفشل. ولا تنتهي صلاحية الرصيد غير المستخدَم.",
+  setupOrStep2Annotation: "صفحة الرصيد",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Amount",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Balance: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "أنشئ مفتاح API",
+  setupOrStep3BodyPrefix: "اذهب إلى ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: "، وانقر على “Create Key”، وسمِّه ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "تأكّد من أنه مفتاح API عادي — لا مفتاح تزويد/إدارة من قسم التكاملات. يمكن لمفاتيح التزويد إنشاء مفاتيح أخرى وسردها لكنها لا تستطيع إجراء الاستدلال، وسيفشل coarse برسالة “User not found” إذا لصقت واحدًا.",
+  setupOrStep3CopyWarning: "انسخ المفتاح الآن — لن تراه مرة أخرى.",
+  setupOrStep3Annotation: "صفحة المفاتيح",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Key name",
+  setupOrStep3MockYourKey: "Your key",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "اضبط حد إنفاق على المفتاح",
+  setupOrStep4BodyPrefix: "في ",
+  setupOrStep4BodyLink: "صفحة المفاتيح",
+  setupOrStep4BodyMid1: "، انقر على قائمة ",
+  setupOrStep4BodyMid2: " بجوار مفتاحك الجديد، واختر “Edit”، واضبط حد الرصيد على ",
+  setupOrStep4BodyAtLeast: "‏$20 على الأقل",
+  setupOrStep4BodySuffix:
+    ". يتوقف المفتاح عن العمل بمجرد بلوغ الحد، لذا تستحيل الرسوم المفاجئة. لكن إن ضبطته ضيّقًا جدًا فقد تستنفده مراجعة واحدة باهظة في منتصف تشغيلها.",
+  setupOrStep4Annotation: "قائمة المفتاح",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Credit limit for this key",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "لماذا يهم هذا:",
+  setupOrStep4WhyMid1: " إنّ coarse مفتوح المصدر — يمكنك ",
+  setupOrStep4WhyLink: "قراءة كل سطر من الشيفرة",
+  setupOrStep4WhySuffix:
+    ". يُرسَل مفتاحك مباشرةً إلى OpenRouter لإجراء المراجعة، ثم يُتلَف — ولا يُخزَّن أبدًا. لكنك لست مضطرًا إلى الوثوق بنا: يضمن الحد لكل مفتاح أنه لا يمكن أبدًا أن ينفق أكثر مما تسمح به، حتى في أسوأ الحالات.",
+  setupOrStep4CostLabel: "ملاحظة عن تقديرات التكلفة:",
+  setupOrStep4CostBody:
+    " التقدير المعروض قبل الإرسال هو تقدير تقريبي بهامش نحو 15%، وليس سقفًا صارمًا. قد تصل التكلفة الفعلية على النماذج الأحدث مع الأوراق الطويلة إلى نحو ضعف التقدير بمجرد بدء التحقق من البراهين وإعادة كتابة النقد. وإذا كان الحد لكل مفتاح عند مستوى التقدير تمامًا، فقد تستنزفه مراجعة صعبة واحدة وتفشل في منتصف التشغيل. اترك هامشًا دائمًا.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "الصق في coarse",
+  setupOrStep5Body: "عُد إلى هنا، والصق مفتاحك في النموذج، وارفع ملف الـ PDF الخاص بك.",
+  setupOrStep5Annotation: "نموذج coarse",
+  setupOrStep5MockEmail: "Email",
+  setupOrStep5MockKey: "OpenRouter key",
+  setupOrStep5MockButton: "Review my paper",
+  // setup page — shared footer CTA
+  setupReadyCta: "جاهز؟ راجِع ورقتك →",
+  // setup page — subscription tab intro
+  setupSubHeading: "استخدم اشتراك وكيل البرمجة لديك",
+  setupSubIntro1:
+    "للمستخدمين الذين يدفعون بالفعل مقابل Claude Code أو Codex أو Gemini CLI. تعمل المراجعة على اشتراكك وتُحتسَب تكلفتها هناك. تدفع OpenRouter نحو $0.15 فقط مقابل خطوة الـ OCR.",
+  setupSubIntro2:
+    "يعمل محليًا على جهازك باستخدام حسابك الخاص في Claude Code أو Codex أو Gemini CLI. لا يتلقّى coarse.ink بيانات تسجيل دخول مزوّدك ولا يخزّنها. وتظل شروط مزوّدك وحدود استخدامه سارية. وليس coarse.ink تابعًا لـ Anthropic أو OpenAI أو Google.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "ثبّت وكيل برمجة",
+  setupSubStep1Body:
+    "اختر أيًّا كان الذي تدفع مقابله. يتوفّر لـ Gemini CLI طبقة مجانية إن لم تكن تدفع. ثبّته من صفحة المورّد نفسها — فوثائقهم تبقى محدّثة.",
+  setupSubStep1ClaudePrice: "Anthropic Pro أو Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus أو Pro أو Business",
+  setupSubStep1GeminiPrice: "الطبقة المجانية تكفي لمعظم الأوراق",
+  setupSubStep1InstallLabel: "تعليمات التثبيت ↗",
+  setupSubStep1Verify:
+    "شغّل أمر الاختبار للتحقق من التثبيت + تسجيل الدخول. إذا طبع استجابة، فأنت جاهز.",
+  setupSubStep1CardLogin: "تسجيل الدخول: ",
+  setupSubStep1CardTest: "الاختبار: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "ضع مفتاح OpenRouter على جهازك (ملفات PDF فقط)",
+  setupSubStep2BodyPrefix:
+    "تنطبق هذه الخطوة على أوراق الـ PDF فقط — أما المصادر غير الـ PDF (.tex, .md, .docx، …) فتُستخرَج محليًا دون OCR، لذا لا تحتاج إلى مفتاح OpenRouter في أي مكان ويمكنك الانتقال مباشرةً إلى الخطوة 3. أما لملفات الـ PDF، فما زال coarse يحتاج إلى OpenRouter لخطوة الـ OCR (نحو $0.10 لكل ورقة). اتبع تبويبة ",
+  setupSubStep2BodyTab: "مفتاح OpenRouter",
+  setupSubStep2BodySuffix:
+    " لإنشاء حساب، وإضافة $1 من الرصيد، وضبط حد قدره $2 لكل مفتاح. لا حاجة هنا إلى هامش الـ $20 الخاص بمسار OpenRouter وحده لأن المراجعة نفسها تعمل على اشتراك وكيل البرمجة لديك.",
+  setupSubStep2KeyPrefix: "ثم ضع المفتاح على جهازك الخاص: شغّل ",
+  setupSubStep2KeyMid1: "، أو ضعه في ملف ",
+  setupSubStep2KeyMid2: "، أو احفظه في ",
+  setupSubStep2KeySuffix:
+    ". تقرأه واجهة سطر الأوامر لديك محليًا عند تشغيل الاستخراج؛ ولا يراه coarse.ink أبدًا.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "ارفع ورقتك واختر واجهة سطر أوامر",
+  setupSubStep3BodyPrefix: "في ",
+  setupSubStep3BodyLink: "الصفحة الرئيسية",
+  setupSubStep3BodyMid: "، أفلِت ورقتك (PDF، .tex، .md، .docx، …) على النموذج، ثم انقر على قائمة ",
+  setupSubStep3BodyButton: "راجِع باستخدام اشتراكي ▾",
+  setupSubStep3BodySuffix:
+    " المنسدلة واختر واجهة سطر الأوامر لديك. يرفع coarse الملف، ويصدر رمز تسليم، ويعرض الموجِّه الذي ستلصقه في الخطوة التالية. لا تلصق مفتاح OpenRouter الخاص بك في النموذج هنا؛ تقرأه واجهة سطر الأوامر من جهازك (الخطوة 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "الصق الموجِّه في واجهة سطر الأوامر لديك",
+  setupSubStep4BodyPrefix: "يمنحك coarse موجِّهًا واحدًا بلغة طبيعية. انسخه من اللوحة، والصقه في جلسة ",
+  setupSubStep4BodyMid1: "، ",
+  setupSubStep4BodyMid2: "، أو ",
+  setupSubStep4BodyMid3: "، واضغط على إرسال. يحدّث الوكيل حزمة مهاراته، ويشغّل خط أنابيب coarse الكامل عبر استدعاءاته الفرعية الخاصة، ويطبع عنوان ",
+  setupSubStep4BodySuffix:
+    " عند الانتهاء. 10–25 دقيقة. انقر على العنوان لفتح المراجعة المكتملة على coarse.ink.",
+  setupSubStep4TimeoutLabel: "إذا كنت تلصق في وكيل برمجة",
+  setupSubStep4TimeoutSuffix:
+    " (لا في طرفية عادية)، فارفع مهلة أداة bash لديه إلى 45 دقيقة على الأقل قبل إرسال الموجِّه. قد تكون مهل الوكلاء الافتراضية منخفضة إلى دقيقتين، أي أقل بكثير من زمن تشغيل المراجعة البالغ 10–25 دقيقة.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "إذا حدث خطأ ما",
+  setupSubTrouble1Symptom: "زر “جرّب فتح Claude Code / Codex” لا يفعل شيئًا.",
+  setupSubTrouble1Fix:
+    "يعمل الزر فقط إذا كان لديك تطبيق سطح المكتب مثبّتًا. مع تثبيت واجهة سطر الأوامر فقط، لا يستطيع المتصفح تشغيل طرفية نيابةً عنك. انسخ الموجِّه من اللوحة والصقه في واجهة سطر الأوامر لديك يدويًا.",
+  setupSubTrouble2Symptom: "“No such command ‘install-skills’” داخل تشغيل الوكيل.",
+  setupSubTrouble2FixPrefix: "آمن التجاهل. ما زالت حزمة المهارات تُحمَّل مباشرةً عبر ",
+  setupSubTrouble2FixSuffix: "؛ وسيتابع الوكيل إلى خطوة المراجعة.",
+  setupSubTrouble3Symptom: "ارتفعت فاتورة Anthropic / OpenAI / Google لديّ بعد مراجعة.",
+  setupSubTrouble3FixPrefix: "تحقّق من وجود ",
+  setupSubTrouble3FixMid1: "، ",
+  setupSubTrouble3FixMid2: "، أو ",
+  setupSubTrouble3FixSuffix:
+    " في بيئة الصدفة لديك. إن كانت مضبوطة، فإن واجهة سطر الأوامر المضيفة تحتسب التكلفة على حساب الـ API بدلًا من اشتراكك. تزيلها الإصدارات v1.3.0+ تلقائيًا، لكن الإصدارات الأقدم لم تكن تفعل.",
+  setupSubTrouble4Symptom: "تعليقات أقل من المعتاد (نحو 10 بدلًا من 15–25).",
+  setupSubTrouble4FixPrefix: "بلغ أحد الأقسام مهلة الـ 30 دقيقة وأُسقط. نادر على الجهد الافتراضي، وأكثر شيوعًا مع ",
+  setupSubTrouble4FixSuffix:
+    " على الأوراق الطويلة. أعِد التشغيل؛ واخفض الجهد درجة واحدة إن تكرّر مرتين.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "تعذّر عرض هذه المقارنة. جرّب نموذجًا آخر أو مقارنة أخرى.",
+  comparePaperCorticalCircuits: "الدوائر القشرية",
+  comparePaperCosetCodes: "شيفرات الأصناف المشتركة",
+  comparePaperPopulationGenetics: "علم وراثة المجموعات السكانية",
+  comparePaperTargetingInterventions: "استهداف التدخلات",
+  compareScoresShow: "إظهار",
+  compareScoresHide: "إخفاء",
+  compareScoresToggleSuffix: " جميع الدرجات عبر الأوراق ",
+  compareScoresColPaper: "الورقة",
+  compareScoresColReference: "المرجع",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "قيّمها Gemini 3.1 Pro بإدخال متعدد الوسائط من ملف PDF. 5.0/5 = تطابق جودة المرجع. 5.5+/5 = تتجاوزها.",
+  compareJudgeShow: "إظهار",
+  compareJudgeHide: "إخفاء",
+  compareJudgeToggleSuffix: " موجِّه الحَكَم المُرسَل إلى Gemini 3.1 Pro ",
+  compareJudgeExplain:
+    "للحدّ من تحيّزات الحَكَم المعروفة في نماذج اللغة، يُشغَّل الحَكَم مرتين لكل تقييم مع تبديل ترتيب عرض المراجعتين، وتُحسَب الدرجات بالمتوسط عبر الترتيبين. يقاوم هذا التحيّز الموضعي، حيث يفضّل الحكّام منهجيًا أي مراجعة تظهر أولًا. ويتضمّن الموجِّه أيضًا تعليمات محدّدة لمقاومة تحيّز الإسهاب (عدم مكافأة الطول على المضمون)، وتحيّز الثقة (عدم مكافأة اللغة الجازمة على التحفّظ الصحيح)، وتحيّز السلطة (عدم مكافأة المصطلحات أو عدد الاستشهادات على الدقة)، وتحيّز التساهل (استخدام نطاق التقييم الكامل من 1 إلى 6 بدلًا من التجمّع في الوسط). وتُوسَم المراجعتان بحياد بوصفهما \"Review A\" و\"Review B\" بدلًا من \"المرجع\" و\"المُولَّدة\" لمنع التقييم القائم على المصدر.",
+  compareJudgeSystemPromptLabel: "موجِّه النظام",
+  compareJudgeUserPromptLabel: "موجِّه المستخدم (تُدرَج الورقة + المراجعات وقت التشغيل)",
+  compareVsMid: " مقابل ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "الشمول",
+  compareMetricSpecificity: "الدقة",
+  compareMetricDepth: "العمق",
+  compareJumpTo: "انتقل إلى",
+  compareSectionOverallFeedback: "الملاحظات العامة",
+  compareSectionDetailedComments: "التعليقات المفصّلة",
+  compareVisitPrefix: "زُر ",
+  comparePdfReviewSuffix: " مراجعة",
+  comparePdfFallback: "نزّل ملف PDF إذا لم يُعرَض الإطار ↓",
 };

--- a/web/src/lib/i18n/de.ts
+++ b/web/src/lib/i18n/de.ts
@@ -393,4 +393,184 @@ export const de: Messages = {
   paperPanelDownload: "Herunterladen",
   paperPanelDownloadAriaLabel: "Paper-Markdown herunterladen",
   paperPanelCloseAriaLabel: "Paper-Panel schließen",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "Einrichtungsweg",
+  setupTabOpenRouter: "OpenRouter-Schlüssel",
+  setupTabSubscription: "Mein Abo nutzen",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "Hol dir deinen OpenRouter-Schlüssel",
+  setupOrIntro:
+    "Dauert etwa 2 Minuten. Du brauchst eine Kreditkarte für ~$1 an Guthaben für den Start — in Schritt 2 lädst du auf $20 auf.",
+  setupOrFasterLabel: "Schnellere Option:",
+  setupOrFasterMid1: " im Hauptformular kannst du auf ",
+  setupOrFasterLogIn: "„Mit OpenRouter anmelden“",
+  setupOrFasterSuffix:
+    " klicken, um coarse zu autorisieren und das manuelle Erstellen des Schlüssels zu überspringen. Du brauchst trotzdem einen OpenRouter-Account mit Guthaben (Schritte 1 und 2 unten), und wir empfehlen weiterhin, ein Ausgabenlimit pro Schlüssel zu setzen (Schritt 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "Erstelle einen Account",
+  setupOrStep1BodyPrefix: "Geh zu ",
+  setupOrStep1BodySuffix: " und klick auf „Get API Key“ oder registriere dich mit Google / GitHub.",
+  setupOrStep1Annotation: "Startseite",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "Eine einheitliche API für LLMs — ein Schlüssel, viele Modelle.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "Guthaben hinzufügen",
+  setupOrStep2BodyPrefix: "Navigiere zu ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Füg mindestens $20 hinzu. Günstige Open-Source-Modelle kosten ~$0,25 pro Review; SOTA-Modelle wie Claude Opus oder GPT-5 können bei einem langen Paper $5–$10 kosten. Die vor dem Einreichen angezeigte Kostenschätzung ist ein Richtwert, keine Obergrenze. Lass Puffer, sonst kann das Review den Schlüssel auf halber Strecke aufbrauchen und fehlschlagen. Ungenutztes Guthaben verfällt nicht.",
+  setupOrStep2Annotation: "Credits-Seite",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Betrag",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Guthaben: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "Erstelle einen API-Schlüssel",
+  setupOrStep3BodyPrefix: "Geh zu ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", klick auf „Create Key“ und benenne ihn ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Stell sicher, dass es ein regulärer API-Schlüssel ist — kein Provisioning-/Management-Schlüssel aus dem Integrations-Bereich. Provisioning-Schlüssel können andere Schlüssel erstellen und auflisten, aber keine Inferenz ausführen, und coarse schlägt mit „User not found“ fehl, wenn du so einen einfügst.",
+  setupOrStep3CopyWarning: "Kopier den Schlüssel jetzt — du siehst ihn nicht noch einmal.",
+  setupOrStep3Annotation: "Keys-Seite",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Schlüsselname",
+  setupOrStep3MockYourKey: "Dein Schlüssel",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "Setz ein Ausgabenlimit für den Schlüssel",
+  setupOrStep4BodyPrefix: "Auf der ",
+  setupOrStep4BodyLink: "Keys-Seite",
+  setupOrStep4BodyMid1: ", klick auf das ",
+  setupOrStep4BodyMid2: "-Menü neben deinem neuen Schlüssel, wähle „Edit“ und setz das Guthabenlimit auf ",
+  setupOrStep4BodyAtLeast: "mindestens $20",
+  setupOrStep4BodySuffix:
+    ". Der Schlüssel funktioniert nicht mehr, sobald das Limit erreicht ist, sodass überraschende Kosten unmöglich sind. Aber wenn du es zu knapp setzt, kann ein einziges teures Review es mitten im Lauf aufbrauchen.",
+  setupOrStep4Annotation: "Schlüssel-Menü",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Guthabenlimit für diesen Schlüssel",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Warum das wichtig ist:",
+  setupOrStep4WhyMid1: " coarse ist Open Source — du kannst ",
+  setupOrStep4WhyLink: "jede Zeile Code lesen",
+  setupOrStep4WhySuffix:
+    ". Dein Schlüssel wird direkt an OpenRouter gesendet, um das Review auszuführen, und danach verworfen — er wird nie gespeichert. Aber du musst uns nicht vertrauen: Das Limit pro Schlüssel garantiert, dass er nie mehr ausgeben kann, als du erlaubst, selbst im schlimmsten Fall.",
+  setupOrStep4CostLabel: "Ein Hinweis zu Kostenschätzungen:",
+  setupOrStep4CostBody:
+    " die vor dem Einreichen angezeigte Schätzung ist eine Heuristik mit einem Puffer von ~15 %, keine harte Obergrenze. Die tatsächlichen Kosten können bei SOTA-Modellen mit langen Papern bis zu ~2× der Schätzung betragen, sobald Beweisprüfung und Kritik-Umschreibungen einsetzen. Wenn die Obergrenze pro Schlüssel genau auf der Schätzung liegt, kann ein schwieriges Review sie aufbrauchen und mitten im Lauf fehlschlagen. Lass immer Puffer.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "Füg ihn in coarse ein",
+  setupOrStep5Body: "Komm hierher zurück, füge deinen Schlüssel in das Formular ein und lade dein PDF hoch.",
+  setupOrStep5Annotation: "coarse-Formular",
+  setupOrStep5MockEmail: "E-Mail",
+  setupOrStep5MockKey: "OpenRouter-Schlüssel",
+  setupOrStep5MockButton: "Mein Paper reviewen",
+  // setup page — shared footer CTA
+  setupReadyCta: "Bereit? Reviewe dein Paper →",
+  // setup page — subscription tab intro
+  setupSubHeading: "Nutze dein Coding-Agent-Abo",
+  setupSubIntro1:
+    "Für Nutzer, die bereits für Claude Code, Codex oder Gemini CLI zahlen. Das Review läuft auf deinem Abo und wird dort abgerechnet. Du zahlst nur OpenRouter ~$0,15 für den OCR-Durchlauf.",
+  setupSubIntro2:
+    "Läuft lokal auf deinem eigenen Rechner mit deinem eigenen Claude-Code-, Codex- oder Gemini-CLI-Account. coarse.ink empfängt oder speichert deinen Provider-Login nicht. Die Bedingungen und Nutzungslimits deines Providers gelten weiterhin. coarse.ink ist nicht mit Anthropic, OpenAI oder Google verbunden.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "Installier einen Coding-Agenten",
+  setupSubStep1Body:
+    "Nimm den, für den du zahlst. Gemini CLI hat einen kostenlosen Tarif, falls nicht. Installier ihn von der Seite des Anbieters selbst — deren Doku bleibt aktuell.",
+  setupSubStep1ClaudePrice: "Anthropic Pro oder Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro oder Business",
+  setupSubStep1GeminiPrice: "Kostenloser Tarif reicht für die meisten Paper",
+  setupSubStep1InstallLabel: "Installationsanleitung ↗",
+  setupSubStep1Verify:
+    "Führ den Test-Befehl aus, um Installation + Login zu prüfen. Wenn er eine Antwort ausgibt, bist du startklar.",
+  setupSubStep1CardLogin: "Login: ",
+  setupSubStep1CardTest: "Test: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "Leg einen OpenRouter-Schlüssel auf deinen Rechner (nur PDFs)",
+  setupSubStep2BodyPrefix:
+    "Dieser Schritt gilt nur für PDF-Paper — Nicht-PDF-Quellen (.tex, .md, .docx, …) werden lokal ohne OCR extrahiert, brauchen also nirgends einen OpenRouter-Schlüssel, und du kannst direkt zu Schritt 3 springen. Für PDFs braucht coarse OpenRouter weiterhin für den OCR-Schritt (~$0,10 pro Paper). Folge dem Tab ",
+  setupSubStep2BodyTab: "OpenRouter-Schlüssel",
+  setupSubStep2BodySuffix:
+    ", um einen Account zu erstellen, $1 Guthaben hinzuzufügen und ein Limit von $2 pro Schlüssel zu setzen. Der $20-Puffer aus dem reinen OpenRouter-Weg ist hier nicht nötig, weil das Review selbst auf deinem Coding-Agent-Abo läuft.",
+  setupSubStep2KeyPrefix: "Leg den Schlüssel dann auf deinen eigenen Rechner: führ ",
+  setupSubStep2KeyMid1: " aus, leg ihn in eine ",
+  setupSubStep2KeyMid2: " ab oder speichere ihn in ",
+  setupSubStep2KeySuffix:
+    ". Deine CLI liest ihn lokal, wenn sie die Extraktion ausführt; coarse.ink sieht ihn nie.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "Lade dein Paper hoch und wähle eine CLI",
+  setupSubStep3BodyPrefix: "Auf der ",
+  setupSubStep3BodyLink: "Hauptseite",
+  setupSubStep3BodyMid: ", zieh dein Paper (PDF, .tex, .md, .docx, …) auf das Formular und klick dann auf das Dropdown ",
+  setupSubStep3BodyButton: "Mit meinem Abo reviewen ▾",
+  setupSubStep3BodySuffix:
+    " und wähle deine CLI. coarse lädt die Datei hoch, erzeugt ein Übergabe-Token und zeigt den Prompt, den du im nächsten Schritt einfügst. Du fügst deinen OpenRouter-Schlüssel hier nicht im Formular ein; die CLI liest ihn von deinem Rechner (Schritt 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "Füg den Prompt in deine CLI ein",
+  setupSubStep4BodyPrefix: "coarse gibt dir einen natürlichsprachlichen Prompt. Kopier ihn aus dem Panel, füge ihn in deine ",
+  setupSubStep4BodyMid1: "-, ",
+  setupSubStep4BodyMid2: "- oder ",
+  setupSubStep4BodyMid3: "-Sitzung ein und drück auf Senden. Der Agent aktualisiert sein Skill-Bundle, führt die vollständige coarse-Pipeline über eigene Subprozess-Aufrufe aus und gibt eine ",
+  setupSubStep4BodySuffix:
+    "-URL aus, wenn er fertig ist. 10–25 Minuten. Klick auf die URL, um das fertige Review auf coarse.ink zu öffnen.",
+  setupSubStep4TimeoutLabel: "Wenn du in einen Coding-Agenten einfügst",
+  setupSubStep4TimeoutSuffix:
+    " (kein einfaches Terminal), erhöh das Bash-Tool-Timeout auf mindestens 45 Min, bevor du den Prompt sendest. Standard-Timeouts von Agenten können bei nur 2 Min liegen, weit unter der Review-Laufzeit von 10–25 Min.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "Wenn etwas schiefgeht",
+  setupSubTrouble1Symptom: "Der Button „Try opening Claude Code / Codex“ tut nichts.",
+  setupSubTrouble1Fix:
+    "Der Button funktioniert nur, wenn du die Desktop-App installiert hast. Bei einer reinen CLI-Installation kann der Browser kein Terminal für dich starten. Kopier den Prompt aus dem Panel und füge ihn manuell in deine CLI ein.",
+  setupSubTrouble2Symptom: "„No such command ‚install-skills‘“ innerhalb des Agenten-Laufs.",
+  setupSubTrouble2FixPrefix: "Kann ignoriert werden. Das Skill-Bundle wird trotzdem direkt über ",
+  setupSubTrouble2FixSuffix: " geladen; der Agent macht mit dem Review-Schritt weiter.",
+  setupSubTrouble3Symptom: "Meine Anthropic-/OpenAI-/Google-Rechnung ist nach einem Review gestiegen.",
+  setupSubTrouble3FixPrefix: "Prüf auf ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: " oder ",
+  setupSubTrouble3FixSuffix:
+    " in deiner Shell-Umgebung. Wenn gesetzt, rechnet die Host-CLI über den API-Account statt über dein Abo ab. v1.3.0+ entfernt diese automatisch, ältere Versionen taten das nicht.",
+  setupSubTrouble4Symptom: "Weniger Kommentare als üblich (~10 statt 15–25).",
+  setupSubTrouble4FixPrefix: "Ein Abschnitt hat das 30-Min-Timeout erreicht und wurde verworfen. Selten bei Standard-Aufwand, häufiger bei ",
+  setupSubTrouble4FixSuffix:
+    " bei langen Papern. Lass es erneut laufen; reduzier den Aufwand um eine Stufe, falls es zweimal passiert.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "Konnte dies nicht rendern. Versuch ein anderes Modell oder einen anderen Vergleich.",
+  comparePaperCorticalCircuits: "Cortical Circuits",
+  comparePaperCosetCodes: "Coset Codes",
+  comparePaperPopulationGenetics: "Population Genetics",
+  comparePaperTargetingInterventions: "Targeting Interventions",
+  compareScoresShow: "Einblenden",
+  compareScoresHide: "Ausblenden",
+  compareScoresToggleSuffix: " aller Bewertungen über alle Paper ",
+  compareScoresColPaper: "Paper",
+  compareScoresColReference: "Referenz",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Bewertet von Gemini 3.1 Pro mit multimodaler PDF-Eingabe. 5,0/5 = entspricht der Referenzqualität. 5,5+/5 = übertrifft sie.",
+  compareJudgeShow: "Einblenden",
+  compareJudgeHide: "Ausblenden",
+  compareJudgeToggleSuffix: " des an Gemini 3.1 Pro gesendeten Judge-Prompts ",
+  compareJudgeExplain:
+    "Um bekannte Verzerrungen bei LLM-as-Judge abzumildern, wird der Judge pro Bewertung zweimal ausgeführt, wobei die beiden Reviews in der Darstellungsreihenfolge getauscht werden, und die Bewertungen werden über beide Reihenfolgen gemittelt. Das wirkt der Positionsverzerrung entgegen, bei der Judges systematisch das Review bevorzugen, das zuerst erscheint. Der Prompt enthält außerdem konkrete Anweisungen, um Verzerrung durch Wortfülle (Länge nicht über Substanz belohnen), Selbstsicherheits-Verzerrung (forsche Sprache nicht über korrektes Abwägen belohnen), Autoritäts-Verzerrung (Fachjargon oder Anzahl der Zitate nicht über Korrektheit belohnen) und Milde-Verzerrung (die volle Bewertungsspanne von 1–6 nutzen statt sich in der Mitte zu sammeln) entgegenzuwirken. Reviews werden neutral als „Review A“ und „Review B“ statt als „Referenz“ und „generiert“ bezeichnet, um eine Bewertung anhand der Herkunft zu verhindern.",
+  compareJudgeSystemPromptLabel: "System-Prompt",
+  compareJudgeUserPromptLabel: "User-Prompt (Paper + Reviews zur Laufzeit eingefügt)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Abdeckung",
+  compareMetricSpecificity: "Spezifität",
+  compareMetricDepth: "Tiefe",
+  compareJumpTo: "Springe zu",
+  compareSectionOverallFeedback: "Gesamtbewertung",
+  compareSectionDetailedComments: "Detaillierte Kommentare",
+  compareVisitPrefix: "Besuche ",
+  comparePdfReviewSuffix: "-Review",
+  comparePdfFallback: "Lad das PDF herunter, falls der iframe nicht rendert ↓",
 };

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -394,4 +394,184 @@ export const en = {
   paperPanelDownload: "Download",
   paperPanelDownloadAriaLabel: "Download paper markdown",
   paperPanelCloseAriaLabel: "Close paper panel",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "Setup path",
+  setupTabOpenRouter: "OpenRouter key",
+  setupTabSubscription: "Use my subscription",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "Get your OpenRouter key",
+  setupOrIntro:
+    "Takes about 2 minutes. You'll need a credit card for ~$1 in credits to get started — you'll top up to $20 in step 2.",
+  setupOrFasterLabel: "Faster option:",
+  setupOrFasterMid1: " on the main form you can click ",
+  setupOrFasterLogIn: "“Log in with OpenRouter”",
+  setupOrFasterSuffix:
+    " to authorize coarse and skip manual key creation. You still need an OpenRouter account with credits (steps 1 and 2 below), and we still recommend setting a per-key spend limit (step 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "Create an account",
+  setupOrStep1BodyPrefix: "Go to ",
+  setupOrStep1BodySuffix: " and click “Get API Key” or sign up with Google / GitHub.",
+  setupOrStep1Annotation: "homepage",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "A unified API for LLMs — one key, many models.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "Add credits",
+  setupOrStep2BodyPrefix: "Navigate to ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Add at least $20. Cheap open-source models cost ~$0.25 per review; SOTA models like Claude Opus or GPT-5 can run $5–$10 on a long paper. The cost estimate shown before submission is a ballpark, not a ceiling. Leave headroom or the review can exhaust the key halfway and fail. Unused credits don't expire.",
+  setupOrStep2Annotation: "credits page",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Amount",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Balance: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "Create an API key",
+  setupOrStep3BodyPrefix: "Go to ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", click “Create Key”, and name it ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Make sure it's a regular API key — not a provisioning/management key from the integrations section. Provisioning keys can create and list other keys but can't run inference, and coarse will fail with “User not found” if you paste one.",
+  setupOrStep3CopyWarning: "Copy the key now — you won't see it again.",
+  setupOrStep3Annotation: "keys page",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Key name",
+  setupOrStep3MockYourKey: "Your key",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "Set a spending limit on the key",
+  setupOrStep4BodyPrefix: "On the ",
+  setupOrStep4BodyLink: "Keys page",
+  setupOrStep4BodyMid1: ", click the ",
+  setupOrStep4BodyMid2: " menu next to your new key, choose “Edit”, and set the credit limit to ",
+  setupOrStep4BodyAtLeast: "at least $20",
+  setupOrStep4BodySuffix:
+    ". The key stops working once the limit is hit, so surprise charges are impossible. But set it too tight and a single expensive review can exhaust it mid-run.",
+  setupOrStep4Annotation: "key menu",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Credit limit for this key",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Why this matters:",
+  setupOrStep4WhyMid1: " coarse is open-source — you can ",
+  setupOrStep4WhyLink: "read every line of code",
+  setupOrStep4WhySuffix:
+    ". Your key is sent directly to OpenRouter to run the review, then discarded — it is never stored. But you don't have to trust us: the per-key limit guarantees it can never spend more than you allow, even in the worst case.",
+  setupOrStep4CostLabel: "A note on cost estimates:",
+  setupOrStep4CostBody:
+    " the estimate shown before submission is a heuristic with a ~15% buffer, not a hard ceiling. Actual cost on SOTA models with long papers can run up to ~2× the estimate once proof-verification and critique rewrites kick in. If the per-key cap sits right at the estimate, one tough review can drain it and fail mid-run. Always leave headroom.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "Paste into coarse",
+  setupOrStep5Body: "Come back here, paste your key into the form, and upload your PDF.",
+  setupOrStep5Annotation: "coarse form",
+  setupOrStep5MockEmail: "Email",
+  setupOrStep5MockKey: "OpenRouter key",
+  setupOrStep5MockButton: "Review my paper",
+  // setup page — shared footer CTA
+  setupReadyCta: "Ready? Review your paper →",
+  // setup page — subscription tab intro
+  setupSubHeading: "Use your coding-agent subscription",
+  setupSubIntro1:
+    "For users already paying for Claude Code, Codex, or Gemini CLI. The review runs on your subscription and bills there. You only pay OpenRouter ~$0.15 for the OCR pass.",
+  setupSubIntro2:
+    "Runs locally on your machine using your own Claude Code, Codex, or Gemini CLI account. coarse.ink does not receive or store your provider login. Your provider's terms and usage limits still apply. coarse.ink is not affiliated with Anthropic, OpenAI, or Google.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "Install a coding agent",
+  setupSubStep1Body:
+    "Pick whichever one you pay for. Gemini CLI has a free tier if you don't. Install it from the vendor's own page — their docs stay up to date.",
+  setupSubStep1ClaudePrice: "Anthropic Pro or Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro, or Business",
+  setupSubStep1GeminiPrice: "Free tier works for most papers",
+  setupSubStep1InstallLabel: "Install instructions ↗",
+  setupSubStep1Verify:
+    "Run the test command to verify install + login. If it prints a response, you're set.",
+  setupSubStep1CardLogin: "login: ",
+  setupSubStep1CardTest: "test: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "Put an OpenRouter key on your machine (PDFs only)",
+  setupSubStep2BodyPrefix:
+    "This step only applies to PDF papers — non-PDF sources (.tex, .md, .docx, …) are extracted locally without OCR, so they need no OpenRouter key anywhere and you can skip straight to step 3. For PDFs, coarse still needs OpenRouter for the OCR step (~$0.10 per paper). Follow the ",
+  setupSubStep2BodyTab: "OpenRouter key",
+  setupSubStep2BodySuffix:
+    " tab to create an account, add $1 of credit, and set a $2 per-key limit. The $20 buffer from the OpenRouter-only path isn't needed here because the review itself runs on your coding-agent subscription.",
+  setupSubStep2KeyPrefix: "Then put the key on your own machine: run ",
+  setupSubStep2KeyMid1: ", drop it in a ",
+  setupSubStep2KeyMid2: ", or save it to ",
+  setupSubStep2KeySuffix:
+    ". Your CLI reads it locally when it runs the extraction; coarse.ink never sees it.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "Upload your paper and pick a CLI",
+  setupSubStep3BodyPrefix: "On the ",
+  setupSubStep3BodyLink: "main page",
+  setupSubStep3BodyMid: ", drop your paper (PDF, .tex, .md, .docx, …) onto the form, then click the ",
+  setupSubStep3BodyButton: "Review with my subscription ▾",
+  setupSubStep3BodySuffix:
+    " dropdown and pick your CLI. coarse uploads the file, mints a handoff token, and shows the prompt you'll paste in the next step. You don't paste your OpenRouter key on the form here; the CLI reads it from your machine (step 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "Paste the prompt into your CLI",
+  setupSubStep4BodyPrefix: "coarse gives you one natural-language prompt. Copy it from the panel, paste it into your ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: ", or ",
+  setupSubStep4BodyMid3: " session, and hit send. The agent refreshes its skill bundle, runs the full coarse pipeline on its own subprocess calls, and prints a ",
+  setupSubStep4BodySuffix:
+    " URL when it's done. 10–25 minutes. Click the URL to open the finished review on coarse.ink.",
+  setupSubStep4TimeoutLabel: "If you're pasting into a coding agent",
+  setupSubStep4TimeoutSuffix:
+    " (not a plain terminal), bump its bash-tool timeout to at least 45 min before you send the prompt. Default agent timeouts can be as low as 2 min, way under the 10–25 min review runtime.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "If something goes wrong",
+  setupSubTrouble1Symptom: "The “Try opening Claude Code / Codex” button does nothing.",
+  setupSubTrouble1Fix:
+    "The button only works if you have the desktop app installed. With a CLI-only install, the browser can't launch a terminal for you. Copy the prompt from the panel and paste it into your CLI manually.",
+  setupSubTrouble2Symptom: "“No such command ‘install-skills’” inside the agent run.",
+  setupSubTrouble2FixPrefix: "Safe to ignore. The skill bundle still loads directly through ",
+  setupSubTrouble2FixSuffix: "; the agent will continue to the review step.",
+  setupSubTrouble3Symptom: "My Anthropic / OpenAI / Google bill went up after a review.",
+  setupSubTrouble3FixPrefix: "Check for ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: ", or ",
+  setupSubTrouble3FixSuffix:
+    " in your shell environment. If set, the host CLI bills the API account instead of your subscription. v1.3.0+ strips these automatically, but older versions didn't.",
+  setupSubTrouble4Symptom: "Fewer comments than usual (~10 instead of 15–25).",
+  setupSubTrouble4FixPrefix: "A section hit the 30-min timeout and got dropped. Rare on default effort, more common with ",
+  setupSubTrouble4FixSuffix:
+    " on long papers. Re-run; drop effort one notch if it happens twice.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "Couldn't render this one. Try another model or comparison.",
+  comparePaperCorticalCircuits: "Cortical Circuits",
+  comparePaperCosetCodes: "Coset Codes",
+  comparePaperPopulationGenetics: "Population Genetics",
+  comparePaperTargetingInterventions: "Targeting Interventions",
+  compareScoresShow: "Show",
+  compareScoresHide: "Hide",
+  compareScoresToggleSuffix: " all scores across papers ",
+  compareScoresColPaper: "Paper",
+  compareScoresColReference: "Reference",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Evaluated by Gemini 3.1 Pro with PDF multimodal input. 5.0/5 = matches reference quality. 5.5+/5 = exceeds it.",
+  compareJudgeShow: "Show",
+  compareJudgeHide: "Hide",
+  compareJudgeToggleSuffix: " judge prompt sent to Gemini 3.1 Pro ",
+  compareJudgeExplain:
+    "To mitigate known LLM-as-judge biases, the judge is run twice per evaluation with the two reviews swapped in presentation order, and scores are averaged across both orderings. This counteracts positional bias, where judges systematically favor whichever review appears first. The prompt also includes specific instructions to counteract verbosity bias (not rewarding length over substance), confidence bias (not rewarding assertive language over correct hedging), authority bias (not rewarding jargon or citation count over accuracy), and leniency bias (using the full 1-6 scoring range rather than clustering in the middle). Reviews are labeled neutrally as \"Review A\" and \"Review B\" rather than \"reference\" and \"generated\" to prevent provenance-based scoring.",
+  compareJudgeSystemPromptLabel: "System prompt",
+  compareJudgeUserPromptLabel: "User prompt (paper + reviews injected at runtime)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Coverage",
+  compareMetricSpecificity: "Specificity",
+  compareMetricDepth: "Depth",
+  compareJumpTo: "Jump to",
+  compareSectionOverallFeedback: "Overall Feedback",
+  compareSectionDetailedComments: "Detailed Comments",
+  compareVisitPrefix: "Visit ",
+  comparePdfReviewSuffix: " review",
+  comparePdfFallback: "Download PDF if iframe doesn't render ↓",
 } as const;

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -393,4 +393,184 @@ export const es: Messages = {
   paperPanelDownload: "Descargar",
   paperPanelDownloadAriaLabel: "Descargar el markdown del artículo",
   paperPanelCloseAriaLabel: "Cerrar el panel del artículo",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "Ruta de configuración",
+  setupTabOpenRouter: "Clave de OpenRouter",
+  setupTabSubscription: "Usar mi suscripción",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "Consigue tu clave de OpenRouter",
+  setupOrIntro:
+    "Lleva unos 2 minutos. Necesitarás una tarjeta de crédito para ~$1 en créditos para empezar — añadirás hasta $20 en el paso 2.",
+  setupOrFasterLabel: "Opción más rápida:",
+  setupOrFasterMid1: " en el formulario principal puedes hacer clic en ",
+  setupOrFasterLogIn: "“Iniciar sesión con OpenRouter”",
+  setupOrFasterSuffix:
+    " para autorizar a coarse y saltarte la creación manual de la clave. Aun así necesitas una cuenta de OpenRouter con créditos (pasos 1 y 2 más abajo), y seguimos recomendando establecer un límite de gasto por clave (paso 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "Crea una cuenta",
+  setupOrStep1BodyPrefix: "Ve a ",
+  setupOrStep1BodySuffix: " y haz clic en “Get API Key” o regístrate con Google / GitHub.",
+  setupOrStep1Annotation: "página de inicio",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "Una API unificada para LLMs — una clave, muchos modelos.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "Añade créditos",
+  setupOrStep2BodyPrefix: "Navega a ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Añade al menos $20. Los modelos baratos de código abierto cuestan ~$0,25 por revisión; los modelos de última generación como Claude Opus o GPT-5 pueden costar entre $5 y $10 en un artículo largo. La estimación de coste que se muestra antes del envío es orientativa, no un tope. Deja margen o la revisión puede agotar la clave a la mitad y fallar. Los créditos no utilizados no caducan.",
+  setupOrStep2Annotation: "página de créditos",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Importe",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Saldo: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "Crea una clave de API",
+  setupOrStep3BodyPrefix: "Ve a ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", haz clic en “Create Key” y ponle el nombre ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Asegúrate de que sea una clave de API normal — no una clave de aprovisionamiento/gestión de la sección de integraciones. Las claves de aprovisionamiento pueden crear y listar otras claves, pero no pueden ejecutar inferencia, y coarse fallará con “User not found” si pegas una.",
+  setupOrStep3CopyWarning: "Copia la clave ahora — no volverás a verla.",
+  setupOrStep3Annotation: "página de claves",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Nombre de la clave",
+  setupOrStep3MockYourKey: "Tu clave",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "Establece un límite de gasto en la clave",
+  setupOrStep4BodyPrefix: "En la ",
+  setupOrStep4BodyLink: "página de claves",
+  setupOrStep4BodyMid1: ", haz clic en el menú ",
+  setupOrStep4BodyMid2: " junto a tu nueva clave, elige “Edit” y establece el límite de crédito en ",
+  setupOrStep4BodyAtLeast: "al menos $20",
+  setupOrStep4BodySuffix:
+    ". La clave deja de funcionar una vez alcanzado el límite, así que los cargos sorpresa son imposibles. Pero si lo estableces demasiado ajustado, una sola revisión cara puede agotarlo a mitad de ejecución.",
+  setupOrStep4Annotation: "menú de la clave",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Límite de crédito para esta clave",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Por qué esto importa:",
+  setupOrStep4WhyMid1: " coarse es de código abierto — puedes ",
+  setupOrStep4WhyLink: "leer cada línea de código",
+  setupOrStep4WhySuffix:
+    ". Tu clave se envía directamente a OpenRouter para ejecutar la revisión y luego se descarta — nunca se almacena. Pero no tienes que confiar en nosotros: el límite por clave garantiza que nunca pueda gastar más de lo que permitas, ni siquiera en el peor de los casos.",
+  setupOrStep4CostLabel: "Una nota sobre las estimaciones de coste:",
+  setupOrStep4CostBody:
+    " la estimación que se muestra antes del envío es una heurística con un margen del ~15 %, no un tope rígido. El coste real en modelos de última generación con artículos largos puede llegar a ~2× la estimación una vez que entran en juego la verificación de pruebas y las reescrituras de la crítica. Si el tope por clave queda justo en la estimación, una revisión difícil puede vaciarlo y fallar a mitad de ejecución. Deja siempre margen.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "Pégala en coarse",
+  setupOrStep5Body: "Vuelve aquí, pega tu clave en el formulario y sube tu PDF.",
+  setupOrStep5Annotation: "formulario de coarse",
+  setupOrStep5MockEmail: "Correo electrónico",
+  setupOrStep5MockKey: "Clave de OpenRouter",
+  setupOrStep5MockButton: "Revisar mi artículo",
+  // setup page — shared footer CTA
+  setupReadyCta: "¿Listo? Revisa tu artículo →",
+  // setup page — subscription tab intro
+  setupSubHeading: "Usa la suscripción de tu agente de programación",
+  setupSubIntro1:
+    "Para usuarios que ya pagan por Claude Code, Codex o Gemini CLI. La revisión se ejecuta en tu suscripción y se factura ahí. Solo pagas a OpenRouter ~$0,15 por la pasada de OCR.",
+  setupSubIntro2:
+    "Se ejecuta en local en tu máquina usando tu propia cuenta de Claude Code, Codex o Gemini CLI. coarse.ink no recibe ni almacena el inicio de sesión de tu proveedor. Se siguen aplicando las condiciones y los límites de uso de tu proveedor. coarse.ink no está afiliado a Anthropic, OpenAI ni Google.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "Instala un agente de programación",
+  setupSubStep1Body:
+    "Elige el que pagues. Gemini CLI tiene un nivel gratuito si no pagas ninguno. Instálalo desde la propia página del proveedor — su documentación se mantiene al día.",
+  setupSubStep1ClaudePrice: "Anthropic Pro o Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro o Business",
+  setupSubStep1GeminiPrice: "El nivel gratuito sirve para la mayoría de los artículos",
+  setupSubStep1InstallLabel: "Instrucciones de instalación ↗",
+  setupSubStep1Verify:
+    "Ejecuta el comando de prueba para verificar la instalación y el inicio de sesión. Si imprime una respuesta, ya está listo.",
+  setupSubStep1CardLogin: "inicio de sesión: ",
+  setupSubStep1CardTest: "prueba: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "Pon una clave de OpenRouter en tu máquina (solo PDFs)",
+  setupSubStep2BodyPrefix:
+    "Este paso solo se aplica a los artículos en PDF — las fuentes que no son PDF (.tex, .md, .docx, …) se extraen en local sin OCR, así que no necesitan ninguna clave de OpenRouter en ningún sitio y puedes saltar directamente al paso 3. Para los PDFs, coarse aún necesita OpenRouter para el paso de OCR (~$0,10 por artículo). Sigue la pestaña ",
+  setupSubStep2BodyTab: "Clave de OpenRouter",
+  setupSubStep2BodySuffix:
+    " para crear una cuenta, añadir $1 de crédito y establecer un límite de $2 por clave. El margen de $20 de la ruta exclusiva de OpenRouter no hace falta aquí porque la revisión en sí se ejecuta en la suscripción de tu agente de programación.",
+  setupSubStep2KeyPrefix: "Luego pon la clave en tu propia máquina: ejecuta ",
+  setupSubStep2KeyMid1: ", ponla en un ",
+  setupSubStep2KeyMid2: ", o guárdala en ",
+  setupSubStep2KeySuffix:
+    ". Tu CLI la lee en local cuando ejecuta la extracción; coarse.ink nunca la ve.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "Sube tu artículo y elige una CLI",
+  setupSubStep3BodyPrefix: "En la ",
+  setupSubStep3BodyLink: "página principal",
+  setupSubStep3BodyMid: ", arrastra tu artículo (PDF, .tex, .md, .docx, …) al formulario y luego haz clic en el desplegable ",
+  setupSubStep3BodyButton: "Revisar con mi suscripción ▾",
+  setupSubStep3BodySuffix:
+    " y elige tu CLI. coarse sube el archivo, acuña un token de transferencia y muestra la instrucción que pegarás en el siguiente paso. Aquí no pegas tu clave de OpenRouter en el formulario; la CLI la lee desde tu máquina (paso 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "Pega la instrucción en tu CLI",
+  setupSubStep4BodyPrefix: "coarse te da una sola instrucción en lenguaje natural. Cópiala del panel, pégala en tu sesión de ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: ", o ",
+  setupSubStep4BodyMid3: " y pulsa enviar. El agente actualiza su paquete de skills, ejecuta toda la pipeline de coarse en sus propias llamadas a subprocesos e imprime una URL de ",
+  setupSubStep4BodySuffix:
+    " cuando termina. De 10 a 25 minutos. Haz clic en la URL para abrir la revisión terminada en coarse.ink.",
+  setupSubStep4TimeoutLabel: "Si vas a pegarla en un agente de programación",
+  setupSubStep4TimeoutSuffix:
+    " (no en una terminal normal), sube el tiempo de espera de su herramienta bash a al menos 45 min antes de enviar la instrucción. Los tiempos de espera por defecto de los agentes pueden ser de tan solo 2 min, muy por debajo del tiempo de ejecución de la revisión de 10 a 25 min.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "Si algo sale mal",
+  setupSubTrouble1Symptom: "El botón “Intenta abrir Claude Code / Codex” no hace nada.",
+  setupSubTrouble1Fix:
+    "El botón solo funciona si tienes la app de escritorio instalada. Con una instalación solo de CLI, el navegador no puede abrirte una terminal. Copia la instrucción del panel y pégala en tu CLI manualmente.",
+  setupSubTrouble2Symptom: "“No such command ‘install-skills’” dentro de la ejecución del agente.",
+  setupSubTrouble2FixPrefix: "Se puede ignorar. El paquete de skills igualmente se carga directamente a través de ",
+  setupSubTrouble2FixSuffix: "; el agente continuará con el paso de la revisión.",
+  setupSubTrouble3Symptom: "Mi factura de Anthropic / OpenAI / Google subió tras una revisión.",
+  setupSubTrouble3FixPrefix: "Comprueba si hay ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: ", o ",
+  setupSubTrouble3FixSuffix:
+    " en el entorno de tu shell. Si están definidas, la CLI anfitriona factura a la cuenta de la API en lugar de a tu suscripción. v1.3.0+ las elimina automáticamente, pero las versiones anteriores no.",
+  setupSubTrouble4Symptom: "Menos comentarios de lo habitual (~10 en lugar de 15–25).",
+  setupSubTrouble4FixPrefix: "Una sección alcanzó el tiempo de espera de 30 min y se descartó. Es raro con el esfuerzo por defecto, más común con ",
+  setupSubTrouble4FixSuffix:
+    " en artículos largos. Vuelve a ejecutarla; baja el esfuerzo un nivel si ocurre dos veces.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "No se pudo renderizar este. Prueba con otro modelo o comparación.",
+  comparePaperCorticalCircuits: "Circuitos Corticales",
+  comparePaperCosetCodes: "Códigos de Clases Laterales",
+  comparePaperPopulationGenetics: "Genética de Poblaciones",
+  comparePaperTargetingInterventions: "Focalización de Intervenciones",
+  compareScoresShow: "Mostrar",
+  compareScoresHide: "Ocultar",
+  compareScoresToggleSuffix: " todas las puntuaciones de los artículos ",
+  compareScoresColPaper: "Artículo",
+  compareScoresColReference: "Referencia",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Evaluado por Gemini 3.1 Pro con entrada multimodal en PDF. 5,0/5 = iguala la calidad de la referencia. 5,5+/5 = la supera.",
+  compareJudgeShow: "Mostrar",
+  compareJudgeHide: "Ocultar",
+  compareJudgeToggleSuffix: " la instrucción del juez enviada a Gemini 3.1 Pro ",
+  compareJudgeExplain:
+    "Para mitigar los sesgos conocidos del LLM como juez, el juez se ejecuta dos veces por evaluación con las dos revisiones intercambiadas en el orden de presentación, y las puntuaciones se promedian entre ambos órdenes. Esto contrarresta el sesgo posicional, por el que los jueces favorecen sistemáticamente la revisión que aparece primero. La instrucción también incluye indicaciones específicas para contrarrestar el sesgo de verbosidad (no premiar la extensión por encima de la sustancia), el sesgo de confianza (no premiar el lenguaje categórico por encima de la cautela correcta), el sesgo de autoridad (no premiar la jerga ni el número de citas por encima de la exactitud) y el sesgo de indulgencia (usar todo el rango de puntuación del 1 al 6 en lugar de agruparse en el centro). Las revisiones se etiquetan de forma neutra como \"Revisión A\" y \"Revisión B\" en lugar de \"referencia\" y \"generada\" para evitar puntuar en función de la procedencia.",
+  compareJudgeSystemPromptLabel: "Instrucción del sistema",
+  compareJudgeUserPromptLabel: "Instrucción del usuario (el artículo y las revisiones se inyectan en tiempo de ejecución)",
+  compareVsMid: " frente a ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Cobertura",
+  compareMetricSpecificity: "Especificidad",
+  compareMetricDepth: "Profundidad",
+  compareJumpTo: "Saltar a",
+  compareSectionOverallFeedback: "Comentarios generales",
+  compareSectionDetailedComments: "Comentarios detallados",
+  compareVisitPrefix: "Visita ",
+  comparePdfReviewSuffix: " revisión",
+  comparePdfFallback: "Descarga el PDF si el iframe no se renderiza ↓",
 };

--- a/web/src/lib/i18n/fr.ts
+++ b/web/src/lib/i18n/fr.ts
@@ -372,4 +372,184 @@ export const fr: Messages = {
   paperPanelDownload: "Télécharger",
   paperPanelDownloadAriaLabel: "Télécharger l'article en markdown",
   paperPanelCloseAriaLabel: "Fermer le panneau de l'article",
+
+  // page de configuration (setup/page.tsx)
+  // page de configuration — sélecteur d'onglets
+  setupTablistAriaLabel: "Méthode de configuration",
+  setupTabOpenRouter: "Clé OpenRouter",
+  setupTabSubscription: "Utiliser mon abonnement",
+  // page de configuration — introduction de l'onglet OpenRouter
+  setupOrHeading: "Obtenez votre clé OpenRouter",
+  setupOrIntro:
+    "Cela prend environ 2 minutes. Vous aurez besoin d'une carte bancaire pour ~$1 de crédits afin de démarrer — vous compléterez jusqu'à $20 à l'étape 2.",
+  setupOrFasterLabel: "Option plus rapide :",
+  setupOrFasterMid1: " sur le formulaire principal, vous pouvez cliquer sur ",
+  setupOrFasterLogIn: "« Se connecter avec OpenRouter »",
+  setupOrFasterSuffix:
+    " pour autoriser coarse et éviter la création manuelle de clé. Vous avez toujours besoin d'un compte OpenRouter avec des crédits (étapes 1 et 2 ci-dessous), et nous recommandons toujours de définir une limite de dépense par clé (étape 4).",
+  // page de configuration — OpenRouter étape 1
+  setupOrStep1Title: "Créez un compte",
+  setupOrStep1BodyPrefix: "Rendez-vous sur ",
+  setupOrStep1BodySuffix: " et cliquez sur « Get API Key » ou inscrivez-vous avec Google / GitHub.",
+  setupOrStep1Annotation: "page d'accueil",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "Une API unifiée pour les LLM — une clé, plusieurs modèles.",
+  // page de configuration — OpenRouter étape 2
+  setupOrStep2Title: "Ajoutez des crédits",
+  setupOrStep2BodyPrefix: "Accédez à ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Ajoutez au moins $20. Les modèles open-source bon marché coûtent ~$0,25 par évaluation ; les modèles de pointe comme Claude Opus ou GPT-5 peuvent coûter $5–$10 sur un article long. L'estimation de coût affichée avant la soumission est un ordre de grandeur, pas un plafond. Laissez de la marge, sinon l'évaluation peut épuiser la clé à mi-parcours et échouer. Les crédits non utilisés n'expirent pas.",
+  setupOrStep2Annotation: "page des crédits",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Montant",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Solde : $0.00",
+  // page de configuration — OpenRouter étape 3
+  setupOrStep3Title: "Créez une clé API",
+  setupOrStep3BodyPrefix: "Rendez-vous sur ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", cliquez sur « Create Key », et nommez-la ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Assurez-vous qu'il s'agit d'une clé API ordinaire — pas d'une clé de provisionnement/gestion de la section intégrations. Les clés de provisionnement peuvent créer et lister d'autres clés mais ne peuvent pas exécuter d'inférence, et coarse échouera avec « User not found » si vous en collez une.",
+  setupOrStep3CopyWarning: "Copiez la clé maintenant — vous ne la reverrez plus.",
+  setupOrStep3Annotation: "page des clés",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Nom de la clé",
+  setupOrStep3MockYourKey: "Votre clé",
+  // page de configuration — OpenRouter étape 4
+  setupOrStep4Title: "Définissez une limite de dépense sur la clé",
+  setupOrStep4BodyPrefix: "Sur la ",
+  setupOrStep4BodyLink: "page des clés",
+  setupOrStep4BodyMid1: ", cliquez sur le menu ",
+  setupOrStep4BodyMid2: " à côté de votre nouvelle clé, choisissez « Edit », et définissez la limite de crédit à ",
+  setupOrStep4BodyAtLeast: "au moins $20",
+  setupOrStep4BodySuffix:
+    ". La clé cesse de fonctionner une fois la limite atteinte, donc les frais surprises sont impossibles. Mais si vous la fixez trop bas, une seule évaluation coûteuse peut l'épuiser en cours d'exécution.",
+  setupOrStep4Annotation: "menu de la clé",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Limite de crédit pour cette clé",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Pourquoi c'est important :",
+  setupOrStep4WhyMid1: " coarse est open-source — vous pouvez ",
+  setupOrStep4WhyLink: "lire chaque ligne de code",
+  setupOrStep4WhySuffix:
+    ". Votre clé est envoyée directement à OpenRouter pour exécuter l'évaluation, puis supprimée — elle n'est jamais conservée. Mais vous n'avez pas à nous faire confiance : la limite par clé garantit qu'elle ne peut jamais dépenser plus que vous ne l'autorisez, même dans le pire des cas.",
+  setupOrStep4CostLabel: "Une note sur les estimations de coût :",
+  setupOrStep4CostBody:
+    " l'estimation affichée avant la soumission est une heuristique avec une marge de ~15 %, pas un plafond strict. Le coût réel sur les modèles de pointe avec des articles longs peut atteindre ~2× l'estimation une fois que la vérification des preuves et les réécritures de critique entrent en jeu. Si le plafond par clé est exactement au niveau de l'estimation, une évaluation difficile peut l'épuiser et échouer en cours d'exécution. Laissez toujours de la marge.",
+  // page de configuration — OpenRouter étape 5
+  setupOrStep5Title: "Collez dans coarse",
+  setupOrStep5Body: "Revenez ici, collez votre clé dans le formulaire et téléversez votre PDF.",
+  setupOrStep5Annotation: "formulaire coarse",
+  setupOrStep5MockEmail: "E-mail",
+  setupOrStep5MockKey: "Clé OpenRouter",
+  setupOrStep5MockButton: "Évaluer mon article",
+  // page de configuration — appel à l'action partagé en bas de page
+  setupReadyCta: "Prêt ? Évaluez votre article →",
+  // page de configuration — introduction de l'onglet abonnement
+  setupSubHeading: "Utilisez l'abonnement de votre agent de codage",
+  setupSubIntro1:
+    "Pour les utilisateurs qui paient déjà Claude Code, Codex ou Gemini CLI. L'évaluation s'exécute sur votre abonnement et y est facturée. Vous payez seulement ~$0,15 à OpenRouter pour la passe d'OCR.",
+  setupSubIntro2:
+    "S'exécute localement sur votre machine avec votre propre compte Claude Code, Codex ou Gemini CLI. coarse.ink ne reçoit ni ne conserve votre identifiant de connexion au fournisseur. Les conditions et limites d'utilisation de votre fournisseur s'appliquent toujours. coarse.ink n'est pas affilié à Anthropic, OpenAI ou Google.",
+  // page de configuration — abonnement étape 1
+  setupSubStep1Title: "Installez un agent de codage",
+  setupSubStep1Body:
+    "Choisissez celui que vous payez. Gemini CLI propose une offre gratuite si ce n'est pas le cas. Installez-le depuis la page du fournisseur — leur documentation reste à jour.",
+  setupSubStep1ClaudePrice: "Anthropic Pro ou Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro ou Business",
+  setupSubStep1GeminiPrice: "L'offre gratuite suffit pour la plupart des articles",
+  setupSubStep1InstallLabel: "Instructions d'installation ↗",
+  setupSubStep1Verify:
+    "Exécutez la commande de test pour vérifier l'installation + la connexion. Si elle affiche une réponse, vous êtes prêt.",
+  setupSubStep1CardLogin: "connexion : ",
+  setupSubStep1CardTest: "test : ",
+  // page de configuration — abonnement étape 2
+  setupSubStep2Title: "Placez une clé OpenRouter sur votre machine (PDF uniquement)",
+  setupSubStep2BodyPrefix:
+    "Cette étape ne s'applique qu'aux articles PDF — les sources non PDF (.tex, .md, .docx, …) sont extraites localement sans OCR, donc elles n'ont besoin d'aucune clé OpenRouter nulle part et vous pouvez passer directement à l'étape 3. Pour les PDF, coarse a toujours besoin d'OpenRouter pour l'étape d'OCR (~$0,10 par article). Suivez l'onglet ",
+  setupSubStep2BodyTab: "Clé OpenRouter",
+  setupSubStep2BodySuffix:
+    " pour créer un compte, ajouter $1 de crédit et définir une limite de $2 par clé. La marge de $20 de la méthode OpenRouter seule n'est pas nécessaire ici, car l'évaluation elle-même s'exécute sur l'abonnement de votre agent de codage.",
+  setupSubStep2KeyPrefix: "Placez ensuite la clé sur votre propre machine : exécutez ",
+  setupSubStep2KeyMid1: ", déposez-la dans un ",
+  setupSubStep2KeyMid2: ", ou enregistrez-la dans ",
+  setupSubStep2KeySuffix:
+    ". Votre CLI la lit localement lorsqu'elle exécute l'extraction ; coarse.ink ne la voit jamais.",
+  // page de configuration — abonnement étape 3
+  setupSubStep3Title: "Téléversez votre article et choisissez une CLI",
+  setupSubStep3BodyPrefix: "Sur la ",
+  setupSubStep3BodyLink: "page principale",
+  setupSubStep3BodyMid: ", déposez votre article (PDF, .tex, .md, .docx, …) sur le formulaire, puis cliquez sur le menu déroulant ",
+  setupSubStep3BodyButton: "Évaluer avec mon abonnement ▾",
+  setupSubStep3BodySuffix:
+    " et choisissez votre CLI. coarse téléverse le fichier, génère un jeton de transfert et affiche l'invite que vous collerez à l'étape suivante. Vous ne collez pas votre clé OpenRouter sur le formulaire ici ; la CLI la lit depuis votre machine (étape 2).",
+  // page de configuration — abonnement étape 4
+  setupSubStep4Title: "Collez l'invite dans votre CLI",
+  setupSubStep4BodyPrefix: "coarse vous donne une invite en langage naturel. Copiez-la depuis le panneau, collez-la dans votre session ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: ", ou ",
+  setupSubStep4BodyMid3: ", et appuyez sur envoyer. L'agent actualise son lot de compétences, exécute tout le pipeline coarse via ses propres appels de sous-processus, et affiche une URL ",
+  setupSubStep4BodySuffix:
+    " une fois terminé. 10–25 minutes. Cliquez sur l'URL pour ouvrir l'évaluation terminée sur coarse.ink.",
+  setupSubStep4TimeoutLabel: "Si vous collez dans un agent de codage",
+  setupSubStep4TimeoutSuffix:
+    " (et non un simple terminal), augmentez le délai d'expiration de son outil bash à au moins 45 min avant d'envoyer l'invite. Les délais par défaut des agents peuvent descendre jusqu'à 2 min, bien en deçà de la durée d'évaluation de 10–25 min.",
+  // page de configuration — abonnement étape 5 (dépannage)
+  setupSubStep5Title: "En cas de problème",
+  setupSubTrouble1Symptom: "Le bouton « Essayer d'ouvrir Claude Code / Codex » ne fait rien.",
+  setupSubTrouble1Fix:
+    "Le bouton ne fonctionne que si l'application de bureau est installée. Avec une installation CLI uniquement, le navigateur ne peut pas lancer de terminal à votre place. Copiez l'invite depuis le panneau et collez-la manuellement dans votre CLI.",
+  setupSubTrouble2Symptom: "« No such command 'install-skills' » pendant l'exécution de l'agent.",
+  setupSubTrouble2FixPrefix: "Sans danger, à ignorer. Le lot de compétences se charge quand même directement via ",
+  setupSubTrouble2FixSuffix: " ; l'agent passera à l'étape d'évaluation.",
+  setupSubTrouble3Symptom: "Ma facture Anthropic / OpenAI / Google a augmenté après une évaluation.",
+  setupSubTrouble3FixPrefix: "Vérifiez la présence de ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: ", ou ",
+  setupSubTrouble3FixSuffix:
+    " dans l'environnement de votre shell. Si elle est définie, la CLI hôte facture le compte API au lieu de votre abonnement. La version v1.3.0+ les supprime automatiquement, mais les versions plus anciennes ne le faisaient pas.",
+  setupSubTrouble4Symptom: "Moins de commentaires que d'habitude (~10 au lieu de 15–25).",
+  setupSubTrouble4FixPrefix: "Une section a atteint le délai d'expiration de 30 min et a été abandonnée. Rare avec l'effort par défaut, plus fréquent avec ",
+  setupSubTrouble4FixSuffix:
+    " sur les articles longs. Relancez ; réduisez l'effort d'un cran si cela se produit deux fois.",
+
+  // page de comparaison (ComparePage.tsx)
+  comparePanelErrorBody: "Impossible d'afficher celle-ci. Essayez un autre modèle ou une autre comparaison.",
+  comparePaperCorticalCircuits: "Circuits corticaux",
+  comparePaperCosetCodes: "Codes de cosets",
+  comparePaperPopulationGenetics: "Génétique des populations",
+  comparePaperTargetingInterventions: "Ciblage des interventions",
+  compareScoresShow: "Afficher",
+  compareScoresHide: "Masquer",
+  compareScoresToggleSuffix: " tous les scores pour tous les articles ",
+  compareScoresColPaper: "Article",
+  compareScoresColReference: "Référence",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Évalué par Gemini 3.1 Pro avec une entrée PDF multimodale. 5,0/5 = égale la qualité de référence. 5,5+/5 = la dépasse.",
+  compareJudgeShow: "Afficher",
+  compareJudgeHide: "Masquer",
+  compareJudgeToggleSuffix: " l'invite du juge envoyée à Gemini 3.1 Pro ",
+  compareJudgeExplain:
+    "Pour atténuer les biais connus du LLM-juge, le juge est exécuté deux fois par évaluation avec les deux relectures présentées dans un ordre inversé, et les scores sont moyennés sur les deux ordres. Cela contrecarre le biais de position, où les juges favorisent systématiquement la relecture présentée en premier. L'invite inclut aussi des instructions spécifiques pour contrecarrer le biais de verbosité (ne pas récompenser la longueur au détriment du fond), le biais de confiance (ne pas récompenser un ton affirmatif au détriment d'une prudence justifiée), le biais d'autorité (ne pas récompenser le jargon ou le nombre de citations au détriment de l'exactitude) et le biais de clémence (utiliser toute la plage de notation de 1 à 6 plutôt que de se regrouper au milieu). Les relectures sont étiquetées de façon neutre « Relecture A » et « Relecture B » plutôt que « référence » et « générée » afin d'éviter une notation fondée sur la provenance.",
+  compareJudgeSystemPromptLabel: "Invite système",
+  compareJudgeUserPromptLabel: "Invite utilisateur (article + relectures injectés à l'exécution)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Couverture",
+  compareMetricSpecificity: "Spécificité",
+  compareMetricDepth: "Profondeur",
+  compareJumpTo: "Aller à",
+  compareSectionOverallFeedback: "Retour global",
+  compareSectionDetailedComments: "Commentaires détaillés",
+  compareVisitPrefix: "Visiter ",
+  comparePdfReviewSuffix: " évaluation",
+  comparePdfFallback: "Téléchargez le PDF si l'iframe ne s'affiche pas ↓",
 };

--- a/web/src/lib/i18n/it.ts
+++ b/web/src/lib/i18n/it.ts
@@ -395,4 +395,184 @@ export const it: Messages = {
   paperPanelDownload: "Scarica",
   paperPanelDownloadAriaLabel: "Scarica l'articolo in markdown",
   paperPanelCloseAriaLabel: "Chiudi il pannello dell'articolo",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "Percorso di configurazione",
+  setupTabOpenRouter: "Chiave OpenRouter",
+  setupTabSubscription: "Usa il mio abbonamento",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "Ottieni la tua chiave OpenRouter",
+  setupOrIntro:
+    "Ci vogliono circa 2 minuti. Ti servirà una carta di credito per ~$1 di crediti iniziali — ricaricherai fino a $20 nel passaggio 2.",
+  setupOrFasterLabel: "Opzione più rapida:",
+  setupOrFasterMid1: " nel modulo principale puoi cliccare ",
+  setupOrFasterLogIn: "“Accedi con OpenRouter”",
+  setupOrFasterSuffix:
+    " per autorizzare coarse e saltare la creazione manuale della chiave. Ti serve comunque un account OpenRouter con crediti (passaggi 1 e 2 qui sotto), e consigliamo comunque di impostare un limite di spesa per chiave (passaggio 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "Crea un account",
+  setupOrStep1BodyPrefix: "Vai su ",
+  setupOrStep1BodySuffix: " e clicca su “Get API Key” oppure registrati con Google / GitHub.",
+  setupOrStep1Annotation: "homepage",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "Un'API unificata per gli LLM — una chiave, molti modelli.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "Aggiungi crediti",
+  setupOrStep2BodyPrefix: "Vai su ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Aggiungi almeno $20. I modelli open-source economici costano ~$0,25 a revisione; i modelli SOTA come Claude Opus o GPT-5 possono arrivare a $5–$10 su un articolo lungo. La stima dei costi mostrata prima dell'invio è indicativa, non un tetto massimo. Lascia un margine, altrimenti la revisione può esaurire la chiave a metà e fallire. I crediti non utilizzati non scadono.",
+  setupOrStep2Annotation: "pagina dei crediti",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Importo",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Saldo: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "Crea una chiave API",
+  setupOrStep3BodyPrefix: "Vai su ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", clicca su “Create Key” e chiamala ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Assicurati che sia una normale chiave API — non una chiave di provisioning/gestione dalla sezione integrazioni. Le chiavi di provisioning possono creare ed elencare altre chiavi ma non possono eseguire inferenza, e coarse fallirà con “User not found” se ne incolli una.",
+  setupOrStep3CopyWarning: "Copia la chiave ora — non la vedrai di nuovo.",
+  setupOrStep3Annotation: "pagina delle chiavi",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Nome chiave",
+  setupOrStep3MockYourKey: "La tua chiave",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "Imposta un limite di spesa sulla chiave",
+  setupOrStep4BodyPrefix: "Nella ",
+  setupOrStep4BodyLink: "pagina delle chiavi",
+  setupOrStep4BodyMid1: ", clicca sul menu ",
+  setupOrStep4BodyMid2: " accanto alla tua nuova chiave, scegli “Edit” e imposta il limite di credito ad ",
+  setupOrStep4BodyAtLeast: "almeno $20",
+  setupOrStep4BodySuffix:
+    ". La chiave smette di funzionare una volta raggiunto il limite, quindi addebiti a sorpresa sono impossibili. Ma se lo imposti troppo stretto, una singola revisione costosa può esaurirlo a metà esecuzione.",
+  setupOrStep4Annotation: "menu della chiave",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Limite di credito per questa chiave",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Perché è importante:",
+  setupOrStep4WhyMid1: " coarse è open-source — puoi ",
+  setupOrStep4WhyLink: "leggere ogni riga di codice",
+  setupOrStep4WhySuffix:
+    ". La tua chiave viene inviata direttamente a OpenRouter per eseguire la revisione, poi scartata — non viene mai conservata. Ma non devi fidarti di noi: il limite per chiave garantisce che non possa mai spendere più di quanto consenti, anche nel caso peggiore.",
+  setupOrStep4CostLabel: "Una nota sulle stime dei costi:",
+  setupOrStep4CostBody:
+    " la stima mostrata prima dell'invio è un'euristica con un margine del ~15%, non un tetto massimo. Il costo effettivo sui modelli SOTA con articoli lunghi può arrivare fino a ~2× la stima una volta che entrano in gioco la verifica delle dimostrazioni e le riscritture della critica. Se il limite per chiave è impostato esattamente sulla stima, una revisione impegnativa può prosciugarlo e fallire a metà esecuzione. Lascia sempre un margine.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "Incolla in coarse",
+  setupOrStep5Body: "Torna qui, incolla la tua chiave nel modulo e carica il tuo PDF.",
+  setupOrStep5Annotation: "modulo coarse",
+  setupOrStep5MockEmail: "Email",
+  setupOrStep5MockKey: "Chiave OpenRouter",
+  setupOrStep5MockButton: "Revisiona il mio articolo",
+  // setup page — shared footer CTA
+  setupReadyCta: "Pronto? Revisiona il tuo articolo →",
+  // setup page — subscription tab intro
+  setupSubHeading: "Usa l'abbonamento del tuo agente di coding",
+  setupSubIntro1:
+    "Per gli utenti che già pagano Claude Code, Codex o Gemini CLI. La revisione viene eseguita sul tuo abbonamento e viene addebitata lì. Paghi a OpenRouter solo ~$0,15 per il passaggio di OCR.",
+  setupSubIntro2:
+    "Viene eseguito in locale sulla tua macchina usando il tuo account Claude Code, Codex o Gemini CLI. coarse.ink non riceve né conserva il login del tuo provider. Si applicano comunque i termini e i limiti di utilizzo del tuo provider. coarse.ink non è affiliato ad Anthropic, OpenAI o Google.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "Installa un agente di coding",
+  setupSubStep1Body:
+    "Scegli quello che paghi. Gemini CLI ha un piano gratuito se non ne hai uno. Installalo dalla pagina ufficiale del fornitore — la loro documentazione resta aggiornata.",
+  setupSubStep1ClaudePrice: "Anthropic Pro o Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro o Business",
+  setupSubStep1GeminiPrice: "Il piano gratuito va bene per la maggior parte degli articoli",
+  setupSubStep1InstallLabel: "Istruzioni di installazione ↗",
+  setupSubStep1Verify:
+    "Esegui il comando di test per verificare installazione + login. Se stampa una risposta, sei a posto.",
+  setupSubStep1CardLogin: "login: ",
+  setupSubStep1CardTest: "test: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "Metti una chiave OpenRouter sulla tua macchina (solo PDF)",
+  setupSubStep2BodyPrefix:
+    "Questo passaggio si applica solo agli articoli in PDF — le fonti non PDF (.tex, .md, .docx, …) vengono estratte in locale senza OCR, quindi non richiedono alcuna chiave OpenRouter da nessuna parte e puoi passare direttamente al passaggio 3. Per i PDF, coarse ha comunque bisogno di OpenRouter per il passaggio di OCR (~$0,10 per articolo). Segui la scheda ",
+  setupSubStep2BodyTab: "Chiave OpenRouter",
+  setupSubStep2BodySuffix:
+    " per creare un account, aggiungere $1 di credito e impostare un limite di $2 per chiave. Il margine di $20 del percorso solo OpenRouter non serve qui perché la revisione stessa viene eseguita sull'abbonamento del tuo agente di coding.",
+  setupSubStep2KeyPrefix: "Poi metti la chiave sulla tua macchina: esegui ",
+  setupSubStep2KeyMid1: ", inseriscila in un ",
+  setupSubStep2KeyMid2: ", oppure salvala in ",
+  setupSubStep2KeySuffix:
+    ". La tua CLI la legge in locale quando esegue l'estrazione; coarse.ink non la vede mai.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "Carica il tuo articolo e scegli una CLI",
+  setupSubStep3BodyPrefix: "Nella ",
+  setupSubStep3BodyLink: "pagina principale",
+  setupSubStep3BodyMid: ", trascina il tuo articolo (PDF, .tex, .md, .docx, …) sul modulo, poi clicca sul menu a discesa ",
+  setupSubStep3BodyButton: "Revisiona con il mio abbonamento ▾",
+  setupSubStep3BodySuffix:
+    " e scegli la tua CLI. coarse carica il file, genera un token di trasferimento e mostra il prompt che incollerai nel passaggio successivo. Qui non incolli la tua chiave OpenRouter nel modulo; la CLI la legge dalla tua macchina (passaggio 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "Incolla il prompt nella tua CLI",
+  setupSubStep4BodyPrefix: "coarse ti dà un unico prompt in linguaggio naturale. Copialo dal pannello, incollalo nella tua sessione ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: " o ",
+  setupSubStep4BodyMid3: " e premi invio. L'agente aggiorna il suo pacchetto di skill, esegue l'intera pipeline coarse con le proprie chiamate a sottoprocessi e stampa un ",
+  setupSubStep4BodySuffix:
+    " URL al termine. 10–25 minuti. Clicca sull'URL per aprire la revisione completata su coarse.ink.",
+  setupSubStep4TimeoutLabel: "Se stai incollando in un agente di coding",
+  setupSubStep4TimeoutSuffix:
+    " (non un semplice terminale), aumenta il timeout dello strumento bash ad almeno 45 minuti prima di inviare il prompt. I timeout predefiniti degli agenti possono arrivare a soli 2 minuti, ben al di sotto del tempo di esecuzione di 10–25 minuti della revisione.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "Se qualcosa va storto",
+  setupSubTrouble1Symptom: "Il pulsante “Try opening Claude Code / Codex” non fa nulla.",
+  setupSubTrouble1Fix:
+    "Il pulsante funziona solo se hai installato l'app desktop. Con un'installazione solo CLI, il browser non può avviare un terminale per te. Copia il prompt dal pannello e incollalo manualmente nella tua CLI.",
+  setupSubTrouble2Symptom: "“No such command ‘install-skills’” durante l'esecuzione dell'agente.",
+  setupSubTrouble2FixPrefix: "Si può ignorare. Il pacchetto di skill viene comunque caricato direttamente tramite ",
+  setupSubTrouble2FixSuffix: "; l'agente proseguirà al passaggio di revisione.",
+  setupSubTrouble3Symptom: "La mia fattura Anthropic / OpenAI / Google è aumentata dopo una revisione.",
+  setupSubTrouble3FixPrefix: "Controlla la presenza di ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: " o ",
+  setupSubTrouble3FixSuffix:
+    " nell'ambiente della tua shell. Se impostate, la CLI host addebita l'account API invece del tuo abbonamento. La v1.3.0+ le rimuove automaticamente, ma le versioni precedenti no.",
+  setupSubTrouble4Symptom: "Meno commenti del solito (~10 invece di 15–25).",
+  setupSubTrouble4FixPrefix: "Una sezione ha raggiunto il timeout di 30 minuti ed è stata scartata. Raro con l'impegno predefinito, più comune con ",
+  setupSubTrouble4FixSuffix:
+    " su articoli lunghi. Riesegui; abbassa l'impegno di un livello se succede due volte.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "Impossibile renderizzare questo elemento. Prova un altro modello o confronto.",
+  comparePaperCorticalCircuits: "Circuiti corticali",
+  comparePaperCosetCodes: "Codici coset",
+  comparePaperPopulationGenetics: "Genetica delle popolazioni",
+  comparePaperTargetingInterventions: "Targeting degli interventi",
+  compareScoresShow: "Mostra",
+  compareScoresHide: "Nascondi",
+  compareScoresToggleSuffix: " tutti i punteggi tra gli articoli ",
+  compareScoresColPaper: "Articolo",
+  compareScoresColReference: "Riferimento",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Valutato da Gemini 3.1 Pro con input multimodale PDF. 5.0/5 = corrisponde alla qualità di riferimento. 5.5+/5 = la supera.",
+  compareJudgeShow: "Mostra",
+  compareJudgeHide: "Nascondi",
+  compareJudgeToggleSuffix: " il prompt del giudice inviato a Gemini 3.1 Pro ",
+  compareJudgeExplain:
+    "Per mitigare i noti bias del modello come giudice, il giudice viene eseguito due volte per ogni valutazione con le due revisioni invertite nell'ordine di presentazione, e i punteggi vengono mediati su entrambi gli ordinamenti. Questo contrasta il bias posizionale, per cui i giudici favoriscono sistematicamente la revisione che appare per prima. Il prompt include anche istruzioni specifiche per contrastare il bias di prolissità (non premiare la lunghezza rispetto alla sostanza), il bias di sicurezza (non premiare un linguaggio assertivo rispetto a un'opportuna cautela), il bias di autorità (non premiare il gergo o il numero di citazioni rispetto all'accuratezza) e il bias di indulgenza (usare l'intera scala di punteggio da 1 a 6 anziché concentrarsi nel mezzo). Le revisioni sono etichettate in modo neutro come \"Review A\" e \"Review B\" anziché \"riferimento\" e \"generata\" per evitare punteggi basati sulla provenienza.",
+  compareJudgeSystemPromptLabel: "Prompt di sistema",
+  compareJudgeUserPromptLabel: "Prompt utente (articolo + revisioni inseriti in fase di esecuzione)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Copertura",
+  compareMetricSpecificity: "Specificità",
+  compareMetricDepth: "Profondità",
+  compareJumpTo: "Vai a",
+  compareSectionOverallFeedback: "Valutazione complessiva",
+  compareSectionDetailedComments: "Commenti dettagliati",
+  compareVisitPrefix: "Visita ",
+  comparePdfReviewSuffix: " revisione",
+  comparePdfFallback: "Scarica il PDF se l'iframe non viene renderizzato ↓",
 };

--- a/web/src/lib/i18n/ja.ts
+++ b/web/src/lib/i18n/ja.ts
@@ -393,4 +393,184 @@ export const ja: Messages = {
   paperPanelDownload: "ダウンロード",
   paperPanelDownloadAriaLabel: "論文の Markdown をダウンロード",
   paperPanelCloseAriaLabel: "論文パネルを閉じる",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "セットアップの方法",
+  setupTabOpenRouter: "OpenRouter キー",
+  setupTabSubscription: "自分のサブスクリプションを使う",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "OpenRouter キーを取得する",
+  setupOrIntro:
+    "所要時間は約 2 分です。開始するにはクレジットカードと ~$1 のクレジットが必要です — ステップ 2 で $20 までチャージします。",
+  setupOrFasterLabel: "より速い方法:",
+  setupOrFasterMid1: " メインのフォームで ",
+  setupOrFasterLogIn: "「OpenRouter でログイン」",
+  setupOrFasterSuffix:
+    " をクリックすると、coarse を認可して手動でのキー作成をスキップできます。それでもクレジットのある OpenRouter アカウントは必要で（下記のステップ 1 と 2）、キーごとの利用上限を設定することを引き続きおすすめします（ステップ 4）。",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "アカウントを作成する",
+  setupOrStep1BodyPrefix: "次にアクセスして ",
+  setupOrStep1BodySuffix: " 「Get API Key」をクリックするか、Google / GitHub でサインアップしてください。",
+  setupOrStep1Annotation: "ホームページ",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "LLM のための統合 API — 1 つのキーで多数のモデルを。",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "クレジットを追加する",
+  setupOrStep2BodyPrefix: "次に移動して ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    "。少なくとも $20 を追加してください。安価なオープンソースモデルは 1 回のレビューあたり ~$0.25 ですが、Claude Opus や GPT-5 のような最先端モデルは長い論文では $5–$10 かかることがあります。投稿前に表示される費用見積もりはおおよその目安であり、上限ではありません。余裕を持たせないと、レビューが途中でキーを使い切って失敗することがあります。未使用のクレジットは失効しません。",
+  setupOrStep2Annotation: "クレジットページ",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "金額",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "残高: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "API キーを作成する",
+  setupOrStep3BodyPrefix: "次にアクセスして ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: "「Create Key」をクリックし、次の名前を付けてください ",
+  setupOrStep3BodySuffix: "。",
+  setupOrStep3Provisioning:
+    "それが通常の API キーであることを確認してください — インテグレーションのセクションにあるプロビジョニング/管理用キーではありません。プロビジョニングキーは他のキーの作成や一覧表示はできますが推論を実行できず、それを貼り付けると coarse は「User not found」で失敗します。",
+  setupOrStep3CopyWarning: "今すぐキーをコピーしてください — 二度と表示されません。",
+  setupOrStep3Annotation: "キーページ",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "キー名",
+  setupOrStep3MockYourKey: "あなたのキー",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "キーに利用上限を設定する",
+  setupOrStep4BodyPrefix: "次の場所で ",
+  setupOrStep4BodyLink: "Keys ページ",
+  setupOrStep4BodyMid1: "新しいキーの横にある ",
+  setupOrStep4BodyMid2: " メニューをクリックし、「Edit」を選んで、クレジット上限を次のように設定してください ",
+  setupOrStep4BodyAtLeast: "少なくとも $20",
+  setupOrStep4BodySuffix:
+    "。上限に達するとキーは動作を停止するため、想定外の請求が発生することはありません。ただし、設定が厳しすぎると、1 回の高額なレビューで途中で使い切ることがあります。",
+  setupOrStep4Annotation: "キーメニュー",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "このキーのクレジット上限",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "これが重要な理由:",
+  setupOrStep4WhyMid1: " coarse はオープンソースです — ",
+  setupOrStep4WhyLink: "すべてのコードを読む",
+  setupOrStep4WhySuffix:
+    "ことができます。あなたのキーはレビューを実行するために OpenRouter に直接送信され、その後破棄されます — 保存されることはありません。しかし当社を信用する必要はありません。キーごとの上限により、最悪の場合でも、あなたが許可した以上に使われることは決してないと保証されます。",
+  setupOrStep4CostLabel: "費用見積もりに関する注意:",
+  setupOrStep4CostBody:
+    " 投稿前に表示される見積もりは ~15% のバッファを持つヒューリスティックであり、確固たる上限ではありません。最先端モデルで長い論文の場合、証明の検証や批評の書き直しが始まると、実際の費用は見積もりの ~2 倍まで達することがあります。キーごとの上限が見積もりちょうどに設定されていると、難しいレビュー 1 回でそれを使い切って途中で失敗することがあります。常に余裕を持たせてください。",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "coarse に貼り付ける",
+  setupOrStep5Body: "ここに戻ってきて、キーをフォームに貼り付け、PDF をアップロードしてください。",
+  setupOrStep5Annotation: "coarse フォーム",
+  setupOrStep5MockEmail: "メール",
+  setupOrStep5MockKey: "OpenRouter キー",
+  setupOrStep5MockButton: "論文をレビューする",
+  // setup page — shared footer CTA
+  setupReadyCta: "準備はいいですか？論文をレビューする →",
+  // setup page — subscription tab intro
+  setupSubHeading: "コーディングエージェントのサブスクリプションを使う",
+  setupSubIntro1:
+    "すでに Claude Code、Codex、または Gemini CLI に料金を支払っているユーザー向けです。レビューはあなたのサブスクリプションで実行され、そこに課金されます。OCR パスのために OpenRouter に ~$0.15 をお支払いいただくだけです。",
+  setupSubIntro2:
+    "ご自身の Claude Code、Codex、または Gemini CLI アカウントを使用して、ご自身のマシン上でローカルに実行されます。coarse.ink はあなたのプロバイダーのログイン情報を受信または保存しません。お使いのプロバイダーの利用規約と利用上限は引き続き適用されます。coarse.ink は Anthropic、OpenAI、Google とは提携していません。",
+  // setup page — subscription step 1
+  setupSubStep1Title: "コーディングエージェントをインストールする",
+  setupSubStep1Body:
+    "お支払いになっているものをどれでも選んでください。支払っていない場合は、Gemini CLI に無料枠があります。ベンダー自身のページからインストールしてください — そちらのドキュメントは最新の状態に保たれています。",
+  setupSubStep1ClaudePrice: "Anthropic Pro または Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus、Pro、または Business",
+  setupSubStep1GeminiPrice: "無料枠でほとんどの論文に対応できます",
+  setupSubStep1InstallLabel: "インストール手順 ↗",
+  setupSubStep1Verify:
+    "テストコマンドを実行して、インストールとログインを確認してください。応答が表示されれば、準備完了です。",
+  setupSubStep1CardLogin: "ログイン: ",
+  setupSubStep1CardTest: "テスト: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "OpenRouter キーをマシンに用意する（PDF のみ）",
+  setupSubStep2BodyPrefix:
+    "このステップは PDF の論文にのみ当てはまります — PDF 以外のソース（.tex, .md, .docx, …）は OCR なしでローカルに抽出されるため、どこにも OpenRouter キーは不要で、ステップ 3 にそのまま進めます。PDF の場合、coarse は OCR ステップ（1 論文あたり ~$0.10）のために引き続き OpenRouter を必要とします。次に従ってください ",
+  setupSubStep2BodyTab: "OpenRouter キー",
+  setupSubStep2BodySuffix:
+    " のタブで、アカウントを作成し、$1 のクレジットを追加して、キーごとに $2 の上限を設定してください。OpenRouter 単独の方法で必要だった $20 のバッファはここでは不要です。レビュー自体はあなたのコーディングエージェントのサブスクリプションで実行されるためです。",
+  setupSubStep2KeyPrefix: "次に、キーをご自身のマシンに用意してください: 次を実行するか ",
+  setupSubStep2KeyMid1: "次に保存するか ",
+  setupSubStep2KeyMid2: "または次に保存してください ",
+  setupSubStep2KeySuffix:
+    "。抽出を実行するとき、CLI はそれをローカルで読み取ります。coarse.ink がそれを目にすることは決してありません。",
+  // setup page — subscription step 3
+  setupSubStep3Title: "論文をアップロードし、CLI を選ぶ",
+  setupSubStep3BodyPrefix: "次の場所で ",
+  setupSubStep3BodyLink: "メインページ",
+  setupSubStep3BodyMid: "論文（PDF, .tex, .md, .docx, …）をフォームにドロップし、次をクリックしてください ",
+  setupSubStep3BodyButton: "自分のサブスクリプションでレビュー ▾",
+  setupSubStep3BodySuffix:
+    " のドロップダウンを開いて CLI を選んでください。coarse はファイルをアップロードし、引き継ぎトークンを発行し、次のステップで貼り付けるプロンプトを表示します。ここではフォームに OpenRouter キーを貼り付けません。CLI があなたのマシンからそれを読み取ります（ステップ 2）。",
+  // setup page — subscription step 4
+  setupSubStep4Title: "プロンプトを CLI に貼り付ける",
+  setupSubStep4BodyPrefix: "coarse は自然言語のプロンプトを 1 つお渡しします。パネルからそれをコピーし、次の ",
+  setupSubStep4BodyMid1: "、 ",
+  setupSubStep4BodyMid2: "、または ",
+  setupSubStep4BodyMid3: " のセッションに貼り付け、送信を押してください。エージェントはスキルバンドルを更新し、独自のサブプロセス呼び出しで完全な coarse パイプラインを実行し、完了すると次を表示します ",
+  setupSubStep4BodySuffix:
+    " の URL です。所要時間は 10–25 分です。その URL をクリックすると、coarse.ink で完成したレビューが開きます。",
+  setupSubStep4TimeoutLabel: "コーディングエージェントに貼り付ける場合",
+  setupSubStep4TimeoutSuffix:
+    " (プレーンなターミナルではない場合)、プロンプトを送信する前に、その bash ツールのタイムアウトを少なくとも 45 分まで引き上げてください。エージェントのデフォルトのタイムアウトは 2 分ほどと短いことがあり、10–25 分のレビュー実行時間を大きく下回ります。",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "うまくいかない場合",
+  setupSubTrouble1Symptom: "「Try opening Claude Code / Codex」ボタンを押しても何も起こらない。",
+  setupSubTrouble1Fix:
+    "このボタンはデスクトップアプリがインストールされている場合にのみ動作します。CLI のみのインストールでは、ブラウザがあなたのためにターミナルを起動できません。パネルからプロンプトをコピーし、手動で CLI に貼り付けてください。",
+  setupSubTrouble2Symptom: "エージェントの実行中に「No such command ‘install-skills’」が表示される。",
+  setupSubTrouble2FixPrefix: "無視して問題ありません。スキルバンドルは引き続き次を通じて直接読み込まれます ",
+  setupSubTrouble2FixSuffix: "。エージェントはレビューのステップへと続行します。",
+  setupSubTrouble3Symptom: "レビュー後に Anthropic / OpenAI / Google の請求が増えた。",
+  setupSubTrouble3FixPrefix: "次を確認してください ",
+  setupSubTrouble3FixMid1: "、 ",
+  setupSubTrouble3FixMid2: "、または ",
+  setupSubTrouble3FixSuffix:
+    " がシェル環境にないか。設定されていると、ホスト CLI はあなたのサブスクリプションではなく API アカウントに課金します。v1.3.0 以降はこれらを自動的に取り除きますが、それ以前のバージョンでは行いませんでした。",
+  setupSubTrouble4Symptom: "コメントがいつもより少ない（15–25 件ではなく ~10 件）。",
+  setupSubTrouble4FixPrefix: "あるセクションが 30 分のタイムアウトに達して除外されました。デフォルトの強度ではまれですが、次の場合に起きやすくなります ",
+  setupSubTrouble4FixSuffix:
+    " 長い論文の場合です。再実行してください。2 回起きるようなら強度を 1 段階下げてください。",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "これは表示できませんでした。別のモデルか比較をお試しください。",
+  comparePaperCorticalCircuits: "皮質回路",
+  comparePaperCosetCodes: "剰余類符号",
+  comparePaperPopulationGenetics: "集団遺伝学",
+  comparePaperTargetingInterventions: "介入のターゲティング",
+  compareScoresShow: "表示",
+  compareScoresHide: "非表示",
+  compareScoresToggleSuffix: " 全論文にわたるすべてのスコア ",
+  compareScoresColPaper: "論文",
+  compareScoresColReference: "リファレンス",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Gemini 3.1 Pro が PDF のマルチモーダル入力で評価しました。5.0/5 = リファレンスと同等の品質。5.5+/5 = それを上回ります。",
+  compareJudgeShow: "表示",
+  compareJudgeHide: "非表示",
+  compareJudgeToggleSuffix: " Gemini 3.1 Pro に送信された判定プロンプト ",
+  compareJudgeExplain:
+    "既知の LLM-as-judge バイアスを軽減するため、判定は評価ごとに 2 回実行され、2 つのレビューを提示順で入れ替え、両方の順序でスコアを平均します。これは、判定者が先に表示されたレビューを体系的に優遇する位置バイアスを打ち消します。プロンプトには、冗長性バイアス（中身よりも長さを評価しない）、自信バイアス（適切なヘッジングよりも断定的な言い回しを評価しない）、権威バイアス（正確さよりも専門用語や引用数を評価しない）、寛大さバイアス（中間に偏らず 1〜6 の全スコア範囲を使う）を打ち消すための具体的な指示も含まれています。レビューは出自に基づくスコアリングを防ぐため、「リファレンス」や「生成」ではなく中立的に「レビュー A」「レビュー B」とラベル付けされます。",
+  compareJudgeSystemPromptLabel: "システムプロンプト",
+  compareJudgeUserPromptLabel: "ユーザープロンプト（論文 + レビューは実行時に挿入されます）",
+  compareVsMid: " 対 ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "カバレッジ",
+  compareMetricSpecificity: "具体性",
+  compareMetricDepth: "深さ",
+  compareJumpTo: "ジャンプ先",
+  compareSectionOverallFeedback: "全体的なフィードバック",
+  compareSectionDetailedComments: "詳細なコメント",
+  compareVisitPrefix: "次にアクセス ",
+  comparePdfReviewSuffix: " のレビュー",
+  comparePdfFallback: "iframe が表示されない場合は PDF をダウンロードしてください ↓",
 };

--- a/web/src/lib/i18n/ko.ts
+++ b/web/src/lib/i18n/ko.ts
@@ -393,4 +393,184 @@ export const ko: Messages = {
   paperPanelDownload: "다운로드",
   paperPanelDownloadAriaLabel: "논문 마크다운 다운로드",
   paperPanelCloseAriaLabel: "논문 패널 닫기",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "설정 경로",
+  setupTabOpenRouter: "OpenRouter 키",
+  setupTabSubscription: "내 구독 사용하기",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "OpenRouter 키 발급받기",
+  setupOrIntro:
+    "약 2분이 걸립니다. 시작하려면 ~$1의 크레딧을 위한 신용카드가 필요합니다 — 2단계에서 $20까지 충전하시게 됩니다.",
+  setupOrFasterLabel: "더 빠른 방법:",
+  setupOrFasterMid1: " 메인 폼에서 ",
+  setupOrFasterLogIn: "“OpenRouter로 로그인”",
+  setupOrFasterSuffix:
+    " 을(를) 클릭하면 coarse를 승인하고 수동 키 생성을 건너뛸 수 있습니다. 여전히 크레딧이 있는 OpenRouter 계정이 필요하며(아래 1단계와 2단계), 키별 지출 한도 설정(4단계)도 권장합니다.",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "계정 만들기",
+  setupOrStep1BodyPrefix: "다음으로 이동하세요: ",
+  setupOrStep1BodySuffix: " 그런 다음 “Get API Key”를 클릭하거나 Google / GitHub으로 가입하세요.",
+  setupOrStep1Annotation: "홈페이지",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "LLM을 위한 통합 API — 하나의 키로 여러 모델을.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "크레딧 추가",
+  setupOrStep2BodyPrefix: "다음으로 이동하세요: ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". 최소 $20를 추가하세요. 저렴한 오픈 소스 모델은 리뷰당 ~$0.25, Claude Opus나 GPT-5 같은 SOTA 모델은 긴 논문에서 $5–$10가 들 수 있습니다. 제출 전에 표시되는 비용 추정치는 대략적인 값일 뿐 상한선이 아닙니다. 여유를 두지 않으면 리뷰가 중간에 키를 소진하고 실패할 수 있습니다. 사용하지 않은 크레딧은 만료되지 않습니다.",
+  setupOrStep2Annotation: "크레딧 페이지",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "금액",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Balance: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "API 키 만들기",
+  setupOrStep3BodyPrefix: "다음으로 이동하세요: ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", “Create Key”를 클릭하고 이름을 다음으로 지정하세요: ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "반드시 일반 API 키여야 합니다 — integrations 섹션의 프로비저닝/관리 키가 아니어야 합니다. 프로비저닝 키는 다른 키를 생성하고 나열할 수 있지만 추론은 실행할 수 없으며, 이런 키를 붙여넣으면 coarse가 “User not found” 오류로 실패합니다.",
+  setupOrStep3CopyWarning: "지금 키를 복사하세요 — 다시 볼 수 없습니다.",
+  setupOrStep3Annotation: "키 페이지",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "키 이름",
+  setupOrStep3MockYourKey: "당신의 키",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "키에 지출 한도 설정하기",
+  setupOrStep4BodyPrefix: "다음에서: ",
+  setupOrStep4BodyLink: "키 페이지",
+  setupOrStep4BodyMid1: ", 새 키 옆의 ",
+  setupOrStep4BodyMid2: " 메뉴를 클릭하고 “Edit”를 선택한 다음 크레딧 한도를 다음으로 설정하세요: ",
+  setupOrStep4BodyAtLeast: "최소 $20",
+  setupOrStep4BodySuffix:
+    ". 한도에 도달하면 키가 작동을 멈추므로 예상치 못한 청구는 불가능합니다. 하지만 너무 빡빡하게 설정하면 비싼 리뷰 하나가 실행 도중에 키를 소진시킬 수 있습니다.",
+  setupOrStep4Annotation: "키 메뉴",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "이 키의 크레딧 한도",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "이것이 중요한 이유:",
+  setupOrStep4WhyMid1: " coarse는 오픈 소스입니다 — 다음을 할 수 있습니다: ",
+  setupOrStep4WhyLink: "모든 코드 줄 읽어보기",
+  setupOrStep4WhySuffix:
+    ". 키는 리뷰를 실행하기 위해 OpenRouter로 직접 전송된 뒤 폐기되며 — 절대 저장되지 않습니다. 하지만 저희를 믿으실 필요는 없습니다: 키별 한도가 최악의 경우에도 허용한 금액 이상을 절대 쓸 수 없도록 보장합니다.",
+  setupOrStep4CostLabel: "비용 추정치에 관한 참고 사항:",
+  setupOrStep4CostBody:
+    " 제출 전에 표시되는 추정치는 ~15% 여유를 둔 휴리스틱이며 엄격한 상한선이 아닙니다. 긴 논문에 SOTA 모델을 사용하면 증명 검증과 비판 재작성이 작동하기 시작하면서 실제 비용이 추정치의 ~2배까지 들 수 있습니다. 키별 상한이 추정치에 딱 맞춰져 있으면 까다로운 리뷰 하나가 이를 소진하고 실행 도중에 실패할 수 있습니다. 항상 여유를 두세요.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "coarse에 붙여넣기",
+  setupOrStep5Body: "여기로 돌아와 키를 폼에 붙여넣고 PDF를 업로드하세요.",
+  setupOrStep5Annotation: "coarse 폼",
+  setupOrStep5MockEmail: "이메일",
+  setupOrStep5MockKey: "OpenRouter 키",
+  setupOrStep5MockButton: "내 논문 리뷰하기",
+  // setup page — shared footer CTA
+  setupReadyCta: "준비되셨나요? 논문을 리뷰하세요 →",
+  // setup page — subscription tab intro
+  setupSubHeading: "코딩 에이전트 구독 사용하기",
+  setupSubIntro1:
+    "이미 Claude Code, Codex 또는 Gemini CLI에 비용을 지불하고 있는 사용자를 위한 방법입니다. 리뷰는 사용자의 구독으로 실행되어 거기에 청구됩니다. OCR 단계에 대해서만 OpenRouter에 ~$0.15를 지불합니다.",
+  setupSubIntro2:
+    "자신의 Claude Code, Codex 또는 Gemini CLI 계정을 사용하여 사용자의 컴퓨터에서 로컬로 실행됩니다. coarse.ink는 사용자의 제공자 로그인을 수신하거나 저장하지 않습니다. 제공자의 약관과 사용 한도는 여전히 적용됩니다. coarse.ink는 Anthropic, OpenAI 또는 Google과 제휴 관계가 없습니다.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "코딩 에이전트 설치하기",
+  setupSubStep1Body:
+    "비용을 지불하고 있는 것 중 아무거나 고르세요. 없다면 Gemini CLI에 무료 등급이 있습니다. 벤더의 자체 페이지에서 설치하세요 — 해당 문서가 최신 상태로 유지됩니다.",
+  setupSubStep1ClaudePrice: "Anthropic Pro 또는 Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro 또는 Business",
+  setupSubStep1GeminiPrice: "대부분의 논문에는 무료 등급으로 충분합니다",
+  setupSubStep1InstallLabel: "설치 안내 ↗",
+  setupSubStep1Verify:
+    "테스트 명령을 실행하여 설치 + 로그인을 확인하세요. 응답이 출력되면 준비된 것입니다.",
+  setupSubStep1CardLogin: "로그인: ",
+  setupSubStep1CardTest: "테스트: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "사용자 컴퓨터에 OpenRouter 키 두기 (PDF만 해당)",
+  setupSubStep2BodyPrefix:
+    "이 단계는 PDF 논문에만 적용됩니다 — PDF가 아닌 소스(.tex, .md, .docx, …)는 OCR 없이 로컬에서 추출되므로 어디에도 OpenRouter 키가 필요 없으며 바로 3단계로 건너뛸 수 있습니다. PDF의 경우 coarse는 OCR 단계(논문당 ~$0.10)에 여전히 OpenRouter가 필요합니다. 다음 ",
+  setupSubStep2BodyTab: "OpenRouter 키",
+  setupSubStep2BodySuffix:
+    " 탭을 따라 계정을 만들고, $1의 크레딧을 추가하고, $2의 키별 한도를 설정하세요. OpenRouter 전용 경로의 $20 여유분은 여기서는 필요하지 않습니다. 리뷰 자체가 코딩 에이전트 구독으로 실행되기 때문입니다.",
+  setupSubStep2KeyPrefix: "그런 다음 키를 자신의 컴퓨터에 두세요: 다음을 실행하거나 ",
+  setupSubStep2KeyMid1: ", 다음에 넣거나 ",
+  setupSubStep2KeyMid2: ", 다음에 저장하세요 ",
+  setupSubStep2KeySuffix:
+    ". CLI가 추출을 실행할 때 로컬에서 키를 읽습니다. coarse.ink는 키를 절대 보지 않습니다.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "논문 업로드하고 CLI 선택하기",
+  setupSubStep3BodyPrefix: "다음에서: ",
+  setupSubStep3BodyLink: "메인 페이지",
+  setupSubStep3BodyMid: ", 논문(PDF, .tex, .md, .docx, …)을 폼에 끌어다 놓은 다음 ",
+  setupSubStep3BodyButton: "내 구독으로 리뷰하기 ▾",
+  setupSubStep3BodySuffix:
+    " 드롭다운을 클릭하고 CLI를 선택하세요. coarse가 파일을 업로드하고 핸드오프 토큰을 발급한 뒤 다음 단계에서 붙여넣을 프롬프트를 보여줍니다. 여기 폼에는 OpenRouter 키를 붙여넣지 않습니다. CLI가 사용자의 컴퓨터에서 키를 읽습니다(2단계).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "프롬프트를 CLI에 붙여넣기",
+  setupSubStep4BodyPrefix: "coarse가 하나의 자연어 프롬프트를 제공합니다. 패널에서 복사하여 다음 ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: ", 또는 ",
+  setupSubStep4BodyMid3: " 세션에 붙여넣고 전송을 누르세요. 에이전트가 스킬 번들을 새로 고치고, 자체 하위 프로세스 호출로 전체 coarse 파이프라인을 실행한 뒤 완료되면 ",
+  setupSubStep4BodySuffix:
+    " URL을 출력합니다. 10–25분이 걸립니다. URL을 클릭하면 완성된 리뷰가 coarse.ink에서 열립니다.",
+  setupSubStep4TimeoutLabel: "코딩 에이전트에 붙여넣는 경우",
+  setupSubStep4TimeoutSuffix:
+    " (일반 터미널이 아닌 경우) 프롬프트를 전송하기 전에 bash 도구 타임아웃을 최소 45분으로 늘리세요. 기본 에이전트 타임아웃은 2분 정도로 낮을 수 있어 10–25분의 리뷰 실행 시간에 훨씬 못 미칩니다.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "문제가 발생하면",
+  setupSubTrouble1Symptom: "“Try opening Claude Code / Codex” 버튼을 눌러도 아무 일이 일어나지 않습니다.",
+  setupSubTrouble1Fix:
+    "이 버튼은 데스크톱 앱이 설치되어 있어야만 작동합니다. CLI만 설치된 경우 브라우저가 터미널을 대신 실행할 수 없습니다. 패널에서 프롬프트를 복사하여 CLI에 직접 붙여넣으세요.",
+  setupSubTrouble2Symptom: "에이전트 실행 중 “No such command ‘install-skills’”.",
+  setupSubTrouble2FixPrefix: "무시해도 안전합니다. 스킬 번들은 여전히 다음을 통해 직접 로드됩니다: ",
+  setupSubTrouble2FixSuffix: "; 에이전트는 리뷰 단계로 계속 진행합니다.",
+  setupSubTrouble3Symptom: "리뷰 후 Anthropic / OpenAI / Google 청구액이 늘었습니다.",
+  setupSubTrouble3FixPrefix: "다음을 확인하세요: ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: ", 또는 ",
+  setupSubTrouble3FixSuffix:
+    " 가 셸 환경에 있는지 확인하세요. 설정되어 있으면 호스트 CLI가 구독 대신 API 계정에 청구합니다. v1.3.0+에서는 이를 자동으로 제거하지만 이전 버전에서는 그렇지 않았습니다.",
+  setupSubTrouble4Symptom: "평소보다 코멘트가 적습니다(15–25개 대신 ~10개).",
+  setupSubTrouble4FixPrefix: "한 섹션이 30분 타임아웃에 걸려 누락되었습니다. 기본 추론 강도에서는 드물지만 긴 논문에 ",
+  setupSubTrouble4FixSuffix:
+    " 을(를) 사용하면 더 흔합니다. 다시 실행하세요. 두 번 발생하면 추론 강도를 한 단계 낮추세요.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "이것을 렌더링할 수 없었습니다. 다른 모델이나 비교를 시도해 보세요.",
+  comparePaperCorticalCircuits: "Cortical Circuits",
+  comparePaperCosetCodes: "Coset Codes",
+  comparePaperPopulationGenetics: "Population Genetics",
+  comparePaperTargetingInterventions: "Targeting Interventions",
+  compareScoresShow: "보기",
+  compareScoresHide: "숨기기",
+  compareScoresToggleSuffix: " 논문별 전체 점수 ",
+  compareScoresColPaper: "논문",
+  compareScoresColReference: "참조",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "PDF 멀티모달 입력으로 Gemini 3.1 Pro가 평가했습니다. 5.0/5 = 참조 품질과 동등. 5.5+/5 = 그 이상.",
+  compareJudgeShow: "보기",
+  compareJudgeHide: "숨기기",
+  compareJudgeToggleSuffix: " Gemini 3.1 Pro에 전송된 심사 프롬프트 ",
+  compareJudgeExplain:
+    "알려진 LLM-as-judge 편향을 완화하기 위해, 심사자는 평가마다 두 리뷰의 제시 순서를 바꿔 두 번 실행되며 점수는 두 순서에 걸쳐 평균을 냅니다. 이는 심사자가 먼저 나오는 리뷰를 체계적으로 선호하는 위치 편향에 대응합니다. 프롬프트에는 또한 장황함 편향(분량을 내용보다 우대하지 않음), 확신 편향(올바른 신중함보다 단정적인 표현을 우대하지 않음), 권위 편향(정확성보다 전문 용어나 인용 수를 우대하지 않음), 관대함 편향(중간에 몰리지 않고 1-6점 척도 전체를 사용)에 대응하기 위한 구체적인 지침이 포함됩니다. 리뷰는 출처 기반 채점을 방지하기 위해 \"참조\"와 \"생성됨\" 대신 \"Review A\"와 \"Review B\"로 중립적으로 표시됩니다.",
+  compareJudgeSystemPromptLabel: "시스템 프롬프트",
+  compareJudgeUserPromptLabel: "사용자 프롬프트(논문 + 리뷰가 런타임에 삽입됨)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "범위",
+  compareMetricSpecificity: "구체성",
+  compareMetricDepth: "깊이",
+  compareJumpTo: "이동",
+  compareSectionOverallFeedback: "전체 피드백",
+  compareSectionDetailedComments: "상세 코멘트",
+  compareVisitPrefix: "방문: ",
+  comparePdfReviewSuffix: " 리뷰",
+  comparePdfFallback: "iframe이 렌더링되지 않으면 PDF를 다운로드하세요 ↓",
 };

--- a/web/src/lib/i18n/nl.ts
+++ b/web/src/lib/i18n/nl.ts
@@ -372,4 +372,184 @@ export const nl: Messages = {
   paperPanelDownload: "Downloaden",
   paperPanelDownloadAriaLabel: "Artikel-markdown downloaden",
   paperPanelCloseAriaLabel: "Artikelpaneel sluiten",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "Setup-pad",
+  setupTabOpenRouter: "OpenRouter-sleutel",
+  setupTabSubscription: "Mijn abonnement gebruiken",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "Haal je OpenRouter-sleutel op",
+  setupOrIntro:
+    "Duurt ongeveer 2 minuten. Je hebt een kredietkaart nodig voor ~$1 aan tegoed om te starten — in stap 2 vul je aan tot $20.",
+  setupOrFasterLabel: "Snellere optie:",
+  setupOrFasterMid1: " op het hoofdformulier kun je klikken op ",
+  setupOrFasterLogIn: "“Inloggen met OpenRouter”",
+  setupOrFasterSuffix:
+    " om coarse te autoriseren en het handmatig aanmaken van een sleutel over te slaan. Je hebt nog steeds een OpenRouter-account met tegoed nodig (stappen 1 en 2 hieronder), en we raden nog steeds aan om een uitgavenlimiet per sleutel in te stellen (stap 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "Maak een account aan",
+  setupOrStep1BodyPrefix: "Ga naar ",
+  setupOrStep1BodySuffix: " en klik op “Get API Key” of meld je aan met Google / GitHub.",
+  setupOrStep1Annotation: "homepage",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "Eén uniforme API voor LLM's — één sleutel, veel modellen.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "Voeg tegoed toe",
+  setupOrStep2BodyPrefix: "Navigeer naar ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Voeg minstens $20 toe. Goedkope open-source modellen kosten ~$0,25 per review; SOTA-modellen zoals Claude Opus of GPT-5 kunnen op een lang artikel $5–$10 lopen. De kostenschatting die voor het indienen wordt getoond, is een ruwe inschatting, geen plafond. Laat speling over, anders kan de review de sleutel halverwege uitputten en mislukken. Ongebruikt tegoed verloopt niet.",
+  setupOrStep2Annotation: "tegoedpagina",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Bedrag",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Saldo: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "Maak een API-sleutel aan",
+  setupOrStep3BodyPrefix: "Ga naar ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", klik op “Create Key” en noem hem ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Zorg dat het een gewone API-sleutel is — niet een provisioning-/managementsleutel uit de integraties-sectie. Provisioning-sleutels kunnen andere sleutels aanmaken en opsommen, maar kunnen geen inferentie draaien, en coarse mislukt met “User not found” als je er zo een plakt.",
+  setupOrStep3CopyWarning: "Kopieer de sleutel nu — je krijgt hem niet opnieuw te zien.",
+  setupOrStep3Annotation: "sleutelpagina",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Sleutelnaam",
+  setupOrStep3MockYourKey: "Je sleutel",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "Stel een uitgavenlimiet in op de sleutel",
+  setupOrStep4BodyPrefix: "Op de ",
+  setupOrStep4BodyLink: "sleutelpagina",
+  setupOrStep4BodyMid1: ", klik op het ",
+  setupOrStep4BodyMid2: "-menu naast je nieuwe sleutel, kies “Edit” en stel de tegoedlimiet in op ",
+  setupOrStep4BodyAtLeast: "minstens $20",
+  setupOrStep4BodySuffix:
+    ". De sleutel stopt met werken zodra de limiet is bereikt, dus onverwachte kosten zijn onmogelijk. Maar stel je hem te krap in, dan kan één dure review hem middenin uitputten.",
+  setupOrStep4Annotation: "sleutelmenu",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Tegoedlimiet voor deze sleutel",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Waarom dit belangrijk is:",
+  setupOrStep4WhyMid1: " coarse is open-source — je kunt ",
+  setupOrStep4WhyLink: "elke regel code lezen",
+  setupOrStep4WhySuffix:
+    ". Je sleutel wordt rechtstreeks naar OpenRouter gestuurd om de review te draaien en daarna weggegooid — hij wordt nooit bewaard. Maar je hoeft ons niet te vertrouwen: de limiet per sleutel garandeert dat hij nooit meer kan uitgeven dan jij toestaat, zelfs in het slechtste geval.",
+  setupOrStep4CostLabel: "Een opmerking over kostenschattingen:",
+  setupOrStep4CostBody:
+    " de schatting die voor het indienen wordt getoond, is een heuristiek met een buffer van ~15%, geen hard plafond. De werkelijke kosten op SOTA-modellen met lange artikels kunnen oplopen tot ~2× de schatting zodra proefverificatie en kritiekherschrijvingen op gang komen. Als de limiet per sleutel precies op de schatting zit, kan één lastige review hem leegmaken en middenin mislukken. Laat altijd speling over.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "Plak in coarse",
+  setupOrStep5Body: "Kom hierheen terug, plak je sleutel in het formulier en upload je PDF.",
+  setupOrStep5Annotation: "coarse-formulier",
+  setupOrStep5MockEmail: "E-mail",
+  setupOrStep5MockKey: "OpenRouter-sleutel",
+  setupOrStep5MockButton: "Review mijn artikel",
+  // setup page — shared footer CTA
+  setupReadyCta: "Klaar? Review je artikel →",
+  // setup page — subscription tab intro
+  setupSubHeading: "Gebruik je coding-agent-abonnement",
+  setupSubIntro1:
+    "Voor gebruikers die al betalen voor Claude Code, Codex of Gemini CLI. De review draait op je abonnement en wordt daar gefactureerd. Je betaalt OpenRouter alleen ~$0,15 voor de OCR-stap.",
+  setupSubIntro2:
+    "Draait lokaal op je eigen machine met je eigen Claude Code-, Codex- of Gemini CLI-account. coarse.ink ontvangt of bewaart je provider-login niet. De voorwaarden en gebruikslimieten van je provider blijven van toepassing. coarse.ink is niet gelieerd aan Anthropic, OpenAI of Google.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "Installeer een coding-agent",
+  setupSubStep1Body:
+    "Kies de agent waarvoor je betaalt. Gemini CLI heeft een gratis laag als je dat niet doet. Installeer hem vanaf de eigen pagina van de leverancier — hun docs blijven actueel.",
+  setupSubStep1ClaudePrice: "Anthropic Pro of Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro of Business",
+  setupSubStep1GeminiPrice: "Gratis laag volstaat voor de meeste artikels",
+  setupSubStep1InstallLabel: "Installatie-instructies ↗",
+  setupSubStep1Verify:
+    "Draai het testcommando om installatie + login te verifiëren. Als het een reactie afdrukt, ben je klaar.",
+  setupSubStep1CardLogin: "login: ",
+  setupSubStep1CardTest: "test: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "Zet een OpenRouter-sleutel op je machine (alleen PDF's)",
+  setupSubStep2BodyPrefix:
+    "Deze stap geldt alleen voor PDF-artikels — niet-PDF-bronnen (.tex, .md, .docx, …) worden lokaal geëxtraheerd zonder OCR, dus die hebben nergens een OpenRouter-sleutel nodig en je kunt meteen door naar stap 3. Voor PDF's heeft coarse OpenRouter nog steeds nodig voor de OCR-stap (~$0,10 per artikel). Volg het tabblad ",
+  setupSubStep2BodyTab: "OpenRouter-sleutel",
+  setupSubStep2BodySuffix:
+    " om een account aan te maken, $1 tegoed toe te voegen en een limiet van $2 per sleutel in te stellen. De buffer van $20 uit het OpenRouter-only pad is hier niet nodig, omdat de review zelf op je coding-agent-abonnement draait.",
+  setupSubStep2KeyPrefix: "Zet de sleutel daarna op je eigen machine: draai ",
+  setupSubStep2KeyMid1: ", zet hem in een ",
+  setupSubStep2KeyMid2: ", of bewaar hem in ",
+  setupSubStep2KeySuffix:
+    ". Je CLI leest hem lokaal wanneer die de extractie draait; coarse.ink ziet hem nooit.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "Upload je artikel en kies een CLI",
+  setupSubStep3BodyPrefix: "Op de ",
+  setupSubStep3BodyLink: "hoofdpagina",
+  setupSubStep3BodyMid: ", sleep je artikel (PDF, .tex, .md, .docx, …) op het formulier en klik daarna op de dropdown ",
+  setupSubStep3BodyButton: "Review met mijn abonnement ▾",
+  setupSubStep3BodySuffix:
+    " en kies je CLI. coarse uploadt het bestand, maakt een overdrachtstoken aan en toont de prompt die je in de volgende stap plakt. Je plakt je OpenRouter-sleutel hier niet op het formulier; de CLI leest hem van je machine (stap 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "Plak de prompt in je CLI",
+  setupSubStep4BodyPrefix: "coarse geeft je één prompt in natuurlijke taal. Kopieer hem uit het paneel, plak hem in je ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: ", of ",
+  setupSubStep4BodyMid3: "-sessie en druk op verzenden. De agent vernieuwt zijn skill-bundel, draait de volledige coarse-pipeline op zijn eigen subprocess-calls en drukt een ",
+  setupSubStep4BodySuffix:
+    "-URL af als die klaar is. 10–25 minuten. Klik op de URL om de voltooide review op coarse.ink te openen.",
+  setupSubStep4TimeoutLabel: "Als je in een coding-agent plakt",
+  setupSubStep4TimeoutSuffix:
+    " (geen gewone terminal), verhoog dan de timeout van zijn bash-tool naar minstens 45 min voordat je de prompt verstuurt. Standaard agent-timeouts kunnen zo laag als 2 min zijn, ver onder de reviewlooptijd van 10–25 min.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "Als er iets misgaat",
+  setupSubTrouble1Symptom: "De knop “Probeer Claude Code / Codex te openen” doet niets.",
+  setupSubTrouble1Fix:
+    "De knop werkt alleen als je de desktopapp hebt geïnstalleerd. Met een CLI-only installatie kan de browser geen terminal voor je starten. Kopieer de prompt uit het paneel en plak hem handmatig in je CLI.",
+  setupSubTrouble2Symptom: "“No such command ‘install-skills’” binnen de agent-run.",
+  setupSubTrouble2FixPrefix: "Veilig te negeren. De skill-bundel laadt nog steeds rechtstreeks via ",
+  setupSubTrouble2FixSuffix: "; de agent gaat door naar de reviewstap.",
+  setupSubTrouble3Symptom: "Mijn Anthropic-/OpenAI-/Google-rekening ging omhoog na een review.",
+  setupSubTrouble3FixPrefix: "Controleer op ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: ", of ",
+  setupSubTrouble3FixSuffix:
+    " in je shell-omgeving. Als die is ingesteld, factureert de host-CLI het API-account in plaats van je abonnement. v1.3.0+ verwijdert deze automatisch, maar oudere versies deden dat niet.",
+  setupSubTrouble4Symptom: "Minder opmerkingen dan gebruikelijk (~10 in plaats van 15–25).",
+  setupSubTrouble4FixPrefix: "Een sectie liep tegen de timeout van 30 min aan en is weggevallen. Zeldzaam bij standaardinspanning, vaker met ",
+  setupSubTrouble4FixSuffix:
+    " op lange artikels. Draai opnieuw; verlaag de inspanning één stap als het twee keer gebeurt.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "Kon deze niet weergeven. Probeer een ander model of een andere vergelijking.",
+  comparePaperCorticalCircuits: "Cortical Circuits",
+  comparePaperCosetCodes: "Coset Codes",
+  comparePaperPopulationGenetics: "Population Genetics",
+  comparePaperTargetingInterventions: "Targeting Interventions",
+  compareScoresShow: "Toon",
+  compareScoresHide: "Verberg",
+  compareScoresToggleSuffix: " alle scores over alle artikels ",
+  compareScoresColPaper: "Artikel",
+  compareScoresColReference: "Referentie",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Geëvalueerd door Gemini 3.1 Pro met multimodale PDF-invoer. 5.0/5 = evenaart de referentiekwaliteit. 5.5+/5 = overtreft die.",
+  compareJudgeShow: "Toon",
+  compareJudgeHide: "Verberg",
+  compareJudgeToggleSuffix: " de juryprompt die naar Gemini 3.1 Pro is gestuurd ",
+  compareJudgeExplain:
+    "Om bekende biases van LLM-als-jury tegen te gaan, wordt de jury per evaluatie twee keer gedraaid met de twee reviews in omgekeerde presentatievolgorde, en worden de scores over beide volgordes gemiddeld. Dit counteret positionele bias, waarbij jury's systematisch de review verkiezen die als eerste verschijnt. De prompt bevat ook specifieke instructies om verbositeitsbias tegen te gaan (lengte niet belonen boven inhoud), confidentiebias (assertief taalgebruik niet belonen boven correcte voorzichtigheid), autoriteitsbias (jargon of aantal citaties niet belonen boven juistheid) en mildheidsbias (het volledige scorebereik van 1-6 gebruiken in plaats van in het midden te clusteren). Reviews worden neutraal gelabeld als \"Review A\" en \"Review B\" in plaats van \"referentie\" en \"gegenereerd\" om scoren op basis van herkomst te voorkomen.",
+  compareJudgeSystemPromptLabel: "Systeemprompt",
+  compareJudgeUserPromptLabel: "Gebruikersprompt (artikel + reviews tijdens runtime ingevoegd)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Dekking",
+  compareMetricSpecificity: "Specificiteit",
+  compareMetricDepth: "Diepgang",
+  compareJumpTo: "Spring naar",
+  compareSectionOverallFeedback: "Algemene feedback",
+  compareSectionDetailedComments: "Gedetailleerde opmerkingen",
+  compareVisitPrefix: "Bezoek ",
+  comparePdfReviewSuffix: " review",
+  comparePdfFallback: "Download de PDF als de iframe niet weergeeft ↓",
 };

--- a/web/src/lib/i18n/pt.ts
+++ b/web/src/lib/i18n/pt.ts
@@ -394,4 +394,184 @@ export const pt: Messages = {
   paperPanelDownload: "Transferir",
   paperPanelDownloadAriaLabel: "Transferir o markdown do artigo",
   paperPanelCloseAriaLabel: "Fechar painel do artigo",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "Caminho de configuração",
+  setupTabOpenRouter: "Chave OpenRouter",
+  setupTabSubscription: "Usar a minha subscrição",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "Obtenha a sua chave OpenRouter",
+  setupOrIntro:
+    "Demora cerca de 2 minutos. Vai precisar de um cartão de crédito para ~$1 em créditos para começar — irá carregar até $20 no passo 2.",
+  setupOrFasterLabel: "Opção mais rápida:",
+  setupOrFasterMid1: " no formulário principal pode clicar em ",
+  setupOrFasterLogIn: "“Iniciar sessão com o OpenRouter”",
+  setupOrFasterSuffix:
+    " para autorizar o coarse e saltar a criação manual da chave. Continua a precisar de uma conta OpenRouter com créditos (passos 1 e 2 abaixo), e continuamos a recomendar definir um limite de gastos por chave (passo 4).",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "Criar uma conta",
+  setupOrStep1BodyPrefix: "Vá a ",
+  setupOrStep1BodySuffix: " e clique em “Get API Key” ou registe-se com Google / GitHub.",
+  setupOrStep1Annotation: "página inicial",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "Uma API unificada para LLMs — uma chave, muitos modelos.",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "Adicionar créditos",
+  setupOrStep2BodyPrefix: "Navegue até ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    ". Adicione pelo menos $20. Os modelos de código aberto baratos custam ~$0,25 por revisão; modelos de ponta como o Claude Opus ou o GPT-5 podem chegar a $5–$10 num artigo longo. A estimativa de custo mostrada antes da submissão é uma aproximação, não um teto. Deixe margem ou a revisão pode esgotar a chave a meio e falhar. Os créditos não utilizados não expiram.",
+  setupOrStep2Annotation: "página de créditos",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "Montante",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Saldo: $0,00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "Criar uma chave de API",
+  setupOrStep3BodyPrefix: "Vá a ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: ", clique em “Create Key” e dê-lhe o nome ",
+  setupOrStep3BodySuffix: ".",
+  setupOrStep3Provisioning:
+    "Certifique-se de que é uma chave de API normal — não uma chave de aprovisionamento/gestão da secção de integrações. As chaves de aprovisionamento podem criar e listar outras chaves, mas não podem executar inferência, e o coarse irá falhar com “User not found” se colar uma.",
+  setupOrStep3CopyWarning: "Copie a chave agora — não a verá novamente.",
+  setupOrStep3Annotation: "página de chaves",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "Nome da chave",
+  setupOrStep3MockYourKey: "A sua chave",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "Definir um limite de gastos na chave",
+  setupOrStep4BodyPrefix: "Na ",
+  setupOrStep4BodyLink: "página de chaves",
+  setupOrStep4BodyMid1: ", clique no menu ",
+  setupOrStep4BodyMid2: " junto à sua nova chave, escolha “Edit” e defina o limite de crédito para ",
+  setupOrStep4BodyAtLeast: "pelo menos $20",
+  setupOrStep4BodySuffix:
+    ". A chave deixa de funcionar assim que o limite é atingido, por isso cobranças-surpresa são impossíveis. Mas se o definir demasiado apertado, uma única revisão dispendiosa pode esgotá-lo a meio da execução.",
+  setupOrStep4Annotation: "menu da chave",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "Limite de crédito para esta chave",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "Porque é que isto importa:",
+  setupOrStep4WhyMid1: " o coarse é de código aberto — pode ",
+  setupOrStep4WhyLink: "ler cada linha de código",
+  setupOrStep4WhySuffix:
+    ". A sua chave é enviada diretamente para o OpenRouter para executar a revisão e depois descartada — nunca é armazenada. Mas não tem de confiar em nós: o limite por chave garante que nunca pode gastar mais do que permite, mesmo no pior cenário.",
+  setupOrStep4CostLabel: "Uma nota sobre estimativas de custo:",
+  setupOrStep4CostBody:
+    " a estimativa mostrada antes da submissão é uma heurística com uma margem de ~15%, não um teto rígido. O custo real em modelos de ponta com artigos longos pode chegar a ~2× a estimativa quando a verificação de provas e as reescritas de crítica entram em ação. Se o limite por chave ficar mesmo no valor da estimativa, uma revisão difícil pode esgotá-lo e falhar a meio. Deixe sempre margem.",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "Colar no coarse",
+  setupOrStep5Body: "Volte aqui, cole a sua chave no formulário e carregue o seu PDF.",
+  setupOrStep5Annotation: "formulário do coarse",
+  setupOrStep5MockEmail: "E-mail",
+  setupOrStep5MockKey: "Chave OpenRouter",
+  setupOrStep5MockButton: "Rever o meu artigo",
+  // setup page — shared footer CTA
+  setupReadyCta: "Pronto? Reveja o seu artigo →",
+  // setup page — subscription tab intro
+  setupSubHeading: "Usar a subscrição do seu agente de programação",
+  setupSubIntro1:
+    "Para utilizadores que já pagam por Claude Code, Codex ou Gemini CLI. A revisão é executada na sua subscrição e é cobrada aí. Paga apenas ~$0,15 ao OpenRouter pelo passo de OCR.",
+  setupSubIntro2:
+    "É executado localmente na sua máquina usando a sua própria conta de Claude Code, Codex ou Gemini CLI. O coarse.ink não recebe nem armazena o seu início de sessão do fornecedor. Aplicam-se na mesma os termos e limites de utilização do seu fornecedor. O coarse.ink não está associado à Anthropic, OpenAI ou Google.",
+  // setup page — subscription step 1
+  setupSubStep1Title: "Instalar um agente de programação",
+  setupSubStep1Body:
+    "Escolha aquele pelo qual paga. O Gemini CLI tem um nível gratuito se não pagar por nenhum. Instale-o a partir da página do próprio fornecedor — a documentação deles mantém-se atualizada.",
+  setupSubStep1ClaudePrice: "Anthropic Pro ou Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus, Pro ou Business",
+  setupSubStep1GeminiPrice: "O nível gratuito serve para a maioria dos artigos",
+  setupSubStep1InstallLabel: "Instruções de instalação ↗",
+  setupSubStep1Verify:
+    "Execute o comando de teste para verificar a instalação + início de sessão. Se imprimir uma resposta, está tudo pronto.",
+  setupSubStep1CardLogin: "início de sessão: ",
+  setupSubStep1CardTest: "teste: ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "Coloque uma chave OpenRouter na sua máquina (apenas PDFs)",
+  setupSubStep2BodyPrefix:
+    "Este passo só se aplica a artigos em PDF — as fontes que não são PDF (.tex, .md, .docx, …) são extraídas localmente sem OCR, por isso não precisam de chave OpenRouter em lado nenhum e pode saltar diretamente para o passo 3. Para PDFs, o coarse ainda precisa do OpenRouter para o passo de OCR (~$0,10 por artigo). Siga o separador ",
+  setupSubStep2BodyTab: "Chave OpenRouter",
+  setupSubStep2BodySuffix:
+    " para criar uma conta, adicionar $1 de crédito e definir um limite de $2 por chave. A margem de $20 do caminho só com OpenRouter não é necessária aqui porque a própria revisão é executada na subscrição do seu agente de programação.",
+  setupSubStep2KeyPrefix: "Depois coloque a chave na sua própria máquina: execute ",
+  setupSubStep2KeyMid1: ", coloque-a num ",
+  setupSubStep2KeyMid2: ", ou guarde-a em ",
+  setupSubStep2KeySuffix:
+    ". A sua CLI lê-a localmente quando executa a extração; o coarse.ink nunca a vê.",
+  // setup page — subscription step 3
+  setupSubStep3Title: "Carregue o seu artigo e escolha uma CLI",
+  setupSubStep3BodyPrefix: "Na ",
+  setupSubStep3BodyLink: "página principal",
+  setupSubStep3BodyMid: ", largue o seu artigo (PDF, .tex, .md, .docx, …) no formulário e depois clique no menu ",
+  setupSubStep3BodyButton: "Rever com a minha subscrição ▾",
+  setupSubStep3BodySuffix:
+    " e escolha a sua CLI. O coarse carrega o ficheiro, cria um token de entrega e mostra o prompt que irá colar no passo seguinte. Não cola a sua chave OpenRouter no formulário aqui; a CLI lê-a a partir da sua máquina (passo 2).",
+  // setup page — subscription step 4
+  setupSubStep4Title: "Cole o prompt na sua CLI",
+  setupSubStep4BodyPrefix: "O coarse dá-lhe um único prompt em linguagem natural. Copie-o do painel, cole-o na sua sessão de ",
+  setupSubStep4BodyMid1: ", ",
+  setupSubStep4BodyMid2: ", ou ",
+  setupSubStep4BodyMid3: " e carregue em enviar. O agente atualiza o seu pacote de skills, executa todo o pipeline do coarse nas suas próprias chamadas de subprocesso e imprime um URL ",
+  setupSubStep4BodySuffix:
+    " quando terminar. 10–25 minutos. Clique no URL para abrir a revisão concluída no coarse.ink.",
+  setupSubStep4TimeoutLabel: "Se estiver a colar num agente de programação",
+  setupSubStep4TimeoutSuffix:
+    " (e não num terminal simples), aumente o tempo limite da ferramenta bash para pelo menos 45 min antes de enviar o prompt. Os tempos limite predefinidos dos agentes podem ser tão baixos como 2 min, muito abaixo do tempo de execução de revisão de 10–25 min.",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "Se algo correr mal",
+  setupSubTrouble1Symptom: "O botão “Tentar abrir o Claude Code / Codex” não faz nada.",
+  setupSubTrouble1Fix:
+    "O botão só funciona se tiver a aplicação de desktop instalada. Com uma instalação só de CLI, o navegador não consegue iniciar um terminal por si. Copie o prompt do painel e cole-o manualmente na sua CLI.",
+  setupSubTrouble2Symptom: "“No such command ‘install-skills’” durante a execução do agente.",
+  setupSubTrouble2FixPrefix: "Pode ignorar com segurança. O pacote de skills continua a carregar diretamente através de ",
+  setupSubTrouble2FixSuffix: "; o agente irá continuar para o passo de revisão.",
+  setupSubTrouble3Symptom: "A minha fatura da Anthropic / OpenAI / Google subiu após uma revisão.",
+  setupSubTrouble3FixPrefix: "Verifique se existe ",
+  setupSubTrouble3FixMid1: ", ",
+  setupSubTrouble3FixMid2: ", ou ",
+  setupSubTrouble3FixSuffix:
+    " no ambiente da sua shell. Se estiver definido, a CLI anfitriã cobra à conta da API em vez da sua subscrição. A v1.3.0+ remove-os automaticamente, mas versões mais antigas não o faziam.",
+  setupSubTrouble4Symptom: "Menos comentários do que o habitual (~10 em vez de 15–25).",
+  setupSubTrouble4FixPrefix: "Uma secção atingiu o tempo limite de 30 min e foi descartada. Raro no esforço predefinido, mais comum com ",
+  setupSubTrouble4FixSuffix:
+    " em artigos longos. Volte a executar; baixe o esforço um nível se acontecer duas vezes.",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "Não foi possível renderizar este. Experimente outro modelo ou comparação.",
+  comparePaperCorticalCircuits: "Circuitos Corticais",
+  comparePaperCosetCodes: "Códigos de Coset",
+  comparePaperPopulationGenetics: "Genética de Populações",
+  comparePaperTargetingInterventions: "Direcionamento de Intervenções",
+  compareScoresShow: "Mostrar",
+  compareScoresHide: "Ocultar",
+  compareScoresToggleSuffix: " todas as pontuações entre artigos ",
+  compareScoresColPaper: "Artigo",
+  compareScoresColReference: "Referência",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "Avaliado pelo Gemini 3.1 Pro com entrada multimodal de PDF. 5,0/5 = corresponde à qualidade da referência. 5,5+/5 = supera-a.",
+  compareJudgeShow: "Mostrar",
+  compareJudgeHide: "Ocultar",
+  compareJudgeToggleSuffix: " o prompt de juiz enviado ao Gemini 3.1 Pro ",
+  compareJudgeExplain:
+    "Para mitigar enviesamentos conhecidos de LLM-como-juiz, o juiz é executado duas vezes por avaliação com as duas revisões trocadas na ordem de apresentação, e as pontuações são calculadas em média entre ambas as ordens. Isto contraria o enviesamento posicional, em que os juízes favorecem sistematicamente a revisão que aparece primeiro. O prompt inclui também instruções específicas para contrariar o enviesamento de verbosidade (não recompensar a extensão em detrimento da substância), o enviesamento de confiança (não recompensar linguagem assertiva em detrimento de uma cautela correta), o enviesamento de autoridade (não recompensar o jargão ou o número de citações em detrimento da exatidão) e o enviesamento de leniência (usar toda a gama de pontuação de 1 a 6 em vez de se concentrar no meio). As revisões são rotuladas neutralmente como \"Review A\" e \"Review B\" em vez de \"referência\" e \"gerada\" para evitar pontuação baseada na proveniência.",
+  compareJudgeSystemPromptLabel: "Prompt de sistema",
+  compareJudgeUserPromptLabel: "Prompt de utilizador (artigo + revisões injetados em tempo de execução)",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "Cobertura",
+  compareMetricSpecificity: "Especificidade",
+  compareMetricDepth: "Profundidade",
+  compareJumpTo: "Saltar para",
+  compareSectionOverallFeedback: "Comentários Gerais",
+  compareSectionDetailedComments: "Comentários Detalhados",
+  compareVisitPrefix: "Visitar ",
+  comparePdfReviewSuffix: " revisão",
+  comparePdfFallback: "Transfira o PDF se o iframe não renderizar ↓",
 };

--- a/web/src/lib/i18n/zh-Hans.ts
+++ b/web/src/lib/i18n/zh-Hans.ts
@@ -394,4 +394,184 @@ export const zhHans: Messages = {
   paperPanelDownload: "下载",
   paperPanelDownloadAriaLabel: "下载论文 markdown",
   paperPanelCloseAriaLabel: "关闭论文面板",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "设置方式",
+  setupTabOpenRouter: "OpenRouter 密钥",
+  setupTabSubscription: "使用我的订阅",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "获取你的 OpenRouter 密钥",
+  setupOrIntro:
+    "大约需要 2 分钟。你需要一张信用卡来充值约 $1 的额度以便开始——你将在第 2 步中充值到 $20。",
+  setupOrFasterLabel: "更快的方式：",
+  setupOrFasterMid1: " 在主表单上你可以点击 ",
+  setupOrFasterLogIn: "“使用 OpenRouter 登录”",
+  setupOrFasterSuffix:
+    " 来授权 coarse 并跳过手动创建密钥。你仍然需要一个有额度的 OpenRouter 账户（下面的第 1 步和第 2 步），并且我们仍然建议设置单个密钥的消费限额（第 4 步）。",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "创建账户",
+  setupOrStep1BodyPrefix: "前往 ",
+  setupOrStep1BodySuffix: " 并点击“Get API Key”，或使用 Google / GitHub 注册。",
+  setupOrStep1Annotation: "主页",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "面向 LLM 的统一 API——一把密钥，多种模型。",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "充值额度",
+  setupOrStep2BodyPrefix: "导航到 ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    "。至少充值 $20。便宜的开源模型每次评审约 $0.25；像 Claude Opus 或 GPT-5 这样的 SOTA 模型在长论文上可能花费 $5–$10。提交前显示的费用估算只是一个大致范围，不是上限。请预留余量，否则评审可能会中途耗尽密钥而失败。未使用的额度不会过期。",
+  setupOrStep2Annotation: "额度页面",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "金额",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Balance: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "创建 API 密钥",
+  setupOrStep3BodyPrefix: "前往 ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: "，点击“Create Key”，并将其命名为 ",
+  setupOrStep3BodySuffix: "。",
+  setupOrStep3Provisioning:
+    "请确保它是常规 API 密钥——而不是集成部分的预配/管理密钥。预配密钥可以创建和列出其他密钥，但无法运行推理，如果你粘贴了这种密钥，coarse 会报错“User not found”。",
+  setupOrStep3CopyWarning: "立即复制密钥——你不会再看到它了。",
+  setupOrStep3Annotation: "密钥页面",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "密钥名称",
+  setupOrStep3MockYourKey: "你的密钥",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "为密钥设置消费限额",
+  setupOrStep4BodyPrefix: "在 ",
+  setupOrStep4BodyLink: "Keys 页面",
+  setupOrStep4BodyMid1: " 上，点击你新密钥旁边的 ",
+  setupOrStep4BodyMid2: " 菜单，选择“Edit”，并将额度限额设置为 ",
+  setupOrStep4BodyAtLeast: "至少 $20",
+  setupOrStep4BodySuffix:
+    "。一旦达到限额，密钥就会停止工作，因此不可能产生意外费用。但如果设置得太紧，单次昂贵的评审就可能在运行中途耗尽它。",
+  setupOrStep4Annotation: "密钥菜单",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "此密钥的额度限额",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "为什么这很重要：",
+  setupOrStep4WhyMid1: " coarse 是开源的——你可以 ",
+  setupOrStep4WhyLink: "阅读每一行代码",
+  setupOrStep4WhySuffix:
+    "。你的密钥会直接发送给 OpenRouter 以运行评审，然后即被丢弃——它绝不会被存储。但你不必信任我们：单个密钥的限额保证了即使在最坏的情况下，它的花费也绝不会超过你所允许的额度。",
+  setupOrStep4CostLabel: "关于费用估算的说明：",
+  setupOrStep4CostBody:
+    " 提交前显示的估算是一个带有约 15% 缓冲的启发式数值，不是硬性上限。在长论文上使用 SOTA 模型时，一旦证明验证和批评重写启动，实际费用可能高达估算的约 2 倍。如果单个密钥的上限正好卡在估算值上，一次棘手的评审就可能把它耗尽并在运行中途失败。请始终预留余量。",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "粘贴到 coarse 中",
+  setupOrStep5Body: "回到这里，将你的密钥粘贴到表单中，然后上传你的 PDF。",
+  setupOrStep5Annotation: "coarse 表单",
+  setupOrStep5MockEmail: "电子邮箱",
+  setupOrStep5MockKey: "OpenRouter 密钥",
+  setupOrStep5MockButton: "评审我的论文",
+  // setup page — shared footer CTA
+  setupReadyCta: "准备好了吗？评审你的论文 →",
+  // setup page — subscription tab intro
+  setupSubHeading: "使用你的编码智能体订阅",
+  setupSubIntro1:
+    "适用于已经在为 Claude Code、Codex 或 Gemini CLI 付费的用户。评审在你的订阅上运行并在那里计费。你只需为 OCR 环节向 OpenRouter 支付约 ~$0.15。",
+  setupSubIntro2:
+    "在你本地的机器上，使用你自己的 Claude Code、Codex 或 Gemini CLI 账户运行。coarse.ink 不会接收或存储你的提供商登录信息。你的提供商的条款和使用限额仍然适用。coarse.ink 与 Anthropic、OpenAI 或 Google 无任何关联。",
+  // setup page — subscription step 1
+  setupSubStep1Title: "安装编码智能体",
+  setupSubStep1Body:
+    "选择你为之付费的那一个。如果你没有付费，Gemini CLI 有免费层级。请从供应商自己的页面安装——他们的文档保持最新。",
+  setupSubStep1ClaudePrice: "Anthropic Pro 或 Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus、Pro 或 Business",
+  setupSubStep1GeminiPrice: "免费层级足以应对大多数论文",
+  setupSubStep1InstallLabel: "安装说明 ↗",
+  setupSubStep1Verify:
+    "运行测试命令以验证安装 + 登录。如果它打印出响应，你就准备好了。",
+  setupSubStep1CardLogin: "登录： ",
+  setupSubStep1CardTest: "测试： ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "在你的机器上放一把 OpenRouter 密钥（仅限 PDF）",
+  setupSubStep2BodyPrefix:
+    "此步骤仅适用于 PDF 论文——非 PDF 来源（.tex, .md, .docx, …）会在本地提取而无需 OCR，因此它们在任何地方都不需要 OpenRouter 密钥，你可以直接跳到第 3 步。对于 PDF，coarse 的 OCR 步骤仍需要 OpenRouter（每篇论文约 $0.10）。请按照 ",
+  setupSubStep2BodyTab: "OpenRouter 密钥",
+  setupSubStep2BodySuffix:
+    " 标签页来创建账户、充值 $1 额度，并设置 $2 的单个密钥限额。这里不需要 OpenRouter-only 路径中的 $20 缓冲，因为评审本身是在你的编码智能体订阅上运行的。",
+  setupSubStep2KeyPrefix: "然后把密钥放到你自己的机器上：运行 ",
+  setupSubStep2KeyMid1: "，将其放入 ",
+  setupSubStep2KeyMid2: "，或将其保存到 ",
+  setupSubStep2KeySuffix:
+    "。你的 CLI 在运行提取时会在本地读取它；coarse.ink 绝不会看到它。",
+  // setup page — subscription step 3
+  setupSubStep3Title: "上传你的论文并选择一个 CLI",
+  setupSubStep3BodyPrefix: "在 ",
+  setupSubStep3BodyLink: "主页面",
+  setupSubStep3BodyMid: " 上，将你的论文（PDF、.tex、.md、.docx、…）拖到表单上，然后点击 ",
+  setupSubStep3BodyButton: "用我的订阅来评审 ▾",
+  setupSubStep3BodySuffix:
+    " 下拉菜单并选择你的 CLI。coarse 会上传文件、铸造一个交接令牌，并显示你将在下一步粘贴的提示词。你不需要在这里的表单上粘贴你的 OpenRouter 密钥；CLI 会从你的机器上读取它（第 2 步）。",
+  // setup page — subscription step 4
+  setupSubStep4Title: "将提示词粘贴到你的 CLI 中",
+  setupSubStep4BodyPrefix: "coarse 会给你一条自然语言提示词。从面板中复制它，将其粘贴到你的 ",
+  setupSubStep4BodyMid1: "、",
+  setupSubStep4BodyMid2: " 或 ",
+  setupSubStep4BodyMid3: " 会话中，然后点击发送。智能体会刷新其技能包，在自己的子进程调用上运行完整的 coarse 流水线，并在完成后打印出一个 ",
+  setupSubStep4BodySuffix:
+    " URL。耗时 10–25 分钟。点击该 URL 即可在 coarse.ink 上打开完成的评审。",
+  setupSubStep4TimeoutLabel: "如果你是粘贴到编码智能体中",
+  setupSubStep4TimeoutSuffix:
+    "（而非普通终端），请在发送提示词之前将其 bash 工具超时调高到至少 45 分钟。智能体的默认超时可能低至 2 分钟，远低于 10–25 分钟的评审运行时间。",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "如果出了问题",
+  setupSubTrouble1Symptom: "“Try opening Claude Code / Codex”按钮没有任何反应。",
+  setupSubTrouble1Fix:
+    "该按钮仅在你安装了桌面应用时才有效。如果只安装了 CLI，浏览器无法为你启动终端。请从面板中复制提示词并手动将其粘贴到你的 CLI 中。",
+  setupSubTrouble2Symptom: "智能体运行中出现“No such command ‘install-skills’”。",
+  setupSubTrouble2FixPrefix: "可以放心忽略。技能包仍会直接通过 ",
+  setupSubTrouble2FixSuffix: " 加载；智能体会继续进行到评审步骤。",
+  setupSubTrouble3Symptom: "评审之后我的 Anthropic / OpenAI / Google 账单上涨了。",
+  setupSubTrouble3FixPrefix: "请检查你的 shell 环境中是否有 ",
+  setupSubTrouble3FixMid1: "、",
+  setupSubTrouble3FixMid2: " 或 ",
+  setupSubTrouble3FixSuffix:
+    "。如果设置了，宿主 CLI 会向 API 账户计费，而不是你的订阅。v1.3.0+ 会自动剥离这些变量，但旧版本不会。",
+  setupSubTrouble4Symptom: "评论比平时少（约 10 条而不是 15–25 条）。",
+  setupSubTrouble4FixPrefix: "某个章节触发了 30 分钟超时并被丢弃。在默认强度下很少见，使用 ",
+  setupSubTrouble4FixSuffix:
+    " 处理长论文时更常见。请重新运行；如果发生两次，就把强度降低一档。",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "无法渲染这一个。请尝试其他模型或对比。",
+  comparePaperCorticalCircuits: "皮层环路",
+  comparePaperCosetCodes: "陪集码",
+  comparePaperPopulationGenetics: "群体遗传学",
+  comparePaperTargetingInterventions: "精准干预",
+  compareScoresShow: "显示",
+  compareScoresHide: "隐藏",
+  compareScoresToggleSuffix: " 各篇论文的全部得分 ",
+  compareScoresColPaper: "论文",
+  compareScoresColReference: "参考",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "由 Gemini 3.1 Pro 通过 PDF 多模态输入评估。5.0/5 = 与参考质量相当。5.5+/5 = 超过参考质量。",
+  compareJudgeShow: "显示",
+  compareJudgeHide: "隐藏",
+  compareJudgeToggleSuffix: " 发送给 Gemini 3.1 Pro 的评判提示词 ",
+  compareJudgeExplain:
+    "为减轻已知的 LLM-as-judge 偏差，评判器在每次评估中以两篇评审的呈现顺序互换的方式运行两次，并对两种顺序下的得分取平均。这可以抵消位置偏差，即评判者系统性地偏好排在前面的那篇评审。提示词还包含具体指令，以抵消冗长偏差（不因篇幅而非实质给予奖励）、自信偏差（不因断言性措辞而非恰当的保留给予奖励）、权威偏差（不因术语或引用数量而非准确性给予奖励）以及宽容偏差（使用完整的 1-6 评分区间，而非聚集在中间）。两篇评审被中性地标记为“Review A”和“Review B”，而非“参考”和“生成”，以防止基于来源的评分。",
+  compareJudgeSystemPromptLabel: "系统提示词",
+  compareJudgeUserPromptLabel: "用户提示词（论文 + 评审在运行时注入）",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "覆盖度",
+  compareMetricSpecificity: "针对性",
+  compareMetricDepth: "深度",
+  compareJumpTo: "跳转到",
+  compareSectionOverallFeedback: "总体反馈",
+  compareSectionDetailedComments: "详细评论",
+  compareVisitPrefix: "访问 ",
+  comparePdfReviewSuffix: " 评审",
+  comparePdfFallback: "如果 iframe 未渲染，请下载 PDF ↓",
 };

--- a/web/src/lib/i18n/zh-Hant.ts
+++ b/web/src/lib/i18n/zh-Hant.ts
@@ -390,4 +390,184 @@ export const zhHant: Messages = {
   paperPanelDownload: "下載",
   paperPanelDownloadAriaLabel: "下載論文 markdown",
   paperPanelCloseAriaLabel: "關閉論文面板",
+
+  // setup page (setup/page.tsx)
+  // setup page — tab switcher
+  setupTablistAriaLabel: "設定路徑",
+  setupTabOpenRouter: "OpenRouter 金鑰",
+  setupTabSubscription: "使用我的訂閱",
+  // setup page — OpenRouter tab intro
+  setupOrHeading: "取得您的 OpenRouter 金鑰",
+  setupOrIntro:
+    "大約需要 2 分鐘。您需要一張信用卡來購買約 ~$1 的額度才能開始——在步驟 2 中您會儲值到 $20。",
+  setupOrFasterLabel: "更快的選項：",
+  setupOrFasterMid1: " 在主表單上，您可以點擊 ",
+  setupOrFasterLogIn: "「使用 OpenRouter 登入」",
+  setupOrFasterSuffix:
+    " 來授權 coarse 並省去手動建立金鑰的步驟。您仍需要一個有額度的 OpenRouter 帳號（下方步驟 1 和 2），而且我們仍建議設定每組金鑰的支出上限（步驟 4）。",
+  // setup page — OpenRouter step 1
+  setupOrStep1Title: "建立帳號",
+  setupOrStep1BodyPrefix: "前往 ",
+  setupOrStep1BodySuffix: " 並點擊「Get API Key」，或使用 Google／GitHub 註冊。",
+  setupOrStep1Annotation: "首頁",
+  setupOrStep1MockButton: "Get API Key",
+  setupOrStep1MockTagline: "一個整合各家 LLM 的統一 API——一把金鑰，多種模型。",
+  // setup page — OpenRouter step 2
+  setupOrStep2Title: "加入額度",
+  setupOrStep2BodyPrefix: "前往 ",
+  setupOrStep2BodyLink: "Settings → Credits",
+  setupOrStep2BodySuffix:
+    "。至少加入 $20。便宜的開放原始碼模型每次審查約 ~$0.25；像 Claude Opus 或 GPT-5 這類頂尖模型在長論文上可能需要 $5–$10。提交前顯示的費用估算只是大略數字，不是上限。請保留充裕的餘額，否則審查可能進行到一半就把金鑰用完而失敗。未使用的額度不會過期。",
+  setupOrStep2Annotation: "額度頁面",
+  setupOrStep2MockSettings: "Settings → Credits",
+  setupOrStep2MockAmount: "金額",
+  setupOrStep2MockButton: "Add credits",
+  setupOrStep2MockBalance: "Balance: $0.00",
+  // setup page — OpenRouter step 3
+  setupOrStep3Title: "建立 API 金鑰",
+  setupOrStep3BodyPrefix: "前往 ",
+  setupOrStep3BodyLink: "Settings → Keys",
+  setupOrStep3BodyMid: "，點擊「Create Key」，並將它命名為 ",
+  setupOrStep3BodySuffix: "。",
+  setupOrStep3Provisioning:
+    "請確認它是一般的 API 金鑰——而非整合區段中的佈建／管理金鑰。佈建金鑰可以建立並列出其他金鑰，但無法執行推理，若您貼上這種金鑰，coarse 會以「User not found」失敗。",
+  setupOrStep3CopyWarning: "立即複製金鑰——您不會再看到它。",
+  setupOrStep3Annotation: "金鑰頁面",
+  setupOrStep3MockSettings: "Settings → Keys",
+  setupOrStep3MockButton: "Create Key",
+  setupOrStep3MockKeyName: "金鑰名稱",
+  setupOrStep3MockYourKey: "您的金鑰",
+  // setup page — OpenRouter step 4
+  setupOrStep4Title: "為金鑰設定支出上限",
+  setupOrStep4BodyPrefix: "在 ",
+  setupOrStep4BodyLink: "Keys 頁面",
+  setupOrStep4BodyMid1: "上，點擊新金鑰旁的 ",
+  setupOrStep4BodyMid2: " 選單，選擇「Edit」，並將額度上限設為 ",
+  setupOrStep4BodyAtLeast: "至少 $20",
+  setupOrStep4BodySuffix:
+    "。一旦達到上限，金鑰就會停止運作，因此不可能出現意外的費用。但若設得太緊，單次昂貴的審查就可能在執行途中把它耗盡。",
+  setupOrStep4Annotation: "金鑰選單",
+  setupOrStep4MockEdit: "Edit",
+  setupOrStep4MockLimitLabel: "此金鑰的額度上限",
+  setupOrStep4MockButton: "Save",
+  setupOrStep4WhyLabel: "為什麼這很重要：",
+  setupOrStep4WhyMid1: " coarse 是開放原始碼的——您可以 ",
+  setupOrStep4WhyLink: "閱讀每一行程式碼",
+  setupOrStep4WhySuffix:
+    "。您的金鑰會直接送往 OpenRouter 來執行審查，然後即丟棄——絕不會被儲存。但您不必信任我們：每組金鑰的上限保證它在最壞的情況下也絕不會花費超過您所允許的額度。",
+  setupOrStep4CostLabel: "關於費用估算的說明：",
+  setupOrStep4CostBody:
+    " 提交前顯示的估算是一種帶有約 ~15% 緩衝的啟發式推算，並非硬性上限。在頂尖模型搭配長論文時，一旦證明驗證與批評改寫啟動，實際費用可能高達估算的約 ~2 倍。若每組金鑰的上限正好卡在估算值上，一次棘手的審查就可能把它耗盡並在執行途中失敗。請務必保留充裕的餘額。",
+  // setup page — OpenRouter step 5
+  setupOrStep5Title: "貼到 coarse",
+  setupOrStep5Body: "回到這裡，將您的金鑰貼到表單中，然後上傳您的 PDF。",
+  setupOrStep5Annotation: "coarse 表單",
+  setupOrStep5MockEmail: "電子郵件",
+  setupOrStep5MockKey: "OpenRouter 金鑰",
+  setupOrStep5MockButton: "審查我的論文",
+  // setup page — shared footer CTA
+  setupReadyCta: "準備好了嗎？審查您的論文 →",
+  // setup page — subscription tab intro
+  setupSubHeading: "使用您的編程代理人訂閱",
+  setupSubIntro1:
+    "適合已經在付費使用 Claude Code、Codex 或 Gemini CLI 的使用者。審查會在您的訂閱上執行並計費。您只需為 OCR 步驟向 OpenRouter 支付約 ~$0.15。",
+  setupSubIntro2:
+    "在您自己的機器上使用您自己的 Claude Code、Codex 或 Gemini CLI 帳號於本機執行。coarse.ink 不會接收或儲存您的供應商登入資訊。您供應商的條款與使用限制仍然適用。coarse.ink 與 Anthropic、OpenAI 或 Google 並無任何隸屬關係。",
+  // setup page — subscription step 1
+  setupSubStep1Title: "安裝編程代理人",
+  setupSubStep1Body:
+    "選擇您有付費的那一個。若都沒有，Gemini CLI 提供免費方案。請從供應商自己的頁面安裝它——他們的文件會保持最新。",
+  setupSubStep1ClaudePrice: "Anthropic Pro 或 Max",
+  setupSubStep1CodexPrice: "ChatGPT Plus、Pro 或 Business",
+  setupSubStep1GeminiPrice: "免費方案足以應付大多數論文",
+  setupSubStep1InstallLabel: "安裝說明 ↗",
+  setupSubStep1Verify:
+    "執行測試指令以驗證安裝與登入。若它印出回應，您就設定完成了。",
+  setupSubStep1CardLogin: "登入： ",
+  setupSubStep1CardTest: "測試： ",
+  // setup page — subscription step 2
+  setupSubStep2Title: "在您的機器上放置 OpenRouter 金鑰（僅限 PDF）",
+  setupSubStep2BodyPrefix:
+    "此步驟僅適用於 PDF 論文——非 PDF 來源（.tex, .md, .docx, …）會在本機擷取而不需要 OCR，因此任何地方都不需要 OpenRouter 金鑰，您可以直接跳到步驟 3。對於 PDF，coarse 在 OCR 步驟仍需要 OpenRouter（每篇論文約 ~$0.10）。請依照 ",
+  setupSubStep2BodyTab: "OpenRouter 金鑰",
+  setupSubStep2BodySuffix:
+    " 分頁來建立帳號、加入 $1 的額度，並設定每組金鑰 $2 的上限。此處不需要僅用 OpenRouter 路徑時的 $20 緩衝，因為審查本身是在您的編程代理人訂閱上執行的。",
+  setupSubStep2KeyPrefix: "接著將金鑰放到您自己的機器上：執行 ",
+  setupSubStep2KeyMid1: "，將它放進 ",
+  setupSubStep2KeyMid2: "，或將它儲存到 ",
+  setupSubStep2KeySuffix:
+    "。您的 CLI 在執行擷取時會於本機讀取它；coarse.ink 絕不會看到它。",
+  // setup page — subscription step 3
+  setupSubStep3Title: "上傳您的論文並挑選一個 CLI",
+  setupSubStep3BodyPrefix: "在 ",
+  setupSubStep3BodyLink: "主頁面",
+  setupSubStep3BodyMid: "上，將您的論文（PDF, .tex, .md, .docx, …）拖曳到表單上，然後點擊 ",
+  setupSubStep3BodyButton: "用我的訂閱審查 ▾",
+  setupSubStep3BodySuffix:
+    " 下拉選單並挑選您的 CLI。coarse 會上傳檔案、產生一組交接權杖，並顯示您將在下一步貼上的提示。您在此處不需要在表單上貼上您的 OpenRouter 金鑰；CLI 會從您的機器讀取它（步驟 2）。",
+  // setup page — subscription step 4
+  setupSubStep4Title: "將提示貼到您的 CLI",
+  setupSubStep4BodyPrefix: "coarse 會給您一段自然語言提示。從面板複製它，貼到您的 ",
+  setupSubStep4BodyMid1: "、 ",
+  setupSubStep4BodyMid2: "或 ",
+  setupSubStep4BodyMid3: " 工作階段，然後按送出。代理人會重新整理它的技能組合，在自己的子程序呼叫上執行完整的 coarse 流程，並在完成時印出一個 ",
+  setupSubStep4BodySuffix:
+    " URL。需時 10–25 分鐘。點擊該 URL 即可在 coarse.ink 上開啟完成的審查。",
+  setupSubStep4TimeoutLabel: "如果您是貼到編程代理人裡",
+  setupSubStep4TimeoutSuffix:
+    " （而非單純的終端機），請在送出提示前將它的 bash 工具逾時調高到至少 45 分鐘。代理人的預設逾時可能低至 2 分鐘，遠低於 10–25 分鐘的審查執行時間。",
+  // setup page — subscription step 5 (troubleshooting)
+  setupSubStep5Title: "如果出了狀況",
+  setupSubTrouble1Symptom: "「Try opening Claude Code / Codex」按鈕沒有反應。",
+  setupSubTrouble1Fix:
+    "該按鈕只有在您安裝了桌面應用程式時才有效。若僅安裝 CLI 版本，瀏覽器無法為您啟動終端機。請從面板複製提示，並手動貼到您的 CLI。",
+  setupSubTrouble2Symptom: "代理人執行中出現「No such command ‘install-skills’」。",
+  setupSubTrouble2FixPrefix: "可以放心忽略。技能組合仍會直接透過 ",
+  setupSubTrouble2FixSuffix: "載入；代理人會繼續進行審查步驟。",
+  setupSubTrouble3Symptom: "審查後我的 Anthropic／OpenAI／Google 帳單增加了。",
+  setupSubTrouble3FixPrefix: "請檢查您的 shell 環境中是否有 ",
+  setupSubTrouble3FixMid1: "、 ",
+  setupSubTrouble3FixMid2: "或 ",
+  setupSubTrouble3FixSuffix:
+    " 。若有設定，主機 CLI 會向 API 帳號計費，而非您的訂閱。v1.3.0+ 會自動移除這些，但舊版本不會。",
+  setupSubTrouble4Symptom: "意見比平常少（約 ~10 則而非 15–25 則）。",
+  setupSubTrouble4FixPrefix: "某個章節觸及了 30 分鐘逾時而被捨棄。在預設推理強度下很少見，搭配 ",
+  setupSubTrouble4FixSuffix:
+    " 處理長論文時較常發生。請重新執行；若發生兩次，請將推理強度調低一級。",
+
+  // compare page (ComparePage.tsx)
+  comparePanelErrorBody: "無法呈現這一則。請嘗試其他模型或比較。",
+  comparePaperCorticalCircuits: "皮質迴路",
+  comparePaperCosetCodes: "陪集碼",
+  comparePaperPopulationGenetics: "族群遺傳學",
+  comparePaperTargetingInterventions: "目標式介入",
+  compareScoresShow: "顯示",
+  compareScoresHide: "隱藏",
+  compareScoresToggleSuffix: " 各篇論文的所有分數 ",
+  compareScoresColPaper: "論文",
+  compareScoresColReference: "參考標準",
+  compareScoresColGpt5Mini: "GPT-5 Mini",
+  compareScoresColGpt54: "GPT-5.4",
+  compareScoresColSonnet: "Sonnet 4.6",
+  compareScoresColKimi: "Kimi K2.5",
+  compareScoresFootnote:
+    "由 Gemini 3.1 Pro 以 PDF 多模態輸入進行評估。5.0/5 = 達到參考標準的品質。5.5+/5 = 超越它。",
+  compareJudgeShow: "顯示",
+  compareJudgeHide: "隱藏",
+  compareJudgeToggleSuffix: " 送往 Gemini 3.1 Pro 的評審提示 ",
+  compareJudgeExplain:
+    "為了減輕已知的 LLM-as-judge 偏誤，評審會在每次評估時以兩篇審查互換呈現順序的方式執行兩次，分數則跨兩種排序取平均。這可抵消位置偏誤，亦即評審會系統性地偏好排在前面的審查。提示中也包含具體指示，以抵消冗長偏誤（不因篇幅長而非實質內容給分）、自信偏誤（不因斷言式語氣而非正確的審慎保留給分）、權威偏誤（不因術語或引用數量而非準確性給分）以及寬鬆偏誤（使用完整的 1-6 評分區間，而非集中在中間）。審查會以中性的「Review A」與「Review B」標示，而非「參考」與「生成」，以防止基於來源的評分。",
+  compareJudgeSystemPromptLabel: "系統提示",
+  compareJudgeUserPromptLabel: "使用者提示（論文與審查於執行時注入）",
+  compareVsMid: " vs ",
+  compareScoreOutOf: "/5",
+  compareMetricCoverage: "涵蓋度",
+  compareMetricSpecificity: "具體性",
+  compareMetricDepth: "深度",
+  compareJumpTo: "跳至",
+  compareSectionOverallFeedback: "整體回饋",
+  compareSectionDetailedComments: "詳細意見",
+  compareVisitPrefix: "造訪 ",
+  comparePdfReviewSuffix: " 審查",
+  comparePdfFallback: "若 iframe 未能呈現，請下載 PDF ↓",
 };


### PR DESCRIPTION
Closes #239. The last two routes that reverted to English after a language switch — the **setup** (configuration) walkthrough and the **compare** (side-by-side) page — now follow the selected site language. After this, **every** user-facing page (submit, status, review, setup, compare) is localized.

## What this does
- Wires `setup/page.tsx` (a `SetupBody` split) and `ComparePage.tsx` (a `ComparePageBody` split) into the existing `SiteLanguageProvider` + `t()` layer; the choice persists in `localStorage`, so it carries across navigation.
- **140 new keys** (108 `setup*` + 32 `compare*`) externalized into the catalog; all 11 non-English catalogs extended by per-language **Opus-4.8** agents, **additive-only** (the existing 292 audited values are byte-identical/untouched) → every catalog now **432 keys**.
- **UI chrome only**: the embedded example reviews/papers on the compare page and the LLM-judge prompt constants stay as data/English (verified byte-identical to origin).

## Invariants
- **English render byte-identical** — adversarially verified across *every* fragment (not a sample): all OpenRouter/Subscription setup steps, troubleshooting fixes, and all 32 compare keys incl. the escaped-quote `compareJudgeExplain`. Boundary spaces / JSX entities reproduce exactly.
- All 12 catalogs node-validated (432 string keys, no quote/parse breakage); `t()` keys all resolve (incl. the dynamic `MessageKey[]`/`as const` patterns, confirmed via strict `tsc`); 3 translators independently ran `tsc --noEmit` clean.

## Testing
- `tests/test_web_site_i18n.py` asserts 432 keys; the `test_setup_page_warns_about_provisioning_keys` drift guard repointed to the catalog (where the "User not found" provisioning copy now lives) + asserts the page renders it via `t()`.
- Full suite **1271 passed**; ruff + security clean. **Vercel build is the TS gate** (no local node_modules) — please confirm green before merge.

## Out of scope (pre-existing, noted by review)
- `compare/page.tsx` server-component `metadata` (title/description) stays English — not trivially localizable from a `metadata` export.
- A pre-existing `--` (vs em-dash) in `compareSuffix` — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)