### PR TITLE
Prepare v1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.9.0 — 2026-07-30
+
 ### Added
 
 - **Optional deep literature review, end to end.** The coarse.ink submit form now has an accessible, localized Deep literature search switch. When enabled, the request flows through the web API and Modal worker into `review_paper()`, which uses Perplexity Sonar Deep Research (`perplexity/sonar-deep-research`) instead of the standard Sonar Pro Search path. The CLI and subscription-backed `coarse-review` path expose the same capability through `--deep-literature-search`; explicit deep searches fail fast with actionable OpenRouter-key guidance and propagate provider failures instead of silently degrading to arXiv or omitting literature after the user selected the paid option. Deep requests use a five-minute provider timeout while retaining the existing 4,096-token literature-context ceiling so broader retrieval does not multiply downstream prompt cost. Python and web estimators share a representative $0.25 pre-buffer deep-search cost (about $0.30 added after the normal 30% buffer). The off state preserves the old request/call shape and resilient fallbacks for backward compatibility. This touches `src/coarse/`, web, and Modal and must soak in preview before production; the package portion ships in the next PyPI release.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure,
 
 ## Version
 
-1.8.0
+1.9.0
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coarse-ink"
-version = "1.8.0"
+version = "1.9.0"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
 license = "MIT"

--- a/src/coarse/__init__.py
+++ b/src/coarse/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 from coarse.pipeline import extract_and_structure, review_paper  # noqa: F401

--- a/src/coarse/_skills/claude_code/SKILL.md
+++ b/src/coarse/_skills/claude_code/SKILL.md
@@ -31,7 +31,7 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -45,13 +45,13 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `claude` CLI logged in.
 
 ## How to run
@@ -69,12 +69,12 @@ Use a **per-review unique log file** so parallel runs in the same shell don't cl
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns within 2 seconds with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host claude [--model claude-opus-5] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --attach "$LOG"
 ```
 
@@ -100,12 +100,12 @@ If the user came from the coarse web form, they'll paste a handoff URL instead o
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host claude [--model ...] [--effort ...]
 
 # STEP 2b — wait (same long-timeout discipline as local mode)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/codex/SKILL.md
+++ b/src/coarse/_skills/codex/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `codex` CLI logged in: `codex login`.
 
 ## How to run
@@ -61,12 +61,12 @@ Step 1 detaches the worker (~2 seconds) and writes `<log>.pid`. Step 2 uses `--a
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns in ~2s)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host codex [--model gpt-5.6-sol] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --attach "$LOG"
 ```
 
@@ -96,12 +96,12 @@ These map to Codex's internal reasoning effort:
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host codex
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/gemini_cli/SKILL.md
+++ b/src/coarse/_skills/gemini_cli/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.8.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.0' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `gemini` CLI signed in (first run prompts for OAuth).
 
 ## How to run
@@ -63,12 +63,12 @@ Use a **per-review unique log file** so parallel runs don't clobber each other's
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch (returns in ~2s with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path_or_handoff_url> --host gemini [--model gemini-3.6-flash] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --attach "$LOG"
 ```
 
@@ -92,12 +92,12 @@ Available effort levels: `low`, `medium`, `high` (default), `max`.
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host gemini
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.8.0' \
+uvx --python 3.12 --from 'coarse-ink==1.9.0' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/model_registry.py
+++ b/src/coarse/model_registry.py
@@ -21,6 +21,7 @@ from coarse.models import (
     GPT_5_6_TERRA_MODEL,
     GROK_4_5_MODEL,
     KIMI_K3_MODEL,
+    LITELLM_OPENROUTER_PREFIX,
     LONG_CONTEXT_PRICING_TIERS,
 )
 
@@ -113,4 +114,4 @@ def register_model_costs() -> None:
 
     for model_id, info in custom_model_info.items():
         litellm.model_cost[model_id] = info
-        litellm.model_cost[f"openrouter/{model_id}"] = info
+        litellm.model_cost[f"{LITELLM_OPENROUTER_PREFIX}{model_id}"] = info

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -115,6 +115,7 @@ WEB_FEATURED_MODEL_IDS: tuple[str, ...] = (
 
 # OpenRouter meta-models whose canonical slug starts with ``openrouter/`` and so
 # must be doubled for litellm provider routing (see FUSION_MODEL note above).
+LITELLM_OPENROUTER_PREFIX = "openrouter/"
 OPENROUTER_NAMESPACE_MODELS: frozenset[str] = frozenset({FUSION_MODEL})
 
 # Vision model for post-extraction QA (multimodal, spot-checks Docling output)

--- a/tests/test_headless_instructions.py
+++ b/tests/test_headless_instructions.py
@@ -30,11 +30,11 @@ def test_bundled_skill_assets_use_ephemeral_uvx_flow() -> None:
         # that lands this branch on main. See CHANGELOG.md ## Unreleased
         # "RELEASE BLOCKER" note — DEFAULT_MCP_UVX_FROM and these SKILL.md
         # files must all flip from the temporary git-ref pin to
-        # ``coarse-ink==1.8.0`` as part of the release cut. The `[mcp]`
+        # ``coarse-ink==1.9.0`` as part of the release cut. The `[mcp]`
         # extra was dropped to cut the uvx install from ~114 to ~60
         # packages — the handoff flow does not need fastmcp or
         # pymupdf4llm.
-        assert "uvx --python 3.12 --from 'coarse-ink==1.8.0'" in text
+        assert "uvx --python 3.12 --from 'coarse-ink==1.9.0'" in text
         assert "coarse install-skills --all --force" in text
         # Per-review unique log file: every skill uses a LOG env var
         # derived from a per-paper suffix so parallel runs in the same
@@ -140,7 +140,7 @@ def test_web_handoff_assets_use_shared_uvx_prompt_flow() -> None:
     # as part of the release cut. The release-blocker coupling test
     # in `test_release_blocker_pin_is_coupled_to_unreleased_version`
     # enforces that this pin matches `__version__`.
-    assert '"coarse-ink==1.8.0"' in handoff_lib
+    assert '"coarse-ink==1.9.0"' in handoff_lib
     assert "@feat/mcp-server" not in handoff_lib
     assert "@feat/mcp-server" not in handoff_route
 

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "coarse-ink"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },

--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -91,13 +91,13 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 // The variable is still called `DEFAULT_MCP_UVX_FROM` for backward
 // compatibility with the `test_release_blocker_pin_is_coupled_to_unreleased_version`
 // drift test that enforces the pin matches `__version__`.
-const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.8.0";
+const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.9.0";
 
 export function resolvePinnedUvFrom(): string {
   const raw = (process.env.NEXT_PUBLIC_COARSE_UVX_FROM ?? "").trim();
   if (!raw) return DEFAULT_MCP_UVX_FROM;
   // Allowlist for `NEXT_PUBLIC_COARSE_UVX_FROM` overrides. Accepts:
-  //   1. Plain semver pin: `coarse-ink==1.8.0` (production default).
+  //   1. Plain semver pin: `coarse-ink==1.9.0` (production default).
   //   2. `[mcp]` extra form for operators who want the MCP path.
   //   3. Commit-sha git ref for pinned dev testing.
   //   4. `@dev` or `@main` branch ref — self-updating Preview default,


### PR DESCRIPTION
## Summary

- Bump the package, lockfile, README, bundled skills, and web handoff pin to 1.9.0.
- Move the accumulated Unreleased notes into the dated v1.9.0 changelog section while retaining an empty Unreleased section.
- Centralize the LiteLLM OpenRouter routing prefix in the canonical model manifest so the committed dev diff passes the model-ID doc-sync guard.

## Validation

- Strict security scanner: zero findings.
- Python: 1,317 passed, 1 deselected.
- Web: 8 Vitest tests, Next.js production build, full and production npm audits all pass.
- Package: sdist and wheel built successfully for 1.9.0.
- Preview before release prep: standard and deep-literature reviews completed against isolated preview Vercel, Supabase, and Modal; subscription handoff bundle/download passed; production remained untouched.