### PR TITLE
fix(security): harden release audit and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,29 +7,19 @@ on:
 
 permissions: read-all
 
-# Opt every JavaScript-based action in this workflow into Node.js 24.
-# GitHub is deprecating Node 20 for JavaScript actions (default flip on
-# 2026-06-02, hard removal on 2026-09-16); setting this env var at
-# workflow level forces `actions/checkout`, `actions/setup-*`,
-# `astral-sh/setup-uv`, etc. onto the Node 24 runner immediately. When
-# the flip becomes the default, this env var becomes a no-op and can be
-# removed. Keeping it here as the single bulk opt-in is cheaper than
-# chasing every action to its next major tag.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -37,15 +27,13 @@ jobs:
       # tests/test_pipeline_spec.py shells out to
       # `node --experimental-strip-types` to run `web/src/lib/estimateCost.ts`
       # directly for the Python↔TS cost-gate parity check. The
-      # `--experimental-strip-types` flag landed in Node 22.6, and the GitHub
-      # `ubuntu-latest` runner currently defaults to Node 20 LTS, which exits
-      # with code 9 ("bad option") on that flag. Pinning Node 22 here keeps
-      # the parity test green without forcing every contributor to upgrade
-      # their local Node too.
+      # `--experimental-strip-types` requires Node 22.6+. Pin Node 24 to
+      # match the Vercel production runtime and keep the Python↔TS parity
+      # test independent of runner-image defaults.
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -78,6 +66,7 @@ jobs:
         working-directory: web
         run: |
           npm ci
+          npm test
           npm run build
 
   version-check:
@@ -85,7 +74,7 @@ jobs:
     timeout-minutes: 2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check version consistency
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,17 +59,17 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
     # or others). This is typically only required for manual builds.
     # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+    #   action reference: actions/setup-example at an immutable SHA
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/modal-deploy.yml
+++ b/.github/workflows/modal-deploy.yml
@@ -1,7 +1,7 @@
 name: deploy-modal
 
-# Auto-deploy both production Modal apps from `main` on every push that
-# changes shipped server code. Together with the companion
+# Auto-deploy the production `coarse-review` Modal app from `main` on
+# every push that changes shipped server code. Together with the companion
 # `modal-preview-deploy.yml` workflow, this makes the default path:
 #
 #   feature branch -> dev -> preview Modal/Vercel/Supabase validation
@@ -40,12 +40,6 @@ on:
 permissions:
   contents: read
 
-# Opt JavaScript-based actions into Node.js 24 ahead of GitHub's
-# 2026-06-02 default flip / 2026-09-16 Node 20 removal. See the note
-# on `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in ci.yml.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 # Serialize deploys: if two pushes land on main within seconds of each
 # other, deploy them in order rather than in parallel. `cancel-in-progress:
 # false` means a second push waits for the first to finish instead of
@@ -75,10 +69,10 @@ jobs:
             path: deploy/modal_worker.py
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/modal-preview-deploy.yml
+++ b/.github/workflows/modal-preview-deploy.yml
@@ -19,9 +19,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 concurrency:
   group: modal-preview-deploy
   cancel-in-progress: false
@@ -44,10 +41,10 @@ jobs:
             needs_force: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -4,12 +4,6 @@ on:
     - cron: '0 8 * * *'  # 8 AM UTC daily
   workflow_dispatch: {}   # Allow manual trigger
 
-# Opt JavaScript-based actions into Node.js 24 ahead of GitHub's
-# 2026-06-02 default flip / 2026-09-16 Node 20 removal. See the note
-# on `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in ci.yml.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,23 +24,18 @@ on:
 permissions:
   contents: read
 
-# Opt JavaScript-based actions into Node.js 24 ahead of GitHub's
-# 2026-06-02 default flip / 2026-09-16 Node 20 removal. See the note
-# on `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in ci.yml.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -48,16 +43,14 @@ jobs:
       # tests/test_pipeline_spec.py shells out to
       # `node --experimental-strip-types` to run `web/src/lib/estimateCost.ts`
       # directly for the Python↔TS cost-gate parity check. The
-      # `--experimental-strip-types` flag landed in Node 22.6, and the GitHub
-      # `ubuntu-latest` runner currently defaults to Node 20 LTS, which exits
-      # with code 9 ("bad option") on that flag. Pinning Node 22 here keeps
-      # the parity test green on the release workflow in lockstep with the
-      # matching step in ci.yml. The v1.3.0 release hit this exact gap on
-      # its first tag push and had to be re-tagged after patching this.
+      # `--experimental-strip-types` requires Node 22.6+. Pin Node 24 to
+      # match Vercel production and keep this release workflow in lockstep
+      # with ci.yml. The v1.3.0 release hit the missing-runtime gap on its
+      # first tag push and had to be re-tagged after patching it.
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -77,12 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
 
       - name: Set up Python
         run: uv python install 3.12
@@ -104,7 +98,7 @@ jobs:
         run: uv build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -125,10 +119,10 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,21 +6,15 @@ on:
   pull_request:
     branches: [main, dev]
 
-# Opt JavaScript-based actions into Node.js 24 ahead of GitHub's
-# 2026-06-02 default flip / 2026-09-16 Node 20 removal. See the note
-# on `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in ci.yml.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   scan:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -34,9 +28,9 @@ jobs:
           pip-audit --strict --desc 2>&1 | tail -80
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/supabase-migrate-preview.yml
+++ b/.github/workflows/supabase-migrate-preview.yml
@@ -44,7 +44,7 @@ jobs:
     environment: preview-modal
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install psql
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ For any substantial deploy-affecting change, the default workflow is:
 4. Validate the change against preview Vercel + preview Supabase +
    preview Modal before touching `main`.
 5. Merge `dev` to `main` only after preview passes.
-6. Let `.github/workflows/modal-deploy.yml` deploy both Modal apps to
-   production from `main`.
+6. Let `.github/workflows/modal-deploy.yml` deploy the `coarse-review`
+   Modal app to production from `main`.
 
 Hard rules:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- **GitHub Actions now run on current Node 24-native releases pinned to immutable commit SHAs.** Checkout, setup-node, setup-python, setup-uv, CodeQL, artifact transfer, and PyPI publishing actions were upgraded to their current releases; the obsolete forced-Node-24 migration flag was removed. The uv cache retains its prior pruning behavior explicitly, a regression test rejects mutable third-party action refs across block/flow and `.yml`/`.yaml` syntax, and CI now executes the web Vitest suite before the production build. CI/deploy-only — no package change.
+
+### Fixed
+
+- **The production release audit now understands Vercel-managed secrets and proves protected reads structurally.** `VERCEL_AUTOMATION_BYPASS_SECRET` is a system variable that Vercel intentionally injects into every deployment when automation bypass is enabled, so middleware no longer reports its expected production presence as a leak. Protected direct-property reads must now sit inside an exact lexical `VERCEL_ENV` equality block; whole-object, bracket/computed, imported-process, and aliased access fail closed. Adversarial tests cover comments, regex literals, closed/opposite branches, indirect identifiers, and process-env aliases. Genuinely misplaced preview Basic Auth variables still produce a once-per-cold-start runtime warning, now covered behaviorally in Vitest; credential comparison performs fixed work for both username and password instead of using short-circuit string equality. The checklist also records that Sensitive Vercel variables are non-readable and must not be treated as empty based on `vercel env pull`. Active deployment docs were corrected to describe the single `coarse-review` Modal app; legacy `coarse-mcp` was retired in v1.3.0. Web/ops-only — no package change.
+
 ## v1.9.0 — 2026-07-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,15 +210,17 @@ For any substantial deploy-affecting change, the default path is:
 Concretely:
 
 - Vercel creates preview deployments for non-`main` pushes.
-- `.github/workflows/modal-preview-deploy.yml` deploys both Modal apps
-  from `dev` into the Modal `preview` environment when the change
+- `.github/workflows/modal-preview-deploy.yml` deploys the
+  `coarse-review` Modal app from `dev` into the Modal `preview`
+  environment when the change
   touches deploy-relevant paths; otherwise rerun it manually on `dev`
   if you need a fresh preview Modal deploy.
-- Preview Vercel env vars point at preview Supabase plus preview Modal
-  URLs (`MODAL_FUNCTION_URL` and `MODAL_EXTRACT_URL`), as documented in
+- Preview Vercel env vars point at preview Supabase plus the preview
+  Modal URL (`MODAL_FUNCTION_URL`), as documented in
   `deploy/PREVIEW_ENVIRONMENTS.md`.
-- `.github/workflows/modal-deploy.yml` deploys both Modal apps from
-  `main` to production.
+- `.github/workflows/modal-deploy.yml` deploys `coarse-review` from
+  `main` to production. The legacy `coarse-mcp` app was retired in
+  v1.3.0.
 
 Hard deploy rules:
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -68,10 +68,9 @@ The `reviews` table stores review metadata and results. PDFs are uploaded to the
 3. Deploy via CI, not manually. Production Modal deploys are handled by
    `.github/workflows/modal-deploy.yml` on every push to `main` that
    touches `src/coarse/**`, `deploy/modal_worker.py`,
-   `deploy/mcp_server.py`, `pyproject.toml`, or the workflow file
-   itself. Preview Modal deploys are handled by
+   `pyproject.toml`, or the workflow file itself. Preview Modal deploys are handled by
    `.github/workflows/modal-preview-deploy.yml` on deploy-relevant
-   pushes to `dev` (`src/coarse/**`, the two Modal entrypoints,
+   pushes to `dev` (`src/coarse/**`, `deploy/modal_worker.py`,
    `pyproject.toml`, or the preview workflow itself). You should almost
    never run `modal deploy` by hand.
 
@@ -106,9 +105,8 @@ The `reviews` table stores review metadata and results. PDFs are uploaded to the
    COARSE_MODAL_DEPLOY_FORCE=1 modal deploy deploy/modal_worker.py
    ```
    Without the `COARSE_MODAL_DEPLOY_FORCE=1` env var, the import-time
-   guard in `deploy/modal_worker.py::_enforce_deploy_branch()` and
-   `deploy/mcp_server.py::_enforce_deploy_branch()` refuses to deploy
-   from any branch other than `main`. This guard exists because on
+   guard in `deploy/modal_worker.py::_enforce_deploy_branch()` refuses
+   to deploy from any branch other than `main`. This guard exists because on
    2026-04-13 a `modal deploy` from a `dev` checkout shipped
    resurrected cheap-tier stage routing plus an api-key race to
    production, breaking every review for hours.
@@ -127,13 +125,6 @@ The `reviews` table stores review metadata and results. PDFs are uploaded to the
 
 **How the worker runs**: When triggered by the frontend, it downloads the PDF from Supabase Storage, calls `coarse.review_paper()` with the user's OpenRouter key, writes the review markdown back to Supabase, sends a completion email, and deletes the PDF. Timeout is 10 minutes, memory is 512 MB.
 
-If you also use the subscription/MCP flow, deploy `deploy/mcp_server.py`
-and save the extract endpoint URL too:
-
-```text
-https://<your-org>--coarse-mcp-run-extract.modal.run
-```
-
 ---
 
 ## 3. Vercel
@@ -150,11 +141,9 @@ https://<your-org>--coarse-mcp-run-extract.modal.run
    | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | `eyJ...` | From step 1 |
    | `SUPABASE_SERVICE_KEY` | `eyJ...` | From step 1 (server-side only) |
    | `MODAL_FUNCTION_URL` | `https://...modal.run` | From step 2 |
-   | `MODAL_EXTRACT_URL` | `https://...modal.run` | `coarse-mcp` `run_extract` endpoint |
    | `MODAL_WEBHOOK_SECRET` | (same value as Modal secret) | Shared secret |
    | `RESEND_API_KEY` | `re_...` | Resend sending-access key (see step 5) |
    | `NEXT_PUBLIC_SITE_URL` | `https://coarse.ink` | Your public URL |
-   | `NEXT_PUBLIC_MCP_SERVER_URL` | `https://.../mcp/` | Optional; used by legacy `/mcp` landing page |
 
 3. Deploy. The site will be live at `https://coarse.ink` (or your Vercel preview URL during development).
 
@@ -179,8 +168,7 @@ Default rollout for substantial changes:
    fix preview infra before merging:
    - preview Vercel must have `NEXT_PUBLIC_SUPABASE_URL`,
      `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY`,
-     `MODAL_FUNCTION_URL`, `MODAL_EXTRACT_URL`, and
-     `MODAL_WEBHOOK_SECRET`
+     `MODAL_FUNCTION_URL`, and `MODAL_WEBHOOK_SECRET`
    - preview Supabase must have every SQL file listed in
      [deploy/PREVIEW_ENVIRONMENTS.md](PREVIEW_ENVIRONMENTS.md)
    - if Turnstile is enabled on preview, its hostname allowlist must
@@ -194,17 +182,17 @@ Preview website signoff checklist:
 
 1. Wait for Vercel preview creation for the latest `dev` commit
 2. If the change touched `src/coarse/**`, `deploy/modal_worker.py`,
-   `deploy/mcp_server.py`, `pyproject.toml`, or the preview workflow,
+   `pyproject.toml`, or the preview workflow,
    also wait for `.github/workflows/modal-preview-deploy.yml` to finish
    or manually re-run it with `gh workflow run modal-preview-deploy.yml --ref dev`
 3. Open the preview URL from the `dev` commit / PR checks
 4. Log in through Vercel Authentication if prompted
 5. If preview browser auth is enabled, enter
    `PREVIEW_BASIC_AUTH_USERNAME` / `PREVIEW_BASIC_AUTH_PASSWORD`
-6. Verify the upload succeeds, the status page loads, and the MCP
-   handoff UI still works
-7. Verify `coarse-review` and `coarse-mcp` invocations appear only in
-   the Modal `preview` environment
+6. Verify the upload succeeds, the status page loads, and the
+   subscription handoff UI still works
+7. Verify `coarse-review` invocations appear only in the Modal
+   `preview` environment
 8. Verify new rows land only in preview Supabase
 
 GitHub checks to watch:
@@ -244,12 +232,18 @@ Email notifications go through Resend. coarse sends both the "review received" c
 1. Create a free Resend account at [resend.com](https://resend.com).
 2. Add and verify the sending domain (e.g. `coarse.ink`) in **Domains → Add Domain**. Resend gives you SPF + DKIM records to publish with your DNS host.
 3. Mint a **sending-access** API key at [resend.com/api-keys](https://resend.com/api-keys), scoped to that domain.
-4. Set `RESEND_API_KEY` in all three places:
-   - **Vercel**: Settings → Environment Variables → add to Production, Preview, and Development.
-   - **Modal**: `modal secret create coarse-resend RESEND_API_KEY=...` (matches `@app.function(secrets=[...])` in `deploy/modal_worker.py`).
+4. Set the production `RESEND_API_KEY` in these three production consumers:
+   - **Vercel**: Settings → Environment Variables → scope it to **Production only**. Leave Preview and Development unset unless they use a separate non-production key and sending domain.
+   - **Modal**: create `coarse-resend` in the default/production environment with `modal secret create coarse-resend RESEND_API_KEY=...` (matches `@app.function(secrets=[...])` in `deploy/modal_worker.py`). The preview environment needs a separately named `coarse-resend` secret object, but its API key should be omitted or independently scoped as described in `deploy/PREVIEW_ENVIRONMENTS.md`.
    - **GitHub Actions**: `gh secret set RESEND_API_KEY` (used by `.github/workflows/monitor.yml` for capacity alerts).
 
-**Key rotation**: all three must rotate together — revoke the old key in the Resend dashboard only after the new one has replaced every environment. Fastest escape hatch if Resend ever breaks: flip `EMAIL_DELIVERY_DISABLED` to `true` in `web/src/lib/emailCapacity.ts` and redeploy — the web UI accepts empty-email submissions and the banner points users at their review key.
+If the Vercel variable is marked **Sensitive**, its value is deliberately
+non-readable and `vercel env pull` may emit an empty value. That does not
+mean the runtime secret is unset. Check the configured variable and recent
+send logs, or rotate it through the dashboard; do not delete and recreate a
+working key solely because the CLI cannot read it back.
+
+**Key rotation**: all three production consumers must rotate together — revoke the old key in the Resend dashboard only after the new one has replaced Vercel Production, Modal's default environment, and the GitHub Actions repository secret. Never copy that production key into Preview or Development. Fastest escape hatch if Resend ever breaks: flip `EMAIL_DELIVERY_DISABLED` to `true` in `web/src/lib/emailCapacity.ts` and redeploy — the web UI accepts empty-email submissions and the banner points users at their review key.
 
 Resend Free is 3k emails/month (≈1500 reviews); Pro is 50k/month for $20. See `deploy/CAPACITY.md` for the math.
 

--- a/deploy/PREVIEW_ENVIRONMENTS.md
+++ b/deploy/PREVIEW_ENVIRONMENTS.md
@@ -1,20 +1,15 @@
 # Preview environment setup — Tier 0 + Tier 1
 
-> **⚠️ v1.3.0 note:** the `coarse-mcp` Modal app and the whole MCP
-> server path were retired in v1.3.0. Any step or paragraph below
-> that references `deploy/mcp_server.py`, `coarse-mcp`,
-> `MODAL_EXTRACT_URL`, or `NEXT_PUBLIC_MCP_SERVER_URL` is historical
-> and should be **skipped** when setting up a new preview environment.
-> Only the `coarse-review` Modal app needs to be deployed. If an
-> old preview still has `coarse-mcp` running, run
+> **Current topology:** only the `coarse-review` Modal app is active.
+> The legacy `coarse-mcp` app and MCP server path were retired in
+> v1.3.0. If an old preview still has `coarse-mcp` running, run
 > `modal app stop coarse-mcp -e preview` to tear it down. The
-> subscription-handoff flow (what replaced the MCP path) runs
+> subscription-handoff flow that replaced it runs
 > entirely on the user's local machine and doesn't need a Modal app
 > beyond `coarse-review` for the OpenRouter review flow.
 
-**Status:** repo-side automation/docs are in place; the external Vercel,
-Supabase, Modal, and GitHub environment setup still needs to be done by
-an operator. Use this file as the runbook.
+**Status:** the isolated preview stack is operational. Use this file to
+validate or rebuild its Vercel, Supabase, Modal, and GitHub configuration.
 
 **Goal:** test `dev`-branch changes against a **fully isolated** preview
 stack (Vercel preview deployment + preview Supabase + preview Modal
@@ -61,9 +56,9 @@ production as part of the release PR.
 
 - **Tier 1** (this doc, part 2): **Isolated downstream services** +
   **Preview-scoped env vars**. Dedicated preview Supabase plus a
-  dedicated Modal **environment** that contains both web-triggered
-  workers (`coarse-review` and `coarse-mcp`). Vercel preview env vars
-  point at those preview resources. After Tier 1, preview deployments
+  dedicated Modal **environment** that contains the `coarse-review`
+  worker. Vercel preview env vars point at those preview resources.
+  After Tier 1, preview deployments
   can break preview Supabase / Modal without any risk to production.
 
 - **Tier 2 / Tier 3** (out of scope for this doc):
@@ -85,7 +80,7 @@ You'll need (or need to create):
   instead, that's a later upgrade; this doc assumes the cheaper,
   simpler dedicated-project route.
 - [ ] Modal account with permission to create a second **environment**
-  (for example `preview`). Same billing account as the existing apps is
+  (for example `preview`). Same billing account as the existing app is
   fine; an idle preview environment costs roughly nothing.
 - [ ] A second Resend API key (optional — you can also just leave
   `RESEND_API_KEY` unset in Preview so emails silently no-op, which
@@ -130,9 +125,12 @@ account → you should see the preview deployment.
 
 **Vercel dashboard → coarse project → Settings → Deployment Protection → Protection Bypass for Automation**
 
-Click **Generate Secret**. Vercel writes the value into the preview
-environment as `VERCEL_AUTOMATION_BYPASS_SECRET` automatically; you
-don't need to copy it anywhere.
+Click **Generate Secret**. Vercel exposes one generated value as the
+`VERCEL_AUTOMATION_BYPASS_SECRET` system environment variable in every
+deployment automatically; you don't need to copy it anywhere. Its
+presence in a production runtime is expected. Coarse only consumes it
+when `VERCEL_ENV === "preview"`, so it cannot enable preview behavior
+on production.
 
 Why this step is required: the CLI / Codex-cloud handoff flow has a
 detached local worker fetch `GET /h/<token>` to pull the paper bundle.
@@ -147,8 +145,8 @@ set, so once you've generated it the flow just works. If the secret
 is missing the response includes a `warning` field naming exactly
 this step; the `src/coarse/cli_review.py` error hint also points here.
 
-Production URLs stay clean because the secret is only defined on the
-preview environment.
+Production URLs stay clean because application code only reads and
+uses the system-provided secret inside an explicit preview block.
 
 **At this point Tier 0 is done.** You have private preview URLs
 that the CLI handoff can still reach. They still talk to production
@@ -161,8 +159,9 @@ Every preview-specific config path is **environment-scoped**: the
 repo-owned Basic Auth middleware, the Vercel Deployment Protection
 bypass secret, the preview Supabase URL, and the preview Modal
 environment all check `VERCEL_ENV === "preview"` (web) or live in a
-Modal "preview" environment (worker) before activating. Production
-cold-starts never see any of it.
+Modal "preview" environment (worker) before activating. Vercel may
+inject its automation-bypass system variable into production too, but
+production code never consumes it.
 
 So "cutting a production release" is just a branch merge plus a
 dashboard audit. There is no code you need to remove, no flag to flip,
@@ -176,34 +175,41 @@ make release-audit
 
 This runs `scripts/release_audit.py`, which:
 
-1. **Repo-local check**: greps `web/src` for any `process.env.<VAR>`
-   read of `PREVIEW_BASIC_AUTH_PASSWORD`, `PREVIEW_BASIC_AUTH_USERNAME`,
-   or `VERCEL_AUTOMATION_BYPASS_SECRET` that isn't within 10 lines of
-   a `VERCEL_ENV === "preview"` (or the
-   `warnIfPreviewVarsLeakedIntoProduction` helper) guard. Fails exit 1
-   if a new code path reads a preview-only var without gating. A
+1. **Repo-local check**: scans `web/src` for direct dot-property access
+   involving protected preview variables and rejects whole-object,
+   bracket/computed, or aliased `process.env` access that cannot be
+   proved safe.
+   Each protected read must be lexically contained by an exact
+   `VERCEL_ENV === "preview"` block; the production leak detector may
+   inspect only the two Basic Auth variables inside an exact production
+   block. Fails exit 1 when it cannot prove that invariant. A
    pytest regression in `tests/test_release_audit.py` pins the same
    check at CI time so this cannot silently regress between releases.
 2. **Manual checklist**: prints the Vercel / Modal / Supabase
    dashboard verification steps the operator still needs to run by
    hand (the script has no credentials for those services). The
    checklist is the single source of truth for "what has to be true
-   on production before tagging vX.Y.Z".
+   before a production cutover" and explicitly distinguishes a package
+   release from a web/deploy/ops-only merge that must not be tagged.
 
 ### Runtime safety net
 
-`web/src/middleware.ts::warnIfPreviewVarsLeakedIntoProduction()`
+`web/src/middleware.ts::warnIfPreviewBasicAuthLeakedIntoProduction()`
 runs once per Vercel cold start. If `VERCEL_ENV === "production"` and
-any of the three preview-only vars is set, it logs a loud
-`[release-audit]` `console.error` line to Vercel runtime logs naming
-the leaked var(s). The preview code paths themselves still no-op on
-production (every consumer gates on `VERCEL_ENV === "preview"` first),
-but the warning makes a dashboard misconfiguration visible instead of
-silent. Watch Vercel runtime logs for `[release-audit]` after the
-first production deploy of each release; if the line appears, go
-unset the leaked var in
+either preview Basic Auth variable is set, it logs a loud
+`[release-audit]` `console.error` line naming the leaked variable. The
+preview code paths themselves still no-op on production, but the
+warning makes a dashboard misconfiguration visible instead of silent.
+Watch Vercel runtime logs for `[release-audit]` after the first
+production deploy of each release; if the line names
+`PREVIEW_BASIC_AUTH_USERNAME` or `PREVIEW_BASIC_AUTH_PASSWORD`, unset
+that variable in
 **Vercel → Project → Settings → Environment Variables → Production**
 and redeploy.
+
+Do not treat `VERCEL_AUTOMATION_BYPASS_SECRET` as a leak. Vercel
+injects that system variable into every deployment by design; the
+repo-local guard verifies that coarse only uses it in preview behavior.
 
 ## Tier 1 — Isolated preview infra (~2 hours)
 
@@ -281,15 +287,13 @@ git pull
 # in the Modal dashboard or CLI.
 ```
 
-Why Modal **environment** instead of preview-named apps:
+Why a Modal **environment** instead of a preview-named app:
 
-- You keep the same app names (`coarse-review`, `coarse-mcp`) and the
-  same secret names.
+- You keep the same `coarse-review` app name and the same secret names.
 - Modal isolates deployments + secrets by environment, so preview and
   production stay separate without code-level app-name branching.
 - The web route validation keys off the app/function hostname suffix
-  (`--coarse-review-run-review.modal.run`,
-  `--coarse-mcp-run-extract.modal.run`), so Modal's environment prefix
+  (`--coarse-review-run-review.modal.run`), so Modal's environment prefix
   (`<workspace>-preview--...`) works without any preview-specific
   special case.
 - The repo automation maps cleanly onto it: `dev` -> preview
@@ -297,7 +301,7 @@ Why Modal **environment** instead of preview-named apps:
 
 ### Step 1.5 — Create the preview Modal + GitHub preview-deploy secrets
 
-The production Modal apps already use these secret names:
+The production Modal app already uses these secret names:
 
 - `coarse-supabase`
 - `coarse-webhook`
@@ -314,10 +318,10 @@ should use the **same names** with **preview values**.
 2. `coarse-webhook`
    - `MODAL_WEBHOOK_SECRET` → generate a fresh random string
      (`openssl rand -base64 32`), save it
-3. `coarse-resend` (optional — skip if you want preview submissions to
-   silently no-op emails, which is usually fine)
-   - `RESEND_API_KEY` → create a separate Resend key scoped to a
-     preview sending domain, or skip entirely
+3. `coarse-resend` (the named Modal secret must exist because the
+   worker mounts it; the API key inside it is optional)
+   - `RESEND_API_KEY` → create a separate key scoped to a preview
+     sending domain, or omit the key so preview email no-ops
    - `SITE_URL` → the preview website URL users should land on if a
      preview email link is clicked
 
@@ -345,11 +349,7 @@ should use the **same names** with **preview values**.
   environment-restricted Modal credentials, preview CI is still
   useful but is not a hard production-isolation boundary.
 
-Important: `coarse-mcp`'s `run_extract` function also uses
-`coarse-supabase` + `coarse-webhook`. Preview is not isolated unless
-both the review worker and the MCP extract worker see preview secrets.
-
-### Step 1.6 — Deploy both preview Modal apps
+### Step 1.6 — Deploy the preview Modal app
 
 If the preview workflow is configured correctly, you should almost never
 need to run these commands manually after initial setup; deploy-relevant
@@ -362,17 +362,13 @@ preview Modal deploy.
 # Deploy the OpenRouter review worker into the preview environment.
 COARSE_MODAL_DEPLOY_FORCE=1 modal deploy -e preview deploy/modal_worker.py
 
-# Deploy the MCP server + extract worker into the same preview environment.
-COARSE_MODAL_DEPLOY_FORCE=1 modal deploy -e preview deploy/mcp_server.py
-
-# Save these two URLs from the deploy output (or Modal dashboard):
+# Save this URL from the deploy output (or Modal dashboard):
 #   https://<workspace>-preview--coarse-review-run-review.modal.run
-#   https://<workspace>-preview--coarse-mcp-run-extract.modal.run
 ```
 
-Both `deploy/modal_worker.py` and `deploy/mcp_server.py` now refuse
-local non-`main` deploys unless `COARSE_MODAL_DEPLOY_FORCE=1` is set.
-Preview deploys are the intended non-`main` exception.
+`deploy/modal_worker.py` refuses local non-`main` deploys unless
+`COARSE_MODAL_DEPLOY_FORCE=1` is set. Preview deploys are the intended
+non-`main` exception.
 
 ### Step 1.7 — Scope Vercel env vars to Preview
 
@@ -390,10 +386,8 @@ preview branches. Use the preview values from steps 1.1–1.6:
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | preview Supabase anon key                            |
 | `SUPABASE_SERVICE_KEY`          | preview Supabase service key                         |
 | `MODAL_FUNCTION_URL`            | preview Modal function URL from step 1.6             |
-| `MODAL_EXTRACT_URL`             | preview MCP extract URL from step 1.6                |
 | `MODAL_WEBHOOK_SECRET`          | preview webhook secret from `coarse-webhook`         |
 | `NEXT_PUBLIC_SITE_URL`          | Optional. On Vercel preview deployments the app now prefers the actual request host, so leaving this unset is safest unless you have a stable preview alias such as `https://dev.coarse.ink`. |
-| `NEXT_PUBLIC_MCP_SERVER_URL`    | preview MCP URL (`https://<workspace>-preview--coarse-mcp-asgi.modal.run/mcp/`) |
 | `RESEND_API_KEY`                | *(leave unset in Preview — emails will no-op)*       |
 | `TURNSTILE_SECRET_KEY`          | *(leave unset in Preview — Turnstile fails open)*    |
 | `NEXT_PUBLIC_TURNSTILE_SITE_KEY`| *(leave unset in Preview — widget skipped)*          |
@@ -427,7 +421,7 @@ hostnames yet, remove `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and
 `TURNSTILE_SECRET_KEY` from the Vercel Preview environment so preview
 fails open while production stays protected.
 
-### Step 1.7b — Add a preview-only browser password gate
+### Step 1.7a — Add a preview-only browser password gate
 
 Vercel's native **Password Protection** is not part of the base Pro
 preview setup; it requires Enterprise or Pro with the Advanced
@@ -447,22 +441,21 @@ Behavior:
 - inactive on production
 - inactive in local development unless you explicitly mimic preview envs
 - applies to pages and same-origin API routes
-- **exempts** the token-based machine-to-machine handoff routes
-  (`/h/<token>`, `/api/mcp-finalize`, `/api/mcp-extract`,
-  `/api/mcp-handoff`) via the `HANDOFF_EXEMPT_PREFIXES` list in
+- **exempts** the token-based machine-to-machine and signed-view routes
+  (`/h/<token>`, `/api/mcp-finalize`, `/review/<id>`,
+  `/api/review/<id>`, and `/api/submit`) via the
+  `HANDOFF_EXEMPT_PREFIXES` list in
   `web/src/middleware.ts`. These endpoints are fetched by the CLI
-  / Codex-cloud sandbox / Modal worker without a browser session and
-  cannot send HTTP Basic Auth credentials, but they already enforce
-  token-based auth of their own (single-use handoff token, finalize
-  token, MCP handoff secret, Modal webhook secret), so the preview
-  gate would be a redundant layer on capabilities that are already
-  cryptographically bound per submission. Without the exemption the
+  or use Bearer/signed tokens that cannot share the HTTP Authorization
+  header with Basic Auth. They enforce token-based auth of their own
+  (single-use handoff/finalize tokens and signed review access), so the
+  preview gate would be redundant. Without the exemption the
   bring-your-own-subscription handoff flow cannot complete on a
   preview deploy — the CLI's `_fetch_handoff` call hits the Basic
   Auth challenge and the detached worker crashes before writing a
-  pidfile. Browser-called routes (`/`, `/status/*`, `/review/*`,
-  `/api/presign`, `/api/submit`, `/api/cli-handoff`, `/api/status`,
-  `/api/delete`, `/api/cancel`) stay behind the Basic Auth gate.
+  pidfile. Other browser-called routes (`/`, `/status/*`,
+  `/api/presign`, `/api/cli-handoff`, `/api/status`, `/api/delete`,
+  `/api/cancel`) stay behind the Basic Auth gate.
 
 This gives collaborators a native browser username/password prompt
 after they reach the preview deployment itself.
@@ -476,7 +469,7 @@ need one of:
 
 Then the app-level preview password prompt is the second gate.
 
-### Step 1.7a — Store local admin secrets in `.env`
+### Step 1.7b — Store local admin secrets in `.env`
 
 The repo already gitignores the root `.env` file. Use that for local
 operator-only credentials:
@@ -495,7 +488,6 @@ PREVIEW_SUPABASE_URL=https://<preview-ref>.supabase.co
 PREVIEW_SUPABASE_ANON_KEY=...
 PREVIEW_SUPABASE_SERVICE_KEY=...
 PREVIEW_MODAL_FUNCTION_URL=https://<workspace>-preview--coarse-review-run-review.modal.run
-PREVIEW_MODAL_EXTRACT_URL=https://<workspace>-preview--coarse-mcp-run-extract.modal.run
 PREVIEW_MODAL_WEBHOOK_SECRET=...
 ```
 
@@ -505,7 +497,7 @@ This is enough for practical programmatic control:
   verify migrations directly against production or preview.
 - `PREVIEW_SUPABASE_*` lets you mirror the Vercel Preview environment
   locally when reproducing web issues.
-- the preview Modal URLs + webhook secret let you exercise the preview
+- the preview Modal URL + webhook secret let you exercise the preview
   worker paths outside Vercel if needed.
 
 Supabase Management API tokens are optional. They are useful only if
@@ -513,19 +505,16 @@ you want to create/list projects programmatically. They are **not**
 required for the main operational tasks in this repo, because DB URLs
 already cover migrations and schema inspection.
 
-### Step 1.8 — Verify both web routes point only at Modal preview endpoints
+### Step 1.8 — Verify the web route points only at the Modal preview endpoint
 
-There are two web→Modal paths that must be isolated:
+There is one web→Modal path that must be isolated:
 
 1. `/api/submit` → `MODAL_FUNCTION_URL` → `coarse-review/run-review`
-2. `/api/mcp-extract` → `MODAL_EXTRACT_URL` → `coarse-mcp/run-extract`
 
-The repo now validates both URLs against their expected Modal hostname
-suffixes. The check is intentionally compatible with Modal
+The repo validates the URL against its expected Modal hostname suffix.
+The check is intentionally compatible with Modal
 environments, so preview URLs like
 `https://<workspace>-preview--coarse-review-run-review.modal.run`
-and
-`https://<workspace>-preview--coarse-mcp-run-extract.modal.run`
 pass without needing preview-specific app names.
 
 Before you smoke-test preview, confirm the deployed `dev` branch
@@ -545,9 +534,10 @@ browser. It should ask for Vercel login (from Tier 0). After login:
 5. Click **Submit** once and confirm the preview `coarse-review`
    worker fires. The production environment should show zero new
    invocations.
-6. Click **Review with my subscription** once and confirm the preview
-   `coarse-mcp` extract worker fires. The production environment should
-   show zero new invocations.
+6. Run **Review with my subscription** once and confirm the generated
+   handoff and final review URLs remain on the preview hostname and the
+   finished row lands in preview Supabase. This local flow should not
+   invoke any Modal app.
 
 If any of the above lights up production infra, stop and
 re-check the env-var scoping in step 1.7. This is the scenario
@@ -564,7 +554,7 @@ big changes before they touch production:
      commit
    - `.github/workflows/modal-preview-deploy.yml` to finish if the
      change touched `src/coarse/**`, `deploy/modal_worker.py`,
-     `deploy/mcp_server.py`, `pyproject.toml`, or the preview workflow
+     `pyproject.toml`, or the preview workflow
      itself
 3. Open the Vercel preview URL for that `dev` commit from the GitHub
    commit / PR checks.
@@ -577,11 +567,11 @@ big changes before they touch production:
    - upload succeeds
    - status page loads
    - no obvious frontend/runtime errors
-   - MCP handoff modal / buttons still work
+   - subscription-handoff modal / buttons still work
 7. Confirm the backend isolation is correct:
    - rows land in preview Supabase, not production
    - `coarse-review` invocations land in preview Modal, not production
-   - `coarse-mcp` extraction invocations land in preview Modal, not production
+   - the subscription flow writes only to preview Supabase and does not invoke Modal
 
 Treat the preview website as the pre-prod signoff surface. If a change
 touches schema, web API routes, Modal workers, auth, or env wiring, it
@@ -592,9 +582,9 @@ GitHub/Vercel check mapping:
 - the GitHub status named `Vercel` is the frontend preview deployment
   for the commit. If it is green, Vercel did redeploy.
 - the GitHub Actions workflow `deploy-modal-preview` is separate and
-  only refreshes the preview Modal backends.
+  only refreshes the preview Modal app.
 - if `Vercel` is green but `deploy-modal-preview` is red, the website
-  preview may be fresh while the preview Modal workers are stale.
+  preview may be fresh while the preview Modal worker is stale.
 
 Preview-site usage rules:
 
@@ -640,21 +630,13 @@ gh workflow run modal-preview-deploy.yml --ref dev
 The workflow only affects preview Modal. It does **not** control the
 Vercel frontend preview deployment.
 
-### Step 1.10 — Document + commit
+### Step 1.10 — Record configuration changes
 
-Add a short section to `deploy/DEPLOY.md` pointing at this file and
-explaining the preview flow. Update `CHANGELOG.md` under
-`## Unreleased` → `### Added`:
-
-> **Preview deployment environment** — `dev`-branch pushes now
-> auto-create a Vercel preview URL, and deploy-relevant `dev` pushes now
-> refresh the preview Modal apps backed by an isolated Supabase project
-> (`coarse-preview`) plus a preview Modal environment containing
-> `coarse-review` + `coarse-mcp`. Migrations can be validated on preview
-> before rolling to production. See `deploy/PREVIEW_ENVIRONMENTS.md`
-> for the setup contract.
-
-Commit as `chore(deploy): set up Tier 0 + Tier 1 preview environment`.
+If you rebuild or rotate any external resource, record the date and
+scope in the operator log or release notes. Dashboard-only rotations do
+not require a repository commit, but any topology or variable-name change
+must update this runbook, `deploy/DEPLOY.md`, and the release audit in the
+same PR.
 
 ## Success criteria
 
@@ -666,8 +648,8 @@ You're done with Tier 0 + Tier 1 when all of the following are true:
   Supabase project, not production.
 - [ ] The OpenRouter submit flow on the preview URL fires preview
   `coarse-review`, not production.
-- [ ] The subscription/MCP flow on the preview URL fires preview
-  `coarse-mcp` extraction, not production.
+- [ ] The subscription-handoff flow stays on the preview hostname,
+  writes to preview Supabase, and does not invoke Modal.
 - [ ] A submission on the preview URL does NOT send emails (Resend key
   unset) and does NOT enforce Turnstile (keys unset) — both fail open.
 - [ ] `coarse.ink` production traffic is still routed to production
@@ -685,17 +667,16 @@ If anything breaks production during Tier 1 setup:
 2. **Modal deployment hit the wrong environment** — production runs in
    Modal's default environment. If you accidentally pushed dev code
    there, the fix is to `git checkout main && modal deploy
-   deploy/modal_worker.py` from a clean checkout. If you also touched
-   `deploy/mcp_server.py`, redeploy that too. The
+   deploy/modal_worker.py` from a clean checkout. The
    `.github/workflows/modal-deploy.yml` auto-deploy from main will also
-   recover both apps on the next deploy-relevant push to main.
+   recover the app on the next deploy-relevant push to main.
 3. **Schema migration applied to wrong DB** — the migrations in
    `deploy/*.sql` are all idempotent additive changes. No rollback
    path is usually needed; they don't drop tables or columns. If
    you need to hard-revert, do it manually in the Supabase SQL
    editor with `drop table if exists ...`.
 4. **Preview env vars point at the wrong Modal URL** — correct the
-   Preview-scoped `MODAL_FUNCTION_URL` / `MODAL_EXTRACT_URL` values in
+   Preview-scoped `MODAL_FUNCTION_URL` value in
    Vercel, then redeploy the preview build.
 
 In all cases, the preview Supabase project and preview Modal
@@ -711,30 +692,18 @@ without touching `coarse.ink`.
 - **Tier 3** (persistent Supabase branches, `staging.coarse.ink`,
   feature flags, canary routing). Not needed at current scale. Revisit
   when coarse has multiple contributors or paying users.
-- **Automated migration runner** for preview. For now, schema changes
-  to preview Supabase are applied manually via the SQL editor. A
-  future improvement is a GitHub Action that runs `deploy/*.sql`
-  files against the preview project on every deploy-relevant push to
-  `dev`.
 - **Per-PR ephemeral Supabase projects.** Supabase Branching (Pro plan)
   does this automatically. Not doing it manually — Tier 1's single
   long-lived preview project is good enough.
 
 ## Operator notes
 
-- **Repo-side pieces are already in place.** What remains is the
-  dashboard/secret/environment setup described above.
-- **The user's `.env.local` currently points at production Supabase.**
-  After Tier 1 you might want to also swap local dev to preview by
-  editing `web/.env.local` — but that's optional and outside this
-  plan's scope.
-- **Release blockers from the 2026-04-13 session are unrelated** —
-  they live in `CHANGELOG.md` under `## Unreleased` as a warning block
-  (`DEFAULT_MCP_UVX_FROM` still pinned to a git ref, needs to flip
-  to `coarse-ink[mcp]==1.3.0` on the next release). Tier 0 + Tier 1
-  does not touch those; the two are independent.
-- **Every `deploy/modal_worker.py` deploy from a non-main branch
-  and `deploy/mcp_server.py` deploy from a non-main branch requires
+- **Repo-side automation and the current dashboard stack are in place.**
+  The setup steps above are also the recovery checklist for a rebuild.
+- **Never point local development at production Supabase for schema or
+  worker validation when preview exists.** Mirror the preview Vercel
+  variables into `web/.env.local` when a local reproduction is needed.
+- **Every `deploy/modal_worker.py` deploy from a non-main branch requires
   `COARSE_MODAL_DEPLOY_FORCE=1`** to bypass `_enforce_deploy_branch`.
   You will be deploying dev-branch code to the preview Modal
   environment, so this env var is needed on every local preview deploy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Changelog = "https://github.com/Davidvandijcke/coarse/blob/main/CHANGELOG.md"
 docling = ["docling>=2.86.0", "transformers>=5.4,<6"]
 formats = ["mammoth>=1.6", "markdownify>=0.12", "ebooklib>=0.18"]
 all = ["coarse-ink[docling]", "coarse-ink[formats]"]
-dev = ["pytest>=8.0", "ruff>=0.4"]
+dev = ["pytest>=8.0", "pyyaml>=6.0", "ruff>=0.4"]
 
 [project.scripts]
 coarse = "coarse.cli:app"

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -13,13 +13,12 @@ Usage:
 
 What this script verifies:
 
-1. **Repo-local**: every preview-specific config path is guarded by
-   an explicit ``VERCEL_ENV`` / ``NODE_ENV`` check. Greps the web
-   source tree for ``PREVIEW_BASIC_AUTH_PASSWORD`` and
-   ``VERCEL_AUTOMATION_BYPASS_SECRET`` and confirms every hit is
-   accompanied by a ``VERCEL_ENV === "preview"`` guard within a
-   small window (so no code path activates these on production by
-   accident).
+1. **Repo-local**: every protected environment-variable read is
+   lexically contained by an explicit ``VERCEL_ENV`` block. The check
+   recognizes direct dot-property ``process.env`` access and rejects
+   bracket/computed access or aliases it cannot prove safe. This keeps the
+   system-managed bypass secret from activating preview behavior on
+   production by accident.
 
 2. **Manual checklist**: prints the Vercel / Modal / Supabase
    verification steps the operator still needs to run by hand
@@ -27,8 +26,8 @@ What this script verifies:
 
 Exit codes:
     0 — repo-local checks passed, manual checklist printed
-    1 — repo-local guard violation (preview-only var referenced
-        without a ``VERCEL_ENV === "preview"`` check nearby)
+    1 — repo-local guard violation (preview-gated var referenced
+        outside an explicit ``VERCEL_ENV === "preview"`` block)
 """
 
 from __future__ import annotations
@@ -40,50 +39,268 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WEB_SRC = REPO_ROOT / "web" / "src"
 
-PREVIEW_ONLY_VARS = (
+PREVIEW_GATED_VARS = (
     "PREVIEW_BASIC_AUTH_PASSWORD",
     "PREVIEW_BASIC_AUTH_USERNAME",
     "VERCEL_AUTOMATION_BYPASS_SECRET",
 )
 
-# Lines that reference a preview-only var are allowed if any of these
-# guard patterns appears within ``GUARD_WINDOW`` lines around the hit.
-GUARD_PATTERNS = (
-    re.compile(r'VERCEL_ENV\s*[!=]==?\s*["\']preview["\']'),
-    re.compile(r'VERCEL_ENV\s*[!=]==?\s*["\']production["\']'),
-    # A release-audit warning function counts as a guard — its whole
-    # job is to notice these vars leaking into production.
-    re.compile(r"warnIfPreviewVarsLeakedIntoProduction"),
-    # Documentation files are allowed to reference the vars freely.
+# The system bypass secret may only be consumed inside an exact preview
+# equality block. Preview Basic Auth vars additionally appear in the
+# production-only leak detector, so those two vars may also sit inside an
+# exact production equality block. We deliberately reject aliases and
+# early-return/proximity patterns: a conservative false positive is safer
+# than accepting a comment, a closed branch, or an unrelated nearby check.
+ENV_GUARD_PATTERN = re.compile(
+    r"if\s*\(\s*process\.env\.VERCEL_ENV\s*===\s*"
+    r"(?P<quote>[\"'])(?P<environment>preview|production)(?P=quote)\s*\)\s*\{",
+    re.MULTILINE,
 )
-GUARD_WINDOW = 10
+PROCESS_ENV_BASE = r"process\s*(?:(?:\?\s*)?\.\s*env|\[\s*[\"']env[\"']\s*\])(?![\w$])"
+DOT_READ_PATTERN = re.compile(
+    PROCESS_ENV_BASE
+    + r"\s*(?:\?\s*)?\.\s*(?P<variable>"
+    + "|".join(re.escape(var) for var in PREVIEW_GATED_VARS)
+    + r")\b"
+)
+BRACKET_READ_PATTERN = re.compile(
+    PROCESS_ENV_BASE
+    + r"\s*\[\s*(?P<quote>[\"'])(?P<variable>"
+    + "|".join(re.escape(var) for var in PREVIEW_GATED_VARS)
+    + r")(?P=quote)\s*\]"
+)
+# Bracket access is forbidden outright. Even a literal-looking key can be
+# turned into an expression (``"PREFIX_" + suffix``), and process["env"]
+# creates another alias surface. The web tree currently needs neither form.
+BRACKET_ENV_KEY_PATTERN = re.compile(r"process\s*(?:\?\s*)?\.\s*env(?![\w$])\s*\[")
+BRACKET_ENV_OBJECT_PATTERN = re.compile(r"process\s*\[\s*[\"']env[\"']\s*\]")
+# Only a direct static property may follow the global process.env object.
+# Passing, spreading, parenthesizing, destructuring, or assigning the whole
+# object creates an alias the text audit cannot follow.
+BARE_PROCESS_ENV_PATTERN = re.compile(PROCESS_ENV_BASE + r"(?!\s*(?:\?\s*)?\.\s*[A-Za-z_$])")
+# Any import/require of the process module creates an alias surface that this
+# lightweight source audit cannot safely follow (named, default, namespace,
+# dynamic, and CommonJS imports all expose ``env``). The web tree does not need
+# this module, so fail closed instead of trying to enumerate local alias names.
+PROCESS_MODULE_REFERENCE_PATTERN = re.compile(
+    r"(?:\bfrom\s*|\bimport\s*\(|\brequire\s*\()"
+    r"[\"'](?:node:)?process[\"']",
+    re.MULTILINE,
+)
+PROCESS_OBJECT_ENV_ALIAS_PATTERN = re.compile(
+    r"\{[^}]*\benv\b[^}]*\}\s*=\s*process\b",
+    re.MULTILINE,
+)
+PROTECTED_KEY_BRACKET_PATTERN = re.compile(
+    r"\[\s*[\"'](?P<variable>" + "|".join(re.escape(var) for var in PREVIEW_GATED_VARS) + r")[\"']"
+)
+ENV_ALIAS_PATTERN = re.compile(
+    r"\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*" + PROCESS_ENV_BASE + r"(?!\s*[?.\[])"
+)
+DESTRUCTURE_PATTERN = re.compile(
+    r"\{(?P<body>[^{}]{0,1000})\}\s*=\s*" + PROCESS_ENV_BASE,
+    re.MULTILINE,
+)
 
 
 def _is_source_file(path: Path) -> bool:
     return path.suffix in {".ts", ".tsx", ".js", ".mjs", ".cjs"}
 
 
-def _check_guard(lines: list[str], hit_idx: int) -> bool:
-    lo = max(0, hit_idx - GUARD_WINDOW)
-    hi = min(len(lines), hit_idx + GUARD_WINDOW + 1)
-    window = "\n".join(lines[lo:hi])
-    return any(pat.search(window) for pat in GUARD_PATTERNS)
+def _lexical_masks(source: str) -> tuple[list[bool], list[bool]]:
+    """Return masks for non-comment text and structural JavaScript code.
+
+    The first mask excludes comments but intentionally retains string/template
+    contents. That makes the detector conservative: a string containing a
+    literal ``process.env.SECRET`` is reported instead of silently masking a
+    template interpolation. The second mask also excludes quoted contents and
+    is used only for brace matching, so braces in messages cannot forge a
+    containing guard block.
+    """
+
+    non_comment = [True] * len(source)
+    structural = [False] * len(source)
+    state = "code"
+    quote = ""
+    regex_character_class = False
+    index = 0
+    while index < len(source):
+        char = source[index]
+        next_char = source[index + 1] if index + 1 < len(source) else ""
+        if state == "code":
+            if char == "/" and next_char == "/":
+                non_comment[index] = non_comment[index + 1] = False
+                state = "line_comment"
+                index += 2
+                continue
+            if char == "/" and next_char == "*":
+                non_comment[index] = non_comment[index + 1] = False
+                state = "block_comment"
+                index += 2
+                continue
+            if char == "/":
+                previous = index - 1
+                while previous >= 0 and source[previous].isspace():
+                    previous -= 1
+                # JavaScript regex literals are context-sensitive. All guard
+                # spoofing shapes begin an expression (most commonly after
+                # ``=``); treating those as non-structural prevents a regex's
+                # text and braces from forging a control-flow block.
+                if previous < 0 or source[previous] in "=(:,![{;?":
+                    state = "regex"
+                    regex_character_class = False
+                    index += 1
+                    continue
+            if char in {"'", '"', "`"}:
+                quote = char
+                state = "string"
+                index += 1
+                continue
+            structural[index] = True
+            index += 1
+            continue
+        if state == "line_comment":
+            non_comment[index] = False
+            if char == "\n":
+                state = "code"
+                structural[index] = True
+            index += 1
+            continue
+        if state == "block_comment":
+            non_comment[index] = False
+            if char == "*" and next_char == "/":
+                non_comment[index + 1] = False
+                index += 2
+                state = "code"
+                continue
+            index += 1
+            continue
+        if state == "regex":
+            if char == "\\":
+                index += 2
+                continue
+            if char == "[":
+                regex_character_class = True
+            elif char == "]":
+                regex_character_class = False
+            elif char == "/" and not regex_character_class:
+                state = "code"
+            index += 1
+            continue
+        # Quoted string or template literal. Escaped delimiters do not end it.
+        if char == "\\":
+            index += 2
+            continue
+        if char == quote:
+            state = "code"
+        index += 1
+    return non_comment, structural
+
+
+def _matching_brace(source: str, structural: list[bool], opening: int) -> int | None:
+    depth = 0
+    for index in range(opening, len(source)):
+        if not structural[index]:
+            continue
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _guard_ranges(source: str, structural: list[bool]) -> list[tuple[int, int, str]]:
+    ranges: list[tuple[int, int, str]] = []
+    for match in ENV_GUARD_PATTERN.finditer(source):
+        previous = match.start() - 1
+        while previous >= 0 and source[previous].isspace():
+            previous -= 1
+        # A real statement-level ``if`` starts the file or follows a block /
+        # statement boundary. This rejects guard-shaped text in regex literals
+        # even in contexts where the lightweight lexer cannot infer that a
+        # slash after ``yield``, ``return``, or a condition begins a regex.
+        if previous >= 0 and source[previous] not in "{;}":
+            continue
+        opening = source.find("{", match.start(), match.end())
+        if opening < 0 or not structural[match.start()] or not structural[opening]:
+            continue
+        closing = _matching_brace(source, structural, opening)
+        if closing is not None:
+            ranges.append((opening, closing, match.group("environment")))
+    return ranges
+
+
+def _named_function_range(
+    source: str, structural: list[bool], function_name: str
+) -> tuple[int, int] | None:
+    pattern = re.compile(
+        rf"\bfunction\s+{re.escape(function_name)}\s*\([^)]*\)\s*"
+        r"(?:\:\s*[^\{]+)?\{",
+        re.MULTILINE,
+    )
+    match = pattern.search(source)
+    if not match or not structural[match.start()]:
+        return None
+    previous = match.start() - 1
+    while previous >= 0 and source[previous].isspace():
+        previous -= 1
+    if previous >= 0 and source[previous] not in "{;}":
+        return None
+    opening = source.find("{", match.start(), match.end())
+    if opening < 0 or not structural[opening]:
+        return None
+    closing = _matching_brace(source, structural, opening)
+    return (opening, closing) if closing is not None else None
+
+
+def _is_guarded(
+    position: int,
+    variable: str,
+    ranges: list[tuple[int, int, str]],
+    *,
+    allow_production_leak_check: bool = False,
+) -> bool:
+    allowed_environments = {"preview"}
+    if variable.startswith("PREVIEW_BASIC_AUTH_") and allow_production_leak_check:
+        allowed_environments.add("production")
+    return any(
+        opening < position < closing and environment in allowed_environments
+        for opening, closing, environment in ranges
+    )
+
+
+def _protected_reads(source: str, non_comment: list[bool]) -> list[tuple[int, str]]:
+    reads: set[tuple[int, str]] = set()
+    for pattern in (DOT_READ_PATTERN, BRACKET_READ_PATTERN):
+        for match in pattern.finditer(source):
+            if non_comment[match.start()]:
+                reads.add((match.start("variable"), match.group("variable")))
+    for match in DESTRUCTURE_PATTERN.finditer(source):
+        if not non_comment[match.start()]:
+            continue
+        body = match.group("body")
+        body_start = match.start("body")
+        for variable in PREVIEW_GATED_VARS:
+            variable_match = re.search(rf"\b{re.escape(variable)}\b", body)
+            if variable_match:
+                reads.add((body_start + variable_match.start(), variable))
+    return sorted(reads)
 
 
 def audit_repo_guards() -> list[str]:
     """Return a list of unguarded preview-var references, or empty list.
 
-    Only real ``process.env.<VAR>`` reads count as references. String
-    literals that happen to mention the variable name (warning text,
-    error messages, doc comments) are not references and are skipped —
-    otherwise every line that explains a guard would itself be flagged.
+    Direct dot-property reads count as references. Plain string literals that
+    only mention a variable name are ignored because they do not contain
+    ``process.env``; comments are masked. Whole-object, bracket/computed, and
+    alias access is rejected because the audit cannot prove which key it
+    consumes.
     """
     violations: list[str] = []
     if not WEB_SRC.exists():
         return [f"web/src not found at {WEB_SRC}"]
-    real_read_patterns = [
-        (var, re.compile(rf"process\.env\.{re.escape(var)}\b")) for var in PREVIEW_ONLY_VARS
-    ]
     for path in sorted(WEB_SRC.rglob("*")):
         if not path.is_file() or not _is_source_file(path):
             continue
@@ -91,21 +308,72 @@ def audit_repo_guards() -> list[str]:
             text = path.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
             continue
-        lines = text.splitlines()
-        for idx, line in enumerate(lines):
-            stripped = line.strip()
-            if stripped.startswith("//") or stripped.startswith("*"):
-                continue
-            for var, pat in real_read_patterns:
-                if not pat.search(line):
+        non_comment, structural = _lexical_masks(text)
+        ranges = _guard_ranges(text, structural)
+        rel = path.relative_to(REPO_ROOT)
+        leak_check_range = None
+        if rel == Path("web/src/middleware.ts"):
+            leak_check_range = _named_function_range(
+                text, structural, "warnIfPreviewBasicAuthLeakedIntoProduction"
+            )
+        for pattern in (BRACKET_ENV_KEY_PATTERN, BRACKET_ENV_OBJECT_PATTERN):
+            for match in pattern.finditer(text):
+                if not non_comment[match.start()]:
                     continue
-                if _check_guard(lines, idx):
-                    continue
-                rel = path.relative_to(REPO_ROOT)
+                line_number = text.count("\n", 0, match.start()) + 1
                 violations.append(
-                    f"{rel}:{idx + 1}: process.env.{var} read without a "
-                    f"VERCEL_ENV guard within {GUARD_WINDOW} lines"
+                    f"{rel}:{line_number}: bracket/computed process.env access is forbidden"
                 )
+        for match in BARE_PROCESS_ENV_PATTERN.finditer(text):
+            if non_comment[match.start()]:
+                line_number = text.count("\n", 0, match.start()) + 1
+                violations.append(
+                    f"{rel}:{line_number}: whole process.env object access is forbidden"
+                )
+        for pattern in (PROCESS_MODULE_REFERENCE_PATTERN, PROCESS_OBJECT_ENV_ALIAS_PATTERN):
+            for match in pattern.finditer(text):
+                if non_comment[match.start()]:
+                    line_number = text.count("\n", 0, match.start()) + 1
+                    violations.append(
+                        f"{rel}:{line_number}: process environment alias is forbidden"
+                    )
+        for match in PROTECTED_KEY_BRACKET_PATTERN.finditer(text):
+            if non_comment[match.start()]:
+                line_number = text.count("\n", 0, match.start()) + 1
+                violations.append(
+                    f"{rel}:{line_number}: indirect bracket key "
+                    f"{match.group('variable')} is forbidden"
+                )
+        for match in ENV_ALIAS_PATTERN.finditer(text):
+            if non_comment[match.start()]:
+                line_number = text.count("\n", 0, match.start()) + 1
+                violations.append(f"{rel}:{line_number}: process.env alias cannot be audited")
+        protected_reads = _protected_reads(text, non_comment)
+        protected_read_positions = {position for position, _ in protected_reads}
+        for variable in PREVIEW_GATED_VARS:
+            for match in re.finditer(rf"\b{re.escape(variable)}\b", text):
+                position = match.start()
+                if structural[position] and position not in protected_read_positions:
+                    line_number = text.count("\n", 0, position) + 1
+                    violations.append(
+                        f"{rel}:{line_number}: indirect {variable} reference cannot be audited"
+                    )
+        for position, variable in protected_reads:
+            allow_production_leak_check = bool(
+                leak_check_range and leak_check_range[0] < position < leak_check_range[1]
+            )
+            if _is_guarded(
+                position,
+                variable,
+                ranges,
+                allow_production_leak_check=allow_production_leak_check,
+            ):
+                continue
+            line_number = text.count("\n", 0, position) + 1
+            violations.append(
+                f"{rel}:{line_number}: process.env.{variable} read outside an "
+                "explicit VERCEL_ENV equality block"
+            )
     return violations
 
 
@@ -114,16 +382,16 @@ CHECKLIST = """
   coarse — dev -> main release audit checklist
 =====================================================================
 
-  Run this script before tagging vX.Y.Z. It verifies the repo side is
-  clean automatically and then prints the manual steps you still need
-  to run against Vercel, Modal, and Supabase.
+  Run this script before a production cutover. It verifies the repo side
+  automatically and then prints the manual steps you still need to run
+  against Vercel, Modal, and Supabase. Tag only when package code changed.
 
-  The preview gate, bypass secret, preview Supabase URL, and preview
-  Modal environment are all *environment-scoped* — production code
-  paths check `VERCEL_ENV === "preview"` before activating anything
-  preview-specific, so in theory a `dev -> main` merge needs no code
-  change. In practice, the dashboard side can drift. Verify all of
-  the below before you tag.
+  The preview gate, preview Supabase URL, and preview Modal environment
+  are environment-scoped. Vercel's automation bypass secret is a
+  platform-managed system variable present in every deployment when
+  that feature is enabled; production safety comes from application
+  reads being gated by `VERCEL_ENV === "preview"`. Verify all of the
+  below before you tag.
 
 --- Vercel (production environment) -------------------------------
 
@@ -147,14 +415,23 @@ CHECKLIST = """
       Production MUST NOT have:
          - PREVIEW_BASIC_AUTH_USERNAME
          - PREVIEW_BASIC_AUTH_PASSWORD
-         - VERCEL_AUTOMATION_BYPASS_SECRET    (Vercel writes this
-           automatically into Preview when Protection Bypass for
-           Automation is enabled; it should never appear on Production)
 
-      If any of these are set on Production, the middleware logs a
-      loud [release-audit] console.error on every cold start. Watch
-      Vercel runtime logs after the first production deploy of the
-      release — if that line appears, go unset the leaked var.
+      If either is set on Production, the middleware logs a loud
+      [release-audit] console.error once per cold start. Watch Vercel
+      runtime logs after the first production deploy and unset only
+      the listed Basic Auth variables if that warning appears.
+
+      `VERCEL_AUTOMATION_BYPASS_SECRET` is different: Vercel injects
+      it as a system environment variable into all deployments when
+      Protection Bypass for Automation is configured. Its presence at
+      production runtime is expected and is NOT a leak. Do not disable
+      the preview bypass to clear it; the repo-local guard above proves
+      that application behavior remains preview-only.
+
+      Sensitive Vercel variables are intentionally non-readable and
+      may pull as blank. Validate their configured presence and runtime
+      behavior; do not delete/recreate a secret solely because
+      `vercel env pull` cannot return its value.
 
   [ ] Vercel -> Project -> Settings -> Deployment Protection ->
       Production Deployment: must be "Public" (unprotected). Only
@@ -184,11 +461,13 @@ CHECKLIST = """
 
 --- Final ---------------------------------------------------------
 
-  [ ] Bump version in pyproject.toml and src/coarse/__init__.py.
-  [ ] Move CHANGELOG.md `## Unreleased` -> `## vX.Y.Z — YYYY-MM-DD`.
+  [ ] Run `git diff vX.Y.Z..main -- src/coarse/` using the latest release tag.
+      - If non-empty: this is a package release. Bump pyproject.toml and
+        src/coarse/__init__.py, then move Unreleased to `## vX.Y.Z — DATE`.
+      - If empty: this is web/deploy/ops-only. Do NOT bump, tag, or publish.
   [ ] Merge the release PR to main.
-  [ ] `git checkout main && git pull && git tag vX.Y.Z && git push origin vX.Y.Z`.
-  [ ] Watch the `Release` workflow in GitHub Actions for the tag push.
+  [ ] Package release only: tag/push vX.Y.Z from main and watch the
+      `Release` workflow. Web/deploy/ops-only cutovers stop after main deploys.
   [ ] After deploy, watch Vercel runtime logs for any
       `[release-audit]` warnings — if you see one, fix the dashboard
       env var and redeploy.
@@ -203,18 +482,17 @@ def main() -> int:
     print("Running repo-local guard check...", flush=True)
     violations = audit_repo_guards()
     if violations:
-        print("\nFAIL: preview-only variables referenced without a VERCEL_ENV guard:")
+        print("\nFAIL: preview-gated variables referenced without a valid VERCEL_ENV block:")
         for v in violations:
             print(f"  - {v}")
         print(
-            "\nEvery reference to PREVIEW_BASIC_AUTH_PASSWORD / "
-            "VERCEL_AUTOMATION_BYPASS_SECRET must be inside a "
-            '`VERCEL_ENV === "preview"` branch so production code '
-            "paths cannot activate them. Fix the violations above "
-            "and re-run this script.",
+            "\nEvery VERCEL_AUTOMATION_BYPASS_SECRET read must be inside "
+            'a `VERCEL_ENV === "preview"` branch. Preview Basic Auth reads '
+            "must be preview-gated or belong to the production-only leak "
+            "detector. Fix the violations above and re-run this script.",
         )
         return 1
-    print("OK: all references to preview-only env vars are guarded.\n")
+    print("OK: all references to preview-gated env vars are guarded.\n")
     print(CHECKLIST)
     return 0
 

--- a/tests/test_release_audit.py
+++ b/tests/test_release_audit.py
@@ -4,10 +4,11 @@
 Its repo-local check is cheap and deterministic, so we also run it
 inside pytest on every commit to catch the case where someone adds a
 new ``process.env.PREVIEW_BASIC_AUTH_PASSWORD`` or
-``process.env.VERCEL_AUTOMATION_BYPASS_SECRET`` read without gating it
-behind a ``VERCEL_ENV === "preview"`` check. Without this test, such
-a regression would silently ship and only be caught during the next
-manual release audit.
+``process.env.VERCEL_AUTOMATION_BYPASS_SECRET`` read without an
+environment guard. Vercel deliberately injects the latter system
+variable into every deployment; the guard ensures only preview code
+can consume it. Without this test, a regression would silently ship
+and only be caught during the next manual release audit.
 """
 
 from __future__ import annotations
@@ -28,17 +29,35 @@ def _load_module():
     return module
 
 
+def _audit_snippet(source: str) -> list[str]:
+    """Run the repository audit against one synthetic TypeScript source."""
+    module = _load_module()
+    original_repo_root = module.REPO_ROOT
+    original_web_src = module.WEB_SRC
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            fake_repo = Path(td)
+            fake_web = fake_repo / "web" / "src" / "app"
+            fake_web.mkdir(parents=True)
+            (fake_web / "sample.ts").write_text(source, encoding="utf-8")
+            module.REPO_ROOT = fake_repo
+            module.WEB_SRC = fake_repo / "web" / "src"
+            return module.audit_repo_guards()
+    finally:
+        module.REPO_ROOT = original_repo_root
+        module.WEB_SRC = original_web_src
+
+
 def test_release_audit_clean_on_dev() -> None:
-    """Every preview-only env var read in web/src must be VERCEL_ENV-guarded."""
+    """Every preview-gated env var read in web/src must be VERCEL_ENV-guarded."""
     module = _load_module()
     violations = module.audit_repo_guards()
     assert not violations, (
-        "release_audit found unguarded reads of preview-only env vars. "
+        "release_audit found unguarded reads of preview-gated env vars. "
         "Every `process.env.PREVIEW_BASIC_AUTH_PASSWORD`, "
         "`process.env.PREVIEW_BASIC_AUTH_USERNAME`, or "
         "`process.env.VERCEL_AUTOMATION_BYPASS_SECRET` in web/src must "
-        'be within 10 lines of a `VERCEL_ENV === "preview"` (or the '
-        "`warnIfPreviewVarsLeakedIntoProduction` helper) so production "
+        "be inside the appropriate explicit `VERCEL_ENV` equality block so production "
         "code paths cannot activate preview-only behavior.\n\nViolations:\n  - "
         + "\n  - ".join(violations)
     )
@@ -119,3 +138,231 @@ def test_release_audit_accepts_guarded_read() -> None:
         module.REPO_ROOT = original_repo_root
         module.WEB_SRC = original_web_src
     assert not violations, "guarded read must not be flagged: " + "\n".join(violations)
+
+
+def test_release_audit_detects_unguarded_system_bypass_read() -> None:
+    """The system bypass may exist in prod, but application use must stay preview-only."""
+    module = _load_module()
+    original_repo_root = module.REPO_ROOT
+    original_web_src = module.WEB_SRC
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            fake_repo = Path(td)
+            fake_web = fake_repo / "web" / "src" / "app"
+            fake_web.mkdir(parents=True)
+            (fake_web / "bad.ts").write_text(
+                "export const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;\n",
+                encoding="utf-8",
+            )
+            module.REPO_ROOT = fake_repo
+            module.WEB_SRC = fake_repo / "web" / "src"
+            violations = module.audit_repo_guards()
+    finally:
+        module.REPO_ROOT = original_repo_root
+        module.WEB_SRC = original_web_src
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in v for v in violations)
+
+
+def test_release_audit_rejects_production_guard_for_system_bypass() -> None:
+    """A production branch is valid for leak reporting, never bypass consumption."""
+    module = _load_module()
+    original_repo_root = module.REPO_ROOT
+    original_web_src = module.WEB_SRC
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            fake_repo = Path(td)
+            fake_web = fake_repo / "web" / "src" / "app"
+            fake_web.mkdir(parents=True)
+            (fake_web / "bad.ts").write_text(
+                'if (process.env.VERCEL_ENV === "production") {\n'
+                "  const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+                "  void secret;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            module.REPO_ROOT = fake_repo
+            module.WEB_SRC = fake_repo / "web" / "src"
+            violations = module.audit_repo_guards()
+    finally:
+        module.REPO_ROOT = original_repo_root
+        module.WEB_SRC = original_web_src
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in v for v in violations)
+
+
+def test_release_audit_rejects_comment_only_guard() -> None:
+    """A nearby comment must not satisfy the control-flow invariant."""
+    violations = _audit_snippet(
+        '// if (process.env.VERCEL_ENV === "preview") {\n'
+        "const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in violations)
+
+
+def test_release_audit_rejects_closed_or_unrelated_preview_branch() -> None:
+    """Only lexical containment counts; proximity to a closed branch is unsafe."""
+    violations = _audit_snippet(
+        'if (process.env.VERCEL_ENV === "preview") {\n'
+        "  console.log('preview');\n"
+        "}\n"
+        "const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in violations)
+
+
+def test_release_audit_detects_bracket_and_destructured_reads() -> None:
+    """Alternate process.env syntax must not bypass the protected-var scan."""
+    violations = _audit_snippet(
+        'const bracket = process.env["VERCEL_AUTOMATION_BYPASS_SECRET"];\n'
+        "const { PREVIEW_BASIC_AUTH_PASSWORD: password } = process.env;\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in violations)
+    assert any("PREVIEW_BASIC_AUTH_PASSWORD" in violation for violation in violations)
+
+
+def test_release_audit_detects_optional_chain_and_bracketed_env_object() -> None:
+    """Common property-access variants must not evade the protected-var scan."""
+    violations = _audit_snippet(
+        "const optional = process.env?.VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+        "const bracketed = process['env'].PREVIEW_BASIC_AUTH_PASSWORD;\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in violations)
+    assert any("PREVIEW_BASIC_AUTH_PASSWORD" in violation for violation in violations)
+
+
+def test_release_audit_rejects_computed_reads_and_process_env_aliases() -> None:
+    """Indirection is rejected because a text audit cannot prove the selected key."""
+    violations = _audit_snippet(
+        "const key = getKey();\n"
+        "const computed = process.env[key];\n"
+        "const environment = process.env;\n"
+    )
+    assert any("bracket/computed process.env access" in violation for violation in violations)
+    assert any("process.env alias" in violation for violation in violations)
+
+
+def test_release_audit_rejects_parenthesized_spread_typed_and_process_aliases() -> None:
+    """Protected identifiers reached through alternate aliases must fail closed."""
+    violations = _audit_snippet(
+        "const parenthesized = (process.env).VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+        "const spread = { ...process.env };\n"
+        "const spreadSecret = spread.PREVIEW_BASIC_AUTH_PASSWORD;\n"
+        "const typed: NodeJS.ProcessEnv = process.env;\n"
+        "const typedSecret = typed.PREVIEW_BASIC_AUTH_USERNAME;\n"
+        "const { env } = process;\n"
+        "const processAliasSecret = env.VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in violations)
+    assert any("PREVIEW_BASIC_AUTH_PASSWORD" in violation for violation in violations)
+    assert any("PREVIEW_BASIC_AUTH_USERNAME" in violation for violation in violations)
+
+
+def test_release_audit_rejects_node_process_import_and_indirect_bracket_key() -> None:
+    """Importing or destructuring a process alias must not hide protected keys."""
+    violations = _audit_snippet(
+        'import { env } from "node:process";\n'
+        'const imported = env["VERCEL_AUTOMATION_BYPASS_SECRET"];\n'
+        "const { env: processEnvironment } = process;\n"
+        'const destructured = processEnvironment["PREVIEW_BASIC_AUTH_PASSWORD"];\n'
+    )
+    assert any("process environment alias" in violation for violation in violations)
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in violations)
+    assert any("PREVIEW_BASIC_AUTH_PASSWORD" in violation for violation in violations)
+
+
+def test_release_audit_rejects_every_process_module_import_shape() -> None:
+    """Default, namespace, dynamic, and CommonJS aliases must all fail closed."""
+    snippets = (
+        'import proc from "node:process";\nconst value = proc.env[key];\n',
+        'import * as proc from "process";\nconst value = proc.env[key];\n',
+        'const proc = await import("node:process");\nconst value = proc.env[key];\n',
+        'const proc = require("process");\nconst value = proc.env[key];\n',
+    )
+    for source in snippets:
+        violations = _audit_snippet(source)
+        assert any("process environment alias" in violation for violation in violations), (
+            source,
+            violations,
+        )
+
+
+def test_release_audit_rejects_computed_string_expression_and_regex_guard_spoof() -> None:
+    """Literal prefixes and regex text must not evade or forge the audit."""
+    computed = _audit_snippet(
+        'const secret = process.env["VERCEL_AUTOMATION_" + "BYPASS_SECRET"];\n'
+    )
+    assert any("bracket/computed process.env access" in violation for violation in computed)
+
+    spoofed = _audit_snippet(
+        'const marker = /if (process.env.VERCEL_ENV === "preview") {/;\n'
+        "const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in spoofed)
+
+    keyword_spoof = _audit_snippet(
+        'function* demo() { yield /if (process.env.VERCEL_ENV === "preview") {x/;\n'
+        "const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET; }\n"
+    )
+    assert any("VERCEL_AUTOMATION_BYPASS_SECRET" in violation for violation in keyword_spoof)
+
+
+def test_release_audit_accepts_production_leak_detector_for_basic_auth_only() -> None:
+    """Production may inspect preview Basic Auth vars solely to report drift."""
+    module = _load_module()
+    original_repo_root = module.REPO_ROOT
+    original_web_src = module.WEB_SRC
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            fake_repo = Path(td)
+            fake_web = fake_repo / "web" / "src"
+            fake_web.mkdir(parents=True)
+            (fake_web / "middleware.ts").write_text(
+                "function warnIfPreviewBasicAuthLeakedIntoProduction(): void {\n"
+                '  if (process.env.VERCEL_ENV === "production") {\n'
+                "    const leaked = process.env.PREVIEW_BASIC_AUTH_PASSWORD;\n"
+                "    void leaked;\n"
+                "  }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            module.REPO_ROOT = fake_repo
+            module.WEB_SRC = fake_web
+            violations = module.audit_repo_guards()
+    finally:
+        module.REPO_ROOT = original_repo_root
+        module.WEB_SRC = original_web_src
+    assert not violations, "production leak detector should be accepted: " + "\n".join(violations)
+
+
+def test_release_audit_rejects_basic_auth_reads_in_other_production_code() -> None:
+    """A production equality block is not a blanket exception for Basic Auth vars."""
+    violations = _audit_snippet(
+        'if (process.env.VERCEL_ENV === "production") {\n'
+        "  const password = process.env.PREVIEW_BASIC_AUTH_PASSWORD;\n"
+        "  void password;\n"
+        "}\n"
+    )
+    assert any("PREVIEW_BASIC_AUTH_PASSWORD" in violation for violation in violations)
+
+
+def test_vercel_system_bypass_is_not_reported_as_a_production_leak() -> None:
+    """Vercel injects its automation bypass system variable into every deployment."""
+    middleware = (REPO_ROOT / "web" / "src" / "middleware.ts").read_text(encoding="utf-8")
+    assert 'leaked.push("VERCEL_AUTOMATION_BYPASS_SECRET")' not in middleware
+    assert "Vercel injects" in middleware
+
+    checklist = _load_module().CHECKLIST
+    must_not_section = checklist.split("Production MUST NOT have:", 1)[1].split(
+        "If either is set", 1
+    )[0]
+    assert "VERCEL_AUTOMATION_BYPASS_SECRET" not in must_not_section
+    assert "Its presence at\n      production runtime is expected" in checklist
+    assert "Sensitive Vercel variables are intentionally non-readable" in checklist
+
+
+def test_release_checklist_branches_on_package_changes() -> None:
+    """Web/ops cutovers must not accidentally create a PyPI release tag."""
+    checklist = _load_module().CHECKLIST
+    assert "git diff vX.Y.Z..main -- src/coarse/" in checklist
+    assert "If non-empty: this is a package release" in checklist
+    assert "If empty: this is web/deploy/ops-only" in checklist
+    assert "Do NOT bump, tag, or publish" in checklist

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -1,0 +1,129 @@
+"""Supply-chain invariants for executable GitHub Actions workflows."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+FULL_COMMIT_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _workflow_paths() -> list[Path]:
+    """GitHub accepts both workflow filename extensions; enforce both."""
+    return sorted({*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")})
+
+
+def _uses_entries(node: Node | None) -> list[tuple[ScalarNode, Node]]:
+    """Return every decoded YAML mapping entry whose key is exactly ``uses``.
+
+    Traversing PyYAML's composed node tree preserves duplicate mapping keys and
+    resolves quoted escapes and aliases. That makes this check match YAML
+    semantics instead of relying on the source spelling of a security-critical
+    key.
+    """
+    if node is None:
+        return []
+    entries: list[tuple[ScalarNode, Node]] = []
+    if isinstance(node, MappingNode):
+        for key, value in node.value:
+            if isinstance(key, ScalarNode) and key.value == "uses":
+                entries.append((key, value))
+            entries.extend(_uses_entries(value))
+    elif isinstance(node, SequenceNode):
+        for item in node.value:
+            entries.extend(_uses_entries(item))
+    return entries
+
+
+def _actions_in(source: str) -> list[str | None]:
+    """Decode action references from a synthetic workflow fragment."""
+    return [
+        value.value.strip() if isinstance(value, ScalarNode) else None
+        for _, value in _uses_entries(yaml.compose(source))
+    ]
+
+
+def test_third_party_actions_are_pinned_to_full_commit_shas() -> None:
+    """Mutable tags must not control CI, deploy, scanning, or PyPI jobs."""
+    violations: list[str] = []
+    for path in _workflow_paths():
+        source = path.read_text()
+        try:
+            root = yaml.compose(source)
+        except yaml.YAMLError as error:
+            violations.append(
+                f"{path.relative_to(REPO_ROOT)}: invalid YAML cannot be audited: {error}"
+            )
+            continue
+        for key, value in _uses_entries(root):
+            line_number = key.start_mark.line + 1
+            if not isinstance(value, ScalarNode):
+                violations.append(
+                    f"{path.relative_to(REPO_ROOT)}:{line_number}: "
+                    "uses must have a scalar action reference"
+                )
+                continue
+            action = value.value.strip()
+            if action.startswith("./"):
+                continue
+            _, separator, revision = action.rpartition("@")
+            if not separator or not FULL_COMMIT_SHA_RE.fullmatch(revision):
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{line_number}: {action}")
+    assert not violations, (
+        "Pin every third-party GitHub Action to an immutable 40-character "
+        "commit SHA (keep a version comment for maintainers):\n  - " + "\n  - ".join(violations)
+    )
+
+
+def test_node20_force_flag_is_retired() -> None:
+    """Current action majors run on Node 24 without GitHub's migration shim."""
+    stale: list[str] = []
+    for path in _workflow_paths():
+        if "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in path.read_text():
+            stale.append(str(path.relative_to(REPO_ROOT)))
+    assert not stale, "remove the obsolete Node 20 force flag from: " + ", ".join(stale)
+
+
+def test_action_parser_covers_yaml_flow_mappings() -> None:
+    """A flow-style step must not evade immutable-ref enforcement."""
+    assert _actions_in("- { name: Unsafe, uses: attacker/action@main }") == ["attacker/action@main"]
+
+
+def test_action_parser_covers_quoted_and_duplicate_flow_keys() -> None:
+    """Quoted keys and later duplicate keys must not hide a mutable action."""
+    assert _actions_in('- "uses": "attacker/action@main"') == ["attacker/action@main"]
+    assert _actions_in("- { uses: ./local-action, 'uses': attacker/action@main }") == [
+        "./local-action",
+        "attacker/action@main",
+    ]
+
+
+def test_action_parser_covers_multiline_yaml_values() -> None:
+    """A line break after ``uses:`` must not hide the selected action."""
+    assert _actions_in("steps:\n  - uses:\n      attacker/action@main\n") == [
+        "attacker/action@main"
+    ]
+
+
+def test_noncanonical_action_keys_fail_closed() -> None:
+    """Explicit, escaped, and aliased YAML keys must decode to ``uses``."""
+    sources = (
+        "steps:\n  - ? uses\n    : attacker/action@main\n",
+        '- "\\x75ses": attacker/action@main\n',
+        '- "\\u0075ses": attacker/action@main\n',
+        '- "\\U00000075ses": attacker/action@main\n',
+        "action_key: &action_key uses\nsteps:\n  - *action_key: attacker/action@main\n",
+    )
+    for source in sources:
+        assert "attacker/action@main" in _actions_in(source)
+
+
+def test_commented_multiline_action_value_fails_closed() -> None:
+    """An inline comment before a multiline value must not hide an action."""
+    source = "steps:\n  - uses: # chosen action\n      attacker/action@main\n"
+    assert _actions_in(source) == ["attacker/action@main"]

--- a/uv.lock
+++ b/uv.lock
@@ -314,6 +314,7 @@ all = [
 ]
 dev = [
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 docling = [
@@ -340,6 +341,7 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.24" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },

--- a/web/src/app/api/cli-handoff/route.ts
+++ b/web/src/app/api/cli-handoff/route.ts
@@ -159,18 +159,19 @@ export async function POST(request: NextRequest) {
   const baseHandoffUrl = `${siteUrl.replace(/\/$/, "")}/h/${tokenRow.token}`;
   const handoffUrl = appendPreviewBypassQuery(baseHandoffUrl);
 
-  const isPreview = process.env.VERCEL_ENV === "preview";
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
   const warnings: string[] = [];
   if (siteUrl.includes("localhost") || siteUrl.includes("127.0.0.1")) {
     warnings.push(
       "Handoff URL uses a loopback address — the CLI must run on this same machine. For remote CLIs, set NEXT_PUBLIC_SITE_URL to a public URL.",
     );
   }
-  if (isPreview && !bypassSecret) {
-    warnings.push(
-      "Preview deployment detected but VERCEL_AUTOMATION_BYPASS_SECRET is unset — the CLI fetch will hit Vercel Preview Protection and fail with HTTP 401. Set the bypass secret on the preview environment (see deploy/PREVIEW_ENVIRONMENTS.md).",
-    );
+  if (process.env.VERCEL_ENV === "preview") {
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
+    if (!bypassSecret) {
+      warnings.push(
+        "Preview deployment detected but VERCEL_AUTOMATION_BYPASS_SECRET is unset — the CLI fetch will hit Vercel Preview Protection and fail with HTTP 401. Set the bypass secret on the preview environment (see deploy/PREVIEW_ENVIRONMENTS.md).",
+      );
+    }
   }
 
   return NextResponse.json({

--- a/web/src/lib/siteOrigin.ts
+++ b/web/src/lib/siteOrigin.ts
@@ -65,12 +65,14 @@ export function getSiteOriginForRequest(requestUrl: string): string {
  * Ref: Vercel → Deployment Protection → Protection Bypass for Automation.
  */
 export function appendPreviewBypassQuery(url: string): string {
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
-  if (process.env.VERCEL_ENV !== "preview" || !bypassSecret) {
-    return url;
+  if (process.env.VERCEL_ENV === "preview") {
+    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? "";
+    if (bypassSecret) {
+      const separator = url.includes("?") ? "&" : "?";
+      return `${url}${separator}x-vercel-protection-bypass=${encodeURIComponent(bypassSecret)}&x-vercel-set-bypass-cookie=true`;
+    }
   }
-  const separator = url.includes("?") ? "&" : "?";
-  return `${url}${separator}x-vercel-protection-bypass=${encodeURIComponent(bypassSecret)}&x-vercel-set-bypass-cookie=true`;
+  return url;
 }
 
 export function getVisibleSiteHost(): string {

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,51 +1,71 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const PREVIEW_BASIC_AUTH_REALM = 'Basic realm="coarse preview", charset="UTF-8"';
+const MAX_PREVIEW_CREDENTIAL_LENGTH = 1024;
 
 // Fires once per cold start, not once per request — `previewBasicAuthConfig`
 // runs inside the middleware hot path, so the guard is cached at module
 // scope to keep request latency unaffected.
-let previewVarsLeakedIntoProdWarned = false;
+let previewBasicAuthLeakWarned = false;
 
-function warnIfPreviewVarsLeakedIntoProduction(): void {
-  if (previewVarsLeakedIntoProdWarned) return;
-  previewVarsLeakedIntoProdWarned = true;
-  if (process.env.VERCEL_ENV !== "production") return;
-  const leaked: string[] = [];
-  if (process.env.PREVIEW_BASIC_AUTH_PASSWORD?.trim()) {
-    leaked.push("PREVIEW_BASIC_AUTH_PASSWORD");
+function warnIfPreviewBasicAuthLeakedIntoProduction(): void {
+  if (previewBasicAuthLeakWarned) return;
+  previewBasicAuthLeakWarned = true;
+  if (process.env.VERCEL_ENV === "production") {
+    const leaked: string[] = [];
+    if (process.env.PREVIEW_BASIC_AUTH_PASSWORD?.trim()) {
+      leaked.push("PREVIEW_BASIC_AUTH_PASSWORD");
+    }
+    if (process.env.PREVIEW_BASIC_AUTH_USERNAME?.trim()) {
+      leaked.push("PREVIEW_BASIC_AUTH_USERNAME");
+    }
+    if (leaked.length === 0) return;
+    // Loud marker so a release deploy with leaked preview Basic Auth
+    // config is obvious in Vercel runtime logs. These vars are no-ops on
+    // production, but their presence almost always means a Vercel
+    // "Apply to all environments" toggle got clicked by accident.
+    //
+    // Do not add VERCEL_AUTOMATION_BYPASS_SECRET here. Vercel injects
+    // that platform-managed system variable into every deployment when
+    // Protection Bypass for Automation is enabled. Its presence in
+    // production is expected; every application consumer separately
+    // gates its behavior on VERCEL_ENV === "preview".
+    console.error(
+      `[release-audit] Preview Basic Auth environment variables are set on the production deployment: ${leaked.join(", ")}. ` +
+        `These are no-ops in production code paths but indicate a dashboard misconfiguration. ` +
+        `Audit in Vercel → Project → Settings → Environment Variables and unset them for the Production environment.`,
+    );
   }
-  if (process.env.PREVIEW_BASIC_AUTH_USERNAME?.trim()) {
-    leaked.push("PREVIEW_BASIC_AUTH_USERNAME");
-  }
-  if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim()) {
-    leaked.push("VERCEL_AUTOMATION_BYPASS_SECRET");
-  }
-  if (leaked.length === 0) return;
-  // Loud marker so a release deploy with leaked preview config is
-  // obvious in Vercel runtime logs. These vars are no-ops on
-  // production (every consumer checks `VERCEL_ENV === "preview"`
-  // first), but their presence is a misconfiguration worth alerting
-  // on — they almost always mean a Vercel "Apply to all environments"
-  // toggle got clicked by accident. See deploy/RELEASE_AUDIT.md.
-  console.error(
-    `[release-audit] Preview-only environment variables are set on the production deployment: ${leaked.join(", ")}. ` +
-      `These are no-ops in production code paths but indicate a dashboard misconfiguration. ` +
-      `Audit in Vercel → Project → Settings → Environment Variables and unset them for the Production environment.`,
-  );
 }
 
 function previewBasicAuthConfig() {
-  warnIfPreviewVarsLeakedIntoProduction();
-  const password = process.env.PREVIEW_BASIC_AUTH_PASSWORD?.trim();
-  if (!password || process.env.VERCEL_ENV !== "preview") {
-    return null;
-  }
+  warnIfPreviewBasicAuthLeakedIntoProduction();
+  if (process.env.VERCEL_ENV === "preview") {
+    const password = process.env.PREVIEW_BASIC_AUTH_PASSWORD?.trim();
+    if (!password) return null;
 
-  return {
-    username: process.env.PREVIEW_BASIC_AUTH_USERNAME?.trim() || "preview",
-    password,
-  };
+    return {
+      username: process.env.PREVIEW_BASIC_AUTH_USERNAME?.trim() || "preview",
+      password,
+    };
+  }
+  return null;
+}
+
+function constantWorkCredentialEqual(left: string, right: string): boolean {
+  // Edge middleware cannot rely on Node's crypto.timingSafeEqual. Compare a
+  // fixed amount of work for every reasonable credential instead, including
+  // length in the accumulated difference. This is defense in depth behind
+  // Vercel Deployment Protection, but avoids turning the fallback gate into
+  // an obvious character-by-character timing oracle.
+  if (left.length > MAX_PREVIEW_CREDENTIAL_LENGTH || right.length > MAX_PREVIEW_CREDENTIAL_LENGTH) {
+    return false;
+  }
+  let difference = left.length ^ right.length;
+  for (let index = 0; index < MAX_PREVIEW_CREDENTIAL_LENGTH; index += 1) {
+    difference |= (left.charCodeAt(index) | 0) ^ (right.charCodeAt(index) | 0);
+  }
+  return difference === 0;
 }
 
 function isAuthorizedForPreview(request: NextRequest, expectedUser: string, expectedPassword: string) {
@@ -63,7 +83,11 @@ function isAuthorizedForPreview(request: NextRequest, expectedUser: string, expe
 
     const username = decoded.slice(0, separator);
     const password = decoded.slice(separator + 1);
-    return username === expectedUser && password === expectedPassword;
+    // Evaluate both comparisons unconditionally so an invalid username does
+    // not short-circuit before the password comparison.
+    const usernameMatches = constantWorkCredentialEqual(username, expectedUser);
+    const passwordMatches = constantWorkCredentialEqual(password, expectedPassword);
+    return usernameMatches && passwordMatches;
   } catch {
     return false;
   }

--- a/web/tests/middleware-release-audit.test.ts
+++ b/web/tests/middleware-release-audit.test.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadMiddleware() {
+  vi.resetModules();
+  return import("../src/middleware");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("production preview-config drift warning", () => {
+  it.each([
+    ["PREVIEW_BASIC_AUTH_USERNAME", "preview-user", "PREVIEW_BASIC_AUTH_PASSWORD"],
+    ["PREVIEW_BASIC_AUTH_PASSWORD", "preview-password", "PREVIEW_BASIC_AUTH_USERNAME"],
+  ] as const)("warns and passes through when only %s leaks", async (leakedName, leakedValue, absentName) => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv(leakedName, leakedValue);
+    vi.stubEnv(absentName, "");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { middleware } = await loadMiddleware();
+
+    const response = middleware(new NextRequest("https://coarse.ink/"));
+
+    expect(response.status).toBe(200);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0]?.[0]).toContain(leakedName);
+    expect(error.mock.calls[0]?.[0]).not.toContain(absentName);
+  });
+
+  it("warns once per module instance when preview Basic Auth leaks into production", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_USERNAME", "preview-user");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_PASSWORD", "preview-password");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { middleware } = await loadMiddleware();
+    const request = new NextRequest("https://coarse.ink/");
+
+    middleware(request);
+    middleware(request);
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0]?.[0]).toContain("[release-audit]");
+    expect(error.mock.calls[0]?.[0]).toContain("PREVIEW_BASIC_AUTH_USERNAME");
+    expect(error.mock.calls[0]?.[0]).toContain("PREVIEW_BASIC_AUTH_PASSWORD");
+  });
+
+  it("does not warn about intentional preview Basic Auth on preview", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_USERNAME", "preview-user");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_PASSWORD", "preview-password");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { middleware } = await loadMiddleware();
+
+    middleware(new NextRequest("https://preview.example.com/"));
+
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("does not treat Vercel's production automation-bypass system variable as a leak", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_USERNAME", "");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_PASSWORD", "");
+    vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "platform-managed-value");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { middleware } = await loadMiddleware();
+
+    middleware(new NextRequest("https://coarse.ink/"));
+
+    expect(error).not.toHaveBeenCalled();
+  });
+});
+
+describe("preview Basic Auth", () => {
+  it("accepts the configured pair and rejects an incorrect password", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_USERNAME", "preview-user");
+    vi.stubEnv("PREVIEW_BASIC_AUTH_PASSWORD", "preview-password");
+    const { middleware } = await loadMiddleware();
+    const authorized = new NextRequest("https://preview.example.com/", {
+      headers: {
+        authorization: `Basic ${btoa("preview-user:preview-password")}`,
+      },
+    });
+    const rejected = new NextRequest("https://preview.example.com/", {
+      headers: {
+        authorization: `Basic ${btoa("preview-user:wrong-password")}`,
+      },
+    });
+
+    expect(middleware(authorized).status).toBe(200);
+    expect(middleware(rejected).status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary\n- correct Vercel system/sensitive-secret release checks and harden preview Basic Auth\n- make protected env-var auditing structural and adversarially tested\n- upgrade and immutably pin GitHub Actions; run web tests in CI\n- reconcile active Modal/preview documentation and production-only Resend scoping\n\n## Validation\n- /pre-pr testing review: No findings\n- /pre-pr security review: No findings\n- pre-commit: all hooks passed\n- pytest: 1,339 passed, 1 deselected\n- Vitest: 14 passed\n- Next.js production build passed\n- release audit and strict security scanner passed\n\nWeb/ops/dev-tooling only: no src/coarse changes and no PyPI tag.