### PR TITLE
fix(web): replace unsupported comparison claims with reproducible evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Public comparison claims no longer outrun reproducible evidence (issue #271).** Homepage copy no longer shows an unsupported “5+ / 5” winner score against named systems. The compare loader keeps the native LLM-judge scale (typically `/6`) instead of rewriting denominators to `/5` (which could display scores above the scale). Side-by-side artifacts are labelled as historical/illustrative; the UI is structured to consume run manifests (model/effort/sample size/date/benchmark version/CIs) once they exist. Vitest coverage for score parsing, scale display, unavailable evidence, and historical labelling. English + all site locales updated consistently. Web-only — no package change.
+
 ## v1.9.2 — 2026-08-27
 
 ### Added

--- a/tests/test_web_site_i18n.py
+++ b/tests/test_web_site_i18n.py
@@ -1,4 +1,4 @@
-"""Completeness guard for the site-UI (chrome) i18n catalogs.
+﻿"""Completeness guard for the site-UI (chrome) i18n catalogs.
 
 There is no JS test runner / local TS build, so this reads the catalog TS
 sources verbatim (like tests/test_web_security_invariants.py) and asserts every
@@ -52,9 +52,9 @@ def test_all_locale_catalogs_exist():
 
 
 def test_english_catalog_has_expected_key_count():
-    # 436 keys after the deep-literature switch added four localized labels to
-    # the 432-key submit + status + review + setup/compare catalog.
-    assert len(_keys(_read("en"))) == 436
+    # 438 keys after #271 added compareHistoricalBadge + compareEvidenceUnavailable
+    # (436 after deep-literature; 432 was submit+status+review+setup/compare).
+    assert len(_keys(_read("en"))) == 438
 
 
 def test_every_locale_defines_exactly_the_english_keys():

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -3,7 +3,7 @@ import { ComparePage } from "@/components/ComparePage";
 
 export const metadata = {
   title: "\u2018coarse \u2014 Compare reviews",
-  description: "See how coarse stacks up against refine.ink and human reviewers.",
+  description: "Historical side-by-side review artifacts. Illustrative only — not a current leaderboard.",
 };
 
 export default function CompareRoute() {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1129,30 +1129,34 @@ function PageBody() {
           {/* Score preview */}
           <div style={{ marginTop: "2.25rem" }}>
             <div style={{ display: "flex", gap: "2.5rem", flexWrap: "wrap", alignItems: "flex-end" }}>
-              {/* Big score */}
+              {/* Evidence posture — no unsupported winner score */}
               <div style={{ transform: "rotate(-1.5deg)" }}>
                 <span
                   style={{
                     fontFamily: "var(--font-chalk)",
-                    fontSize: "2.75rem",
-                    fontWeight: 700,
-                    color: "var(--yellow-chalk)",
-                    lineHeight: 1,
+                    fontSize: "1.75rem",
+                    fontWeight: 600,
+                    color: "var(--chalk-bright)",
+                    lineHeight: 1.15,
+                    display: "block",
+                    maxWidth: "11rem",
                   }}
                 >
-                  5<span style={{ fontSize: "1.5rem", verticalAlign: "super", lineHeight: 0 }}>+</span>
-                  <span style={{ fontSize: "1.1rem", fontWeight: 400, color: "var(--dust)" }}> / 5</span>
+                  {t("scoreVsOthers")}
                 </span>
                 <span
                   style={{
                     fontFamily: "var(--font-chalk)",
-                    fontSize: "1.1rem",
+                    fontSize: "1.05rem",
                     color: "var(--dust)",
                     display: "block",
-                    marginTop: "0.25rem",
+                    marginTop: "0.35rem",
+                    fontStyle: "italic",
+                    maxWidth: "14rem",
+                    lineHeight: 1.35,
                   }}
                 >
-                  {t("scoreVsOthers")}
+                  {t("compareHistoricalBadge")}
                 </span>
               </div>
 

--- a/web/src/components/ComparePage.tsx
+++ b/web/src/components/ComparePage.tsx
@@ -9,6 +9,11 @@ import type { PaperId, ModelId, ComparisonId, PaperData } from "@/data/compare-t
 import { MODEL_LABELS, COMPARISON_LABELS, COMPARISON_URLS } from "@/data/compare-types";
 import type { Components } from "react-markdown";
 import { SiteLanguageProvider, useSiteLanguageContext, type MessageKey } from "@/lib/i18n";
+import {
+  resolveCompareEvidence,
+  scoreDenominatorSuffix,
+  scoreNumeratorLabel,
+} from "@/lib/compareScores";
 
 const katexOptions = { strict: false, throwOnError: false };
 
@@ -281,7 +286,7 @@ function ScoresOverviewTable({ papers }: { papers: Record<PaperId, PaperData> })
                             background: active && score >= 5.0 ? "rgba(212, 168, 67, 0.12)" : "transparent",
                           }}
                         >
-                          {active ? score.toFixed(2) : "N/A"}
+                          {active ? score.toFixed(2) : t("compareEvidenceUnavailable")}
                         </td>
                       );
                     })}
@@ -390,6 +395,8 @@ function ComparePageBody({ papers }: { papers: Record<PaperId, PaperData> }) {
   const effectiveModelId = modelEntry ? modelId : "claude";
   const effectiveModel = paper.models[effectiveModelId]!;
   const activeScores = effectiveModel.scores[comparisonId];
+  // File-backed LLM-judge rows are historical until run manifests (#273) exist.
+  const evidence = resolveCompareEvidence({ scores: activeScores });
 
   const leftComponents = useMemo(() => makeHeadingComponents("left"), []);
   const rightComponents = useMemo(() => makeHeadingComponents("right"), []);
@@ -508,7 +515,7 @@ function ComparePageBody({ papers }: { papers: Record<PaperId, PaperData> }) {
             flexWrap: "wrap",
           }}
         >
-          {/* Scrawled grade */}
+          {/* Scrawled grade — native scale, no denominator rewrite */}
           <div style={{ transform: "rotate(-1.5deg)", transformOrigin: "center" }}>
             <p
               style={{
@@ -525,13 +532,35 @@ function ComparePageBody({ papers }: { papers: Record<PaperId, PaperData> }) {
                 fontFamily: "var(--font-chalk)",
                 fontSize: "3rem",
                 fontWeight: 700,
-                color: "var(--yellow-chalk)",
+                color: evidence.overall.available ? "var(--yellow-chalk)" : "var(--dust)",
                 lineHeight: 1,
               }}
             >
-              {activeScores.overall.replace(/\/[\d.]+$/, "")}
-              <span style={{ fontSize: "1.25rem", fontWeight: 400, color: "var(--dust)" }}>{t("compareScoreOutOf")}</span>
+              {evidence.overall.available
+                ? scoreNumeratorLabel(activeScores.overall)
+                : t("compareEvidenceUnavailable")}
+              {evidence.overall.available && (
+                <span style={{ fontSize: "1.25rem", fontWeight: 400, color: "var(--dust)" }}>
+                  {scoreDenominatorSuffix(activeScores.overall)}
+                </span>
+              )}
             </span>
+            {evidence.historical && (
+              <p
+                data-testid="compare-historical-badge"
+                style={{
+                  fontFamily: "var(--font-chalk)",
+                  fontSize: "0.95rem",
+                  color: "var(--dust)",
+                  margin: "0.35rem 0 0",
+                  maxWidth: "16rem",
+                  lineHeight: 1.35,
+                  fontStyle: "italic",
+                }}
+              >
+                {t("compareHistoricalBadge")}
+              </p>
+            )}
           </div>
 
           {/* Paper title + metrics */}
@@ -549,16 +578,16 @@ function ComparePageBody({ papers }: { papers: Record<PaperId, PaperData> }) {
             </p>
             <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap" }}>
               {([
-                ["compareMetricCoverage", activeScores.coverage],
-                ["compareMetricSpecificity", activeScores.specificity],
-                ["compareMetricDepth", activeScores.depth],
-              ] as const).map(([labelKey, val]) => (
+                ["compareMetricCoverage", evidence.dimensions.coverage],
+                ["compareMetricSpecificity", evidence.dimensions.specificity],
+                ["compareMetricDepth", evidence.dimensions.depth],
+              ] as const).map(([labelKey, dim]) => (
                 <span key={labelKey} style={{ fontSize: "0.92rem" }}>
                   <span style={{ fontFamily: "var(--font-chalk)", color: "var(--dust)" }}>
                     {t(labelKey)}
                   </span>{" "}
                   <span style={{ fontFamily: "var(--font-chalk)", color: "var(--chalk-bright)", fontWeight: 600 }}>
-                    {val}
+                    {dim.available ? dim.text : t("compareEvidenceUnavailable")}
                   </span>
                 </span>
               ))}

--- a/web/src/data/compare-types.ts
+++ b/web/src/data/compare-types.ts
@@ -1,9 +1,6 @@
-export type QualityScores = {
-  overall: string;
-  coverage: string;
-  specificity: string;
-  depth: string;
-};
+import type { QualityScores } from "@/lib/compareScores";
+
+export type { QualityScores, RunManifestSummary } from "@/lib/compareScores";
 
 export type ModelId = "claude" | "kimi" | "gpt5mini" | "gpt54";
 export type ComparisonId = "refine" | "stanford" | "reviewer3";
@@ -12,6 +9,8 @@ export type PaperId = "cortical_circuits" | "coset_codes" | "population_genetics
 export type ModelEntry = {
   review: string;
   scores: Record<ComparisonId, QualityScores>;
+  /** Optional reproducible run manifest once evaluation substrate (#273) exists. */
+  runManifest?: import("@/lib/compareScores").RunManifestSummary | null;
 };
 
 export type ComparisonEntry = {

--- a/web/src/data/compare.ts
+++ b/web/src/data/compare.ts
@@ -2,7 +2,9 @@
  * Side-by-side comparison data loader.
  *
  * Score sources — each model × paper combination references specific quality
- * evaluation files in data/refine_examples/ so results are reproducible.
+ * evaluation files in data/refine_examples/. These are historical illustrative
+ * artifacts, not decision-grade same-model leaderboard evidence. Display keeps
+ * the native judge scale (typically /6); never rewrite denominators.
  *
  * Sonnet 4.6 & Kimi K2.5 reviews: generated 2026-03-15 via the coarse web app.
  * GPT-5 Mini reviews: generated 2026-03-16 via coarse CLI.
@@ -21,24 +23,17 @@
  */
 import fs from "fs";
 import path from "path";
-import type { QualityScores, ComparisonId, PaperId, PaperData } from "./compare-types";
+import type { ComparisonId, PaperId, PaperData } from "./compare-types";
+import {
+  NA_SCORES,
+  parseQualityScores,
+  type QualityScores,
+} from "@/lib/compareScores";
 
 export type { QualityScores, ModelId, ComparisonId, PaperId, ModelEntry, ComparisonEntry, PaperData } from "./compare-types";
+export type { RunManifestSummary } from "@/lib/compareScores";
 export { MODEL_LABELS, COMPARISON_LABELS, COMPARISON_URLS } from "./compare-types";
-
-function parseQualityScores(report: string): QualityScores {
-  // Display denominator as /5 (public-facing) even though judge uses a /6 scale internally
-  const swapDenom = (s: string) => s.replace(/\/\d+(\.\d+)?$/, "/5");
-  const overall = report.match(/Overall Score:\s*([\d.]+\/[\d.]+)/)?.[1] ?? "N/A";
-  const dim = (name: string) =>
-    report.match(new RegExp(`\\|\\s*${name}\\s*\\|\\s*([\\d.]+/\\d+)`))?.[1] ?? "N/A";
-  return {
-    overall: overall !== "N/A" ? swapDenom(overall) : overall,
-    coverage: dim("coverage") !== "N/A" ? swapDenom(dim("coverage")) : "N/A",
-    specificity: dim("specificity") !== "N/A" ? swapDenom(dim("specificity")) : "N/A",
-    depth: dim("depth") !== "N/A" ? swapDenom(dim("depth")) : "N/A",
-  };
-}
+export { parseQualityScores, NA_SCORES } from "@/lib/compareScores";
 
 function normalizeEscapedUnicode(text: string): string {
   return text.replace(/\\u([0-9a-fA-F]{4})/g, (_match, hex: string) =>
@@ -57,8 +52,6 @@ function tryReadFile(filePath: string): string | null {
     return null;
   }
 }
-
-const NA_SCORES: QualityScores = { overall: "N/A", coverage: "N/A", specificity: "N/A", depth: "N/A" };
 
 function loadScoresForRef(dir: string, qualityFile: string): QualityScores {
   const content = tryReadFile(path.join(dir, qualityFile));

--- a/web/src/lib/compareScores.ts
+++ b/web/src/lib/compareScores.ts
@@ -1,0 +1,174 @@
+/**
+ * Compare-page score parsing and evidence labelling.
+ *
+ * Quality reports use a 1-6 judge scale. Display must keep the native
+ * denominator (or a documented rescaling). Never substitute /6 -> /5.
+ */
+
+export const QUALITY_JUDGE_SCALE_MAX = 6;
+export const UNAVAILABLE_SCORE = "N/A";
+
+/** Fields a future reproducible run manifest should expose to the compare UI. */
+export type RunManifestSummary = {
+  model?: string;
+  effort?: string;
+  configuration?: string;
+  sampleSize?: number;
+  date?: string;
+  benchmarkVersion?: string;
+  confidenceInterval?: string;
+  /** Repo-relative or URL path to the full manifest once #273 lands. */
+  manifestPath?: string;
+};
+
+export type ScoreEvidenceKind = "historical_llm_judge" | "run_manifest" | "unavailable";
+
+export type QualityScores = {
+  overall: string;
+  coverage: string;
+  specificity: string;
+  depth: string;
+};
+
+export type ScoreFraction = {
+  numerator: number;
+  denominator: number;
+  /** Canonical display, e.g. "5.83/6". */
+  display: string;
+};
+
+const FRACTION_RE = /^([\d.]+)\s*\/\s*([\d.]+)$/;
+
+export function parseScoreFraction(score: string): ScoreFraction | null {
+  if (!score || score === UNAVAILABLE_SCORE) return null;
+  const m = score.trim().match(FRACTION_RE);
+  if (!m) return null;
+  const numerator = Number.parseFloat(m[1]);
+  const denominator = Number.parseFloat(m[2]);
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator <= 0) {
+    return null;
+  }
+  const display = `${formatNum(numerator)}/${formatNum(denominator)}`;
+  return { numerator, denominator, display };
+}
+
+function formatNum(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(2).replace(/\.?0+$/, "");
+}
+
+/** True when a displayed fraction's numerator exceeds its denominator. */
+export function scoreExceedsDenominator(score: string): boolean {
+  const frac = parseScoreFraction(score);
+  if (!frac) return false;
+  return frac.numerator > frac.denominator + 1e-9;
+}
+
+/**
+ * Format a stored score string for UI. Keeps the native denominator.
+ * Unavailable / unparsable scores return the unavailable label.
+ */
+export function formatScoreForDisplay(
+  score: string,
+  unavailableLabel: string = UNAVAILABLE_SCORE,
+): { text: string; available: boolean; exceedsDenominator: boolean } {
+  if (!score || score === UNAVAILABLE_SCORE) {
+    return { text: unavailableLabel, available: false, exceedsDenominator: false };
+  }
+  const frac = parseScoreFraction(score);
+  if (!frac) {
+    return { text: unavailableLabel, available: false, exceedsDenominator: false };
+  }
+  return {
+    text: frac.display,
+    available: true,
+    exceedsDenominator: frac.numerator > frac.denominator + 1e-9,
+  };
+}
+
+/** Numerator-only big display; denominator comes from the score itself. */
+export function scoreNumeratorLabel(score: string): string {
+  const frac = parseScoreFraction(score);
+  if (!frac) return UNAVAILABLE_SCORE;
+  return formatNum(frac.numerator);
+}
+
+/** Denominator suffix including slash, e.g. "/6". */
+export function scoreDenominatorSuffix(score: string, fallbackMax = QUALITY_JUDGE_SCALE_MAX): string {
+  const frac = parseScoreFraction(score);
+  if (!frac) return `/${fallbackMax}`;
+  return `/${formatNum(frac.denominator)}`;
+}
+
+export function parseQualityScores(report: string): QualityScores {
+  // Keep the native validated scale from the report (typically /6).
+  const overall = report.match(/Overall Score:\s*([\d.]+\/[\d.]+)/)?.[1] ?? UNAVAILABLE_SCORE;
+  const dim = (name: string) =>
+    report.match(new RegExp(`\\|\\s*${name}\\s*\\|\\s*([\\d.]+/\\d+(?:\\.\\d+)?)`))?.[1] ??
+    UNAVAILABLE_SCORE;
+  return {
+    overall,
+    coverage: dim("coverage"),
+    specificity: dim("specificity"),
+    depth: dim("depth"),
+  };
+}
+
+export const NA_SCORES: QualityScores = {
+  overall: UNAVAILABLE_SCORE,
+  coverage: UNAVAILABLE_SCORE,
+  specificity: UNAVAILABLE_SCORE,
+  depth: UNAVAILABLE_SCORE,
+};
+
+/**
+ * Classify how a score cell should be labelled.
+ * Until run manifests exist (#273), file-backed LLM-judge scores are historical.
+ */
+export function classifyScoreEvidence(
+  scores: QualityScores,
+  manifest?: RunManifestSummary | null,
+): ScoreEvidenceKind {
+  if (manifest?.manifestPath) return "run_manifest";
+  const anyAvailable = [scores.overall, scores.coverage, scores.specificity, scores.depth].some(
+    (s) => s && s !== UNAVAILABLE_SCORE && parseScoreFraction(s) !== null,
+  );
+  if (!anyAvailable) return "unavailable";
+  return "historical_llm_judge";
+}
+
+export function isHistoricalIllustrative(kind: ScoreEvidenceKind): boolean {
+  return kind === "historical_llm_judge";
+}
+
+/**
+ * Optional manifest overlay for the compare UI. When present, pages should
+ * prefer manifest metadata over ad-hoc winner copy.
+ */
+export function resolveCompareEvidence(opts: {
+  scores: QualityScores;
+  manifest?: RunManifestSummary | null;
+}): {
+  kind: ScoreEvidenceKind;
+  historical: boolean;
+  overall: ReturnType<typeof formatScoreForDisplay>;
+  dimensions: {
+    coverage: ReturnType<typeof formatScoreForDisplay>;
+    specificity: ReturnType<typeof formatScoreForDisplay>;
+    depth: ReturnType<typeof formatScoreForDisplay>;
+  };
+  manifest: RunManifestSummary | null;
+} {
+  const kind = classifyScoreEvidence(opts.scores, opts.manifest);
+  return {
+    kind,
+    historical: isHistoricalIllustrative(kind),
+    overall: formatScoreForDisplay(opts.scores.overall),
+    dimensions: {
+      coverage: formatScoreForDisplay(opts.scores.coverage),
+      specificity: formatScoreForDisplay(opts.scores.specificity),
+      depth: formatScoreForDisplay(opts.scores.depth),
+    },
+    manifest: opts.manifest ?? null,
+  };
+}

--- a/web/src/lib/i18n/ar.ts
+++ b/web/src/lib/i18n/ar.ts
@@ -40,7 +40,7 @@ export const ar: Messages = {
     "تقوم مراجعة الأقران الأكاديمية على عمل أكاديمي غير مدفوع الأجر. وقد قرّر آخرون أن يجعلوا منها تجارة. لم يرُقْ لنا ذلك.",
 
   // hero — score preview
-  scoreVsOthers: "مقارنةً بمراجِعي الذكاء الاصطناعي الآخرين",
+  scoreVsOthers: "تقييم مفتوح",
   statCostNum: "< $2*",
   statCostLabel: "لكل مراجعة",
   statCostFootnote: "*عادةً :)",
@@ -50,13 +50,13 @@ export const ar: Messages = {
   statOpenSourceLabel: "مفتوح المصدر",
 
   // hero — competitive comparison
-  comparePrefix: "خضع لتقييم أعمى مقابل",
+  comparePrefix: "مواد تاريخية جنباً إلى جنب مع",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "يحقّق درجات أعلى في الشمول والدقة والعمق -- بجزء يسير من التكلفة.",
-  compareLink: "اطّلع على المقارنة جنبًا إلى جنب →",
+    "للتوضيح فقط — ليست أدلة قرار بنفس النموذج ولا لوحة صدارة حالية.",
+  compareLink: "تصفح المقارنات التاريخية ←",
 
   // submit form — section heading + paper field
   formSubmitHeading: "أرسِل ورقة",
@@ -561,7 +561,7 @@ export const ar: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "قيّمها Gemini 3.1 Pro بإدخال متعدد الوسائط من ملف PDF. 5.0/5 = تطابق جودة المرجع. 5.5+/5 = تتجاوزها.",
+    "درجات تاريخية من محكّم LLM (Gemini 3.1 Pro، PDF متعدد الوسائط). المقياس الأصلي 1–6: 5.0 = تطابق جودة المرجع؛ 5.5–6.0 = تتجاوزها. ليست أدلة لوحة صدارة بأقصى استدلال وبنفس النموذج.",
   compareJudgeShow: "إظهار",
   compareJudgeHide: "إخفاء",
   compareJudgeToggleSuffix: " موجِّه الحَكَم المُرسَل إلى Gemini 3.1 Pro ",
@@ -570,7 +570,7 @@ export const ar: Messages = {
   compareJudgeSystemPromptLabel: "موجِّه النظام",
   compareJudgeUserPromptLabel: "موجِّه المستخدم (تُدرَج الورقة + المراجعات وقت التشغيل)",
   compareVsMid: " مقابل ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "الشمول",
   compareMetricSpecificity: "الدقة",
   compareMetricDepth: "العمق",
@@ -580,4 +580,6 @@ export const ar: Messages = {
   compareVisitPrefix: "زُر ",
   comparePdfReviewSuffix: " مراجعة",
   comparePdfFallback: "نزّل ملف PDF إذا لم يُعرَض الإطار ↓",
+  compareHistoricalBadge: "مثال تاريخي توضيحي — ليس دليل لوحة صدارة حالية",
+  compareEvidenceUnavailable: "الأدلة غير متوفرة",
 };

--- a/web/src/lib/i18n/de.ts
+++ b/web/src/lib/i18n/de.ts
@@ -38,7 +38,7 @@ export const de: Messages = {
     "Akademische Peer Review läuft auf unbezahlter akademischer Arbeit. Andere haben beschlossen, daraus ein Geschäft zu machen. Das fanden wir nicht gut.",
 
   // hero — score preview
-  scoreVsOthers: "vs. andere KI-Reviewer",
+  scoreVsOthers: "offene Evaluation",
   statCostNum: "< $2*",
   statCostLabel: "pro Review",
   statCostFootnote: "*meistens :)",
@@ -48,13 +48,13 @@ export const de: Messages = {
   statOpenSourceLabel: "Open Source",
 
   // hero — competitive comparison
-  comparePrefix: "Blind getestet gegen",
+  comparePrefix: "Historische Side-by-Side-Artefakte mit",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Schneidet besser ab bei Abdeckung, Spezifität und Tiefe -- zu einem Bruchteil der Kosten.",
-  compareLink: "Sieh dir den Vergleich an →",
+    "Nur illustrativ — keine entscheidungsreife Same-Model-Evidenz und keine aktuelle Rangliste.",
+  compareLink: "Historische Vergleiche ansehen →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "Ein Paper einreichen",
@@ -559,7 +559,7 @@ export const de: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Bewertet von Gemini 3.1 Pro mit multimodaler PDF-Eingabe. 5,0/5 = entspricht der Referenzqualität. 5,5+/5 = übertrifft sie.",
+    "Historische LLM-als-Richter-Scores (Gemini 3.1 Pro, multimodales PDF). Native 1–6-Skala: 5,0 = entspricht der Referenzqualität; 5,5–6,0 = übertrifft sie. Keine Same-Model-Maximum-Reasoning-Ranglistenevidenz.",
   compareJudgeShow: "Einblenden",
   compareJudgeHide: "Ausblenden",
   compareJudgeToggleSuffix: " des an Gemini 3.1 Pro gesendeten Judge-Prompts ",
@@ -568,7 +568,7 @@ export const de: Messages = {
   compareJudgeSystemPromptLabel: "System-Prompt",
   compareJudgeUserPromptLabel: "User-Prompt (Paper + Reviews zur Laufzeit eingefügt)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Abdeckung",
   compareMetricSpecificity: "Spezifität",
   compareMetricDepth: "Tiefe",
@@ -578,4 +578,6 @@ export const de: Messages = {
   compareVisitPrefix: "Besuche ",
   comparePdfReviewSuffix: "-Review",
   comparePdfFallback: "Lad das PDF herunter, falls der iframe nicht rendert ↓",
+  compareHistoricalBadge: "Historisches illustratives Beispiel — keine aktuelle Ranglistenevidenz",
+  compareEvidenceUnavailable: "Evidenz nicht verfügbar",
 };

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -42,7 +42,7 @@ export const en = {
     "Academic peer review runs on unpaid academic labor. Others decided to make a business out of that. We didn't like that.",
 
   // hero — score preview
-  scoreVsOthers: "vs. other AI reviewers",
+  scoreVsOthers: "open evaluation",
   statCostNum: "< $2*",
   statCostLabel: "per review",
   statCostFootnote: "*typically :)",
@@ -52,13 +52,13 @@ export const en = {
   statOpenSourceLabel: "open source",
 
   // hero — competitive comparison
-  comparePrefix: "Blind-evaluated against",
+  comparePrefix: "Historical side-by-side artifacts with",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Scores higher on coverage, specificity, and depth -- at a fraction of the cost.",
-  compareLink: "See the side-by-side →",
+    "Illustrative only — not decision-grade same-model evidence or a current leaderboard.",
+  compareLink: "Browse historical comparisons →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "Submit a paper",
@@ -560,7 +560,7 @@ export const en = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Evaluated by Gemini 3.1 Pro with PDF multimodal input. 5.0/5 = matches reference quality. 5.5+/5 = exceeds it.",
+    "Historical LLM-as-judge scores (Gemini 3.1 Pro, PDF multimodal). Native 1–6 scale: 5.0 = matches reference quality; 5.5–6.0 = exceeds it. Not same-model maximum-reasoning leaderboard evidence.",
   compareJudgeShow: "Show",
   compareJudgeHide: "Hide",
   compareJudgeToggleSuffix: " judge prompt sent to Gemini 3.1 Pro ",
@@ -569,7 +569,7 @@ export const en = {
   compareJudgeSystemPromptLabel: "System prompt",
   compareJudgeUserPromptLabel: "User prompt (paper + reviews injected at runtime)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Coverage",
   compareMetricSpecificity: "Specificity",
   compareMetricDepth: "Depth",
@@ -579,4 +579,7 @@ export const en = {
   compareVisitPrefix: "Visit ",
   comparePdfReviewSuffix: " review",
   comparePdfFallback: "Download PDF if iframe doesn't render ↓",
+  compareHistoricalBadge:
+    "Historical illustrative example — not current leaderboard evidence",
+  compareEvidenceUnavailable: "Evidence unavailable",
 } as const;

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -38,7 +38,7 @@ export const es: Messages = {
     "La revisión académica por pares se sostiene sobre trabajo académico no remunerado. Otros decidieron hacer un negocio de eso. No nos pareció bien.",
 
   // hero — score preview
-  scoreVsOthers: "frente a otros revisores de IA",
+  scoreVsOthers: "evaluación abierta",
   statCostNum: "< $2*",
   statCostLabel: "por revisión",
   statCostFootnote: "*normalmente :)",
@@ -48,13 +48,13 @@ export const es: Messages = {
   statOpenSourceLabel: "código abierto",
 
   // hero — competitive comparison
-  comparePrefix: "Evaluado a ciegas frente a",
+  comparePrefix: "Artefactos históricos lado a lado con",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Puntúa más alto en cobertura, especificidad y profundidad -- por una fracción del coste.",
-  compareLink: "Ver la comparativa →",
+    "Solo ilustrativo: no es evidencia de decisión con el mismo modelo ni una clasificación actual.",
+  compareLink: "Ver comparaciones históricas →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "Enviar un artículo",
@@ -559,7 +559,7 @@ export const es: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Evaluado por Gemini 3.1 Pro con entrada multimodal en PDF. 5,0/5 = iguala la calidad de la referencia. 5,5+/5 = la supera.",
+    "Puntuaciones históricas de un juez LLM (Gemini 3.1 Pro, PDF multimodal). Escala nativa 1–6: 5,0 = iguala la calidad de referencia; 5,5–6,0 = la supera. No es evidencia de clasificación con máximo razonamiento y el mismo modelo.",
   compareJudgeShow: "Mostrar",
   compareJudgeHide: "Ocultar",
   compareJudgeToggleSuffix: " la instrucción del juez enviada a Gemini 3.1 Pro ",
@@ -568,7 +568,7 @@ export const es: Messages = {
   compareJudgeSystemPromptLabel: "Instrucción del sistema",
   compareJudgeUserPromptLabel: "Instrucción del usuario (el artículo y las revisiones se inyectan en tiempo de ejecución)",
   compareVsMid: " frente a ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Cobertura",
   compareMetricSpecificity: "Especificidad",
   compareMetricDepth: "Profundidad",
@@ -578,4 +578,6 @@ export const es: Messages = {
   compareVisitPrefix: "Visita ",
   comparePdfReviewSuffix: " revisión",
   comparePdfFallback: "Descarga el PDF si el iframe no se renderiza ↓",
+  compareHistoricalBadge: "Ejemplo histórico ilustrativo — no es evidencia de clasificación actual",
+  compareEvidenceUnavailable: "Evidencia no disponible",
 };

--- a/web/src/lib/i18n/fr.ts
+++ b/web/src/lib/i18n/fr.ts
@@ -32,7 +32,7 @@ export const fr: Messages = {
   heroManifesto:
     "L'évaluation académique par les pairs repose sur un travail universitaire non rémunéré. D'autres ont décidé d'en faire un commerce. Ça ne nous a pas plu.",
 
-  scoreVsOthers: "vs. autres relecteurs IA",
+  scoreVsOthers: "évaluation ouverte",
   statCostNum: "< $2*",
   statCostLabel: "par évaluation",
   statCostFootnote: "*en général :)",
@@ -41,13 +41,13 @@ export const fr: Messages = {
   statOpenSourceNum: "MIT",
   statOpenSourceLabel: "open source",
 
-  comparePrefix: "Évalué à l'aveugle face à",
+  comparePrefix: "Artefacts historiques côte à côte avec",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Obtient de meilleurs scores en couverture, spécificité et profondeur -- pour une fraction du coût.",
-  compareLink: "Voir la comparaison →",
+    "Illustratif uniquement — pas une preuve décisionnelle même modèle, ni un classement actuel.",
+  compareLink: "Parcourir les comparaisons historiques →",
 
   formSubmitHeading: "Soumettre un article",
   fieldPaper: "Article",
@@ -538,7 +538,7 @@ export const fr: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Évalué par Gemini 3.1 Pro avec une entrée PDF multimodale. 5,0/5 = égale la qualité de référence. 5,5+/5 = la dépasse.",
+    "Scores historiques d’un juge LLM (Gemini 3.1 Pro, PDF multimodal). Échelle native 1–6 : 5,0 = égale la qualité de référence ; 5,5–6,0 = la dépasse. Ce n’est pas une preuve de classement à raisonnement maximal sur le même modèle.",
   compareJudgeShow: "Afficher",
   compareJudgeHide: "Masquer",
   compareJudgeToggleSuffix: " l'invite du juge envoyée à Gemini 3.1 Pro ",
@@ -547,7 +547,7 @@ export const fr: Messages = {
   compareJudgeSystemPromptLabel: "Invite système",
   compareJudgeUserPromptLabel: "Invite utilisateur (article + relectures injectés à l'exécution)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Couverture",
   compareMetricSpecificity: "Spécificité",
   compareMetricDepth: "Profondeur",
@@ -557,4 +557,6 @@ export const fr: Messages = {
   compareVisitPrefix: "Visiter ",
   comparePdfReviewSuffix: " évaluation",
   comparePdfFallback: "Téléchargez le PDF si l'iframe ne s'affiche pas ↓",
+  compareHistoricalBadge: "Exemple historique illustratif — pas une preuve de classement actuel",
+  compareEvidenceUnavailable: "Preuve indisponible",
 };

--- a/web/src/lib/i18n/it.ts
+++ b/web/src/lib/i18n/it.ts
@@ -38,7 +38,7 @@ export const it: Messages = {
     "La revisione tra pari in ambito accademico si regge sul lavoro accademico non retribuito. Altri hanno deciso di farne un business. La cosa non ci è piaciuta.",
 
   // hero — score preview
-  scoreVsOthers: "vs. altri revisori IA",
+  scoreVsOthers: "valutazione aperta",
   statCostNum: "< $2*",
   statCostLabel: "per revisione",
   statCostFootnote: "*di solito :)",
@@ -48,13 +48,13 @@ export const it: Messages = {
   statOpenSourceLabel: "open source",
 
   // hero — competitive comparison
-  comparePrefix: "Valutato alla cieca rispetto a",
+  comparePrefix: "Artefatti storici affiancati con",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Ottiene punteggi più alti su copertura, specificità e profondità -- a una frazione del costo.",
-  compareLink: "Guarda il confronto →",
+    "Solo illustrativo — non è evidenza decisionale same-model né una classifica attuale.",
+  compareLink: "Sfoglia i confronti storici →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "Invia un articolo",
@@ -561,7 +561,7 @@ export const it: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Valutato da Gemini 3.1 Pro con input multimodale PDF. 5.0/5 = corrisponde alla qualità di riferimento. 5.5+/5 = la supera.",
+    "Punteggi storici da giudice LLM (Gemini 3.1 Pro, PDF multimodale). Scala nativa 1–6: 5,0 = corrisponde alla qualità di riferimento; 5,5–6,0 = la supera. Non è evidenza di classifica a ragionamento massimo sullo stesso modello.",
   compareJudgeShow: "Mostra",
   compareJudgeHide: "Nascondi",
   compareJudgeToggleSuffix: " il prompt del giudice inviato a Gemini 3.1 Pro ",
@@ -570,7 +570,7 @@ export const it: Messages = {
   compareJudgeSystemPromptLabel: "Prompt di sistema",
   compareJudgeUserPromptLabel: "Prompt utente (articolo + revisioni inseriti in fase di esecuzione)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Copertura",
   compareMetricSpecificity: "Specificità",
   compareMetricDepth: "Profondità",
@@ -580,4 +580,6 @@ export const it: Messages = {
   compareVisitPrefix: "Visita ",
   comparePdfReviewSuffix: " revisione",
   comparePdfFallback: "Scarica il PDF se l'iframe non viene renderizzato ↓",
+  compareHistoricalBadge: "Esempio storico illustrativo — non è evidenza di classifica attuale",
+  compareEvidenceUnavailable: "Evidenza non disponibile",
 };

--- a/web/src/lib/i18n/ja.ts
+++ b/web/src/lib/i18n/ja.ts
@@ -38,7 +38,7 @@ export const ja: Messages = {
     "学術的な査読は、無償の学術労働によって成り立っています。他社はそれをビジネスにすることにしました。私たちはそれが気に入りませんでした。",
 
   // hero — score preview
-  scoreVsOthers: "他の AI レビュアーとの比較",
+  scoreVsOthers: "オープン評価",
   statCostNum: "< $2*",
   statCostLabel: "1 回のレビューあたり",
   statCostFootnote: "*通常は :)",
@@ -48,13 +48,13 @@ export const ja: Messages = {
   statOpenSourceLabel: "オープンソース",
 
   // hero — competitive comparison
-  comparePrefix: "ブラインド評価で比較した相手:",
+  comparePrefix: "次との歴史的な並列比較資料：",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "カバレッジ、具体性、深さでより高いスコアを獲得 -- しかもごくわずかな費用で。",
-  compareLink: "比較を見る →",
+    "説明用のみ — 同一モデルでの意思決定級の証拠でも、現行リーダーボードでもありません。",
+  compareLink: "歴史的な比較を見る →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "論文を投稿する",
@@ -559,7 +559,7 @@ export const ja: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Gemini 3.1 Pro が PDF のマルチモーダル入力で評価しました。5.0/5 = リファレンスと同等の品質。5.5+/5 = それを上回ります。",
+    "歴史的な LLM 審査スコア（Gemini 3.1 Pro、PDF マルチモーダル）。ネイティブ 1–6 尺度：5.0 = リファレンスと同等、5.5–6.0 = それを上回る。同一モデル最大推論のリーダーボード証拠ではありません。",
   compareJudgeShow: "表示",
   compareJudgeHide: "非表示",
   compareJudgeToggleSuffix: " Gemini 3.1 Pro に送信された判定プロンプト ",
@@ -568,7 +568,7 @@ export const ja: Messages = {
   compareJudgeSystemPromptLabel: "システムプロンプト",
   compareJudgeUserPromptLabel: "ユーザープロンプト（論文 + レビューは実行時に挿入されます）",
   compareVsMid: " 対 ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "カバレッジ",
   compareMetricSpecificity: "具体性",
   compareMetricDepth: "深さ",
@@ -578,4 +578,6 @@ export const ja: Messages = {
   compareVisitPrefix: "次にアクセス ",
   comparePdfReviewSuffix: " のレビュー",
   comparePdfFallback: "iframe が表示されない場合は PDF をダウンロードしてください ↓",
+  compareHistoricalBadge: "歴史的な説明用の例 — 現行リーダーボードの証拠ではありません",
+  compareEvidenceUnavailable: "証拠なし",
 };

--- a/web/src/lib/i18n/ko.ts
+++ b/web/src/lib/i18n/ko.ts
@@ -38,7 +38,7 @@ export const ko: Messages = {
     "학술 동료 심사는 무보수 학술 노동으로 굴러갑니다. 누군가는 그것으로 사업을 벌이기로 했습니다. 우리는 그게 마음에 들지 않았습니다.",
 
   // hero — score preview
-  scoreVsOthers: "다른 AI 리뷰어 대비",
+  scoreVsOthers: "공개 평가",
   statCostNum: "< $2*",
   statCostLabel: "리뷰당",
   statCostFootnote: "*보통은 그렇습니다 :)",
@@ -48,13 +48,13 @@ export const ko: Messages = {
   statOpenSourceLabel: "오픈 소스",
 
   // hero — competitive comparison
-  comparePrefix: "블라인드 평가 대상:",
+  comparePrefix: "다음과의 과거 나란히 비교 자료:",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "훨씬 적은 비용으로 범위, 구체성, 깊이에서 더 높은 점수를 받습니다.",
-  compareLink: "나란히 비교 보기 →",
+    "예시용일 뿐 — 동일 모델 의사결정급 증거가 아니며 현재 리더보드도 아닙니다.",
+  compareLink: "과거 비교 보기 →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "논문 제출",
@@ -559,7 +559,7 @@ export const ko: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "PDF 멀티모달 입력으로 Gemini 3.1 Pro가 평가했습니다. 5.0/5 = 참조 품질과 동등. 5.5+/5 = 그 이상.",
+    "과거 LLM 심사 점수(Gemini 3.1 Pro, PDF 멀티모달). 고유 1–6 척도: 5.0 = 참조 품질과 동등, 5.5–6.0 = 그 이상. 동일 모델 최대 추론 리더보드 증거가 아닙니다.",
   compareJudgeShow: "보기",
   compareJudgeHide: "숨기기",
   compareJudgeToggleSuffix: " Gemini 3.1 Pro에 전송된 심사 프롬프트 ",
@@ -568,7 +568,7 @@ export const ko: Messages = {
   compareJudgeSystemPromptLabel: "시스템 프롬프트",
   compareJudgeUserPromptLabel: "사용자 프롬프트(논문 + 리뷰가 런타임에 삽입됨)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "범위",
   compareMetricSpecificity: "구체성",
   compareMetricDepth: "깊이",
@@ -578,4 +578,6 @@ export const ko: Messages = {
   compareVisitPrefix: "방문: ",
   comparePdfReviewSuffix: " 리뷰",
   comparePdfFallback: "iframe이 렌더링되지 않으면 PDF를 다운로드하세요 ↓",
+  compareHistoricalBadge: "과거 예시 — 현재 리더보드 증거 아님",
+  compareEvidenceUnavailable: "증거 없음",
 };

--- a/web/src/lib/i18n/nl.ts
+++ b/web/src/lib/i18n/nl.ts
@@ -32,7 +32,7 @@ export const nl: Messages = {
   heroManifesto:
     "Academische peer review draait op onbetaalde academische arbeid. Anderen besloten daar een verdienmodel van te maken. Daar waren wij niet van gediend.",
 
-  scoreVsOthers: "vs. andere AI-reviewers",
+  scoreVsOthers: "open evaluatie",
   statCostNum: "< $2*",
   statCostLabel: "per review",
   statCostFootnote: "*meestal :)",
@@ -41,13 +41,13 @@ export const nl: Messages = {
   statOpenSourceNum: "MIT",
   statOpenSourceLabel: "open source",
 
-  comparePrefix: "Blind geëvalueerd tegen",
+  comparePrefix: "Historische side-by-side-artefacten met",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Scoort hoger op dekking, specificiteit en diepgang -- tegen een fractie van de kosten.",
-  compareLink: "Bekijk de vergelijking →",
+    "Alleen illustratief — geen beslissingsrijpe same-model-evidence of een actuele ranglijst.",
+  compareLink: "Bekijk historische vergelijkingen →",
 
   formSubmitHeading: "Dien een artikel in",
   fieldPaper: "Artikel",
@@ -538,7 +538,7 @@ export const nl: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Geëvalueerd door Gemini 3.1 Pro met multimodale PDF-invoer. 5.0/5 = evenaart de referentiekwaliteit. 5.5+/5 = overtreft die.",
+    "Historische LLM-als-rechter-scores (Gemini 3.1 Pro, multimodale PDF). Native schaal 1–6: 5,0 = evenaart referentiekwaliteit; 5,5–6,0 = overtreft die. Geen same-model maximum-reasoning-ranglijstevidence.",
   compareJudgeShow: "Toon",
   compareJudgeHide: "Verberg",
   compareJudgeToggleSuffix: " de juryprompt die naar Gemini 3.1 Pro is gestuurd ",
@@ -547,7 +547,7 @@ export const nl: Messages = {
   compareJudgeSystemPromptLabel: "Systeemprompt",
   compareJudgeUserPromptLabel: "Gebruikersprompt (artikel + reviews tijdens runtime ingevoegd)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Dekking",
   compareMetricSpecificity: "Specificiteit",
   compareMetricDepth: "Diepgang",
@@ -557,4 +557,6 @@ export const nl: Messages = {
   compareVisitPrefix: "Bezoek ",
   comparePdfReviewSuffix: " review",
   comparePdfFallback: "Download de PDF als de iframe niet weergeeft ↓",
+  compareHistoricalBadge: "Historisch illustratief voorbeeld — geen actuele ranglijstevidence",
+  compareEvidenceUnavailable: "Evidence niet beschikbaar",
 };

--- a/web/src/lib/i18n/pt.ts
+++ b/web/src/lib/i18n/pt.ts
@@ -38,7 +38,7 @@ export const pt: Messages = {
     "A revisão por pares académica assenta em trabalho académico não remunerado. Outros decidiram fazer disso um negócio. Nós não gostámos.",
 
   // hero — score preview
-  scoreVsOthers: "vs. outros revisores de IA",
+  scoreVsOthers: "avaliação aberta",
   statCostNum: "< $2*",
   statCostLabel: "por revisão",
   statCostFootnote: "*normalmente :)",
@@ -48,13 +48,13 @@ export const pt: Messages = {
   statOpenSourceLabel: "código aberto",
 
   // hero — competitive comparison
-  comparePrefix: "Avaliado às cegas contra",
+  comparePrefix: "Artefatos históricos lado a lado com",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "Pontua mais alto em cobertura, especificidade e profundidade -- por uma fração do custo.",
-  compareLink: "Veja a comparação →",
+    "Apenas ilustrativo — não é evidência decisória com o mesmo modelo nem um ranking atual.",
+  compareLink: "Ver comparações históricas →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "Submeter um artigo",
@@ -560,7 +560,7 @@ export const pt: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "Avaliado pelo Gemini 3.1 Pro com entrada multimodal de PDF. 5,0/5 = corresponde à qualidade da referência. 5,5+/5 = supera-a.",
+    "Pontuações históricas de juiz LLM (Gemini 3.1 Pro, PDF multimodal). Escala nativa 1–6: 5,0 = corresponde à qualidade de referência; 5,5–6,0 = supera-a. Não é evidência de ranking com raciocínio máximo no mesmo modelo.",
   compareJudgeShow: "Mostrar",
   compareJudgeHide: "Ocultar",
   compareJudgeToggleSuffix: " o prompt de juiz enviado ao Gemini 3.1 Pro ",
@@ -569,7 +569,7 @@ export const pt: Messages = {
   compareJudgeSystemPromptLabel: "Prompt de sistema",
   compareJudgeUserPromptLabel: "Prompt de utilizador (artigo + revisões injetados em tempo de execução)",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "Cobertura",
   compareMetricSpecificity: "Especificidade",
   compareMetricDepth: "Profundidade",
@@ -579,4 +579,6 @@ export const pt: Messages = {
   compareVisitPrefix: "Visitar ",
   comparePdfReviewSuffix: " revisão",
   comparePdfFallback: "Transfira o PDF se o iframe não renderizar ↓",
+  compareHistoricalBadge: "Exemplo histórico ilustrativo — não é evidência de ranking atual",
+  compareEvidenceUnavailable: "Evidência indisponível",
 };

--- a/web/src/lib/i18n/zh-Hans.ts
+++ b/web/src/lib/i18n/zh-Hans.ts
@@ -39,7 +39,7 @@ export const zhHans: Messages = {
     "学术同行评审依靠无偿的学术劳动运转。有些人却决定借此牟利。我们对此并不认同。",
 
   // hero — score preview
-  scoreVsOthers: "对比其他 AI 评审工具",
+  scoreVsOthers: "开放评估",
   statCostNum: "< $2*",
   statCostLabel: "每次评审",
   statCostFootnote: "*通常如此 :)",
@@ -49,13 +49,13 @@ export const zhHans: Messages = {
   statOpenSourceLabel: "开源",
 
   // hero — competitive comparison
-  comparePrefix: "盲测对比",
+  comparePrefix: "与以下对象的历史并排对照材料：",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "在覆盖度、针对性和深度上得分更高——而成本只是其中的一小部分。",
-  compareLink: "查看并排对比 →",
+    "仅供示意——并非同模型决策级证据，也不是当前排行榜。",
+  compareLink: "浏览历史对照 →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "提交论文",
@@ -560,7 +560,7 @@ export const zhHans: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "由 Gemini 3.1 Pro 通过 PDF 多模态输入评估。5.0/5 = 与参考质量相当。5.5+/5 = 超过参考质量。",
+    "历史性 LLM 评判分数（Gemini 3.1 Pro，PDF 多模态）。原生 1–6 分制：5.0 = 与参考质量相当；5.5–6.0 = 超过参考质量。并非同模型最大推理的排行榜证据。",
   compareJudgeShow: "显示",
   compareJudgeHide: "隐藏",
   compareJudgeToggleSuffix: " 发送给 Gemini 3.1 Pro 的评判提示词 ",
@@ -569,7 +569,7 @@ export const zhHans: Messages = {
   compareJudgeSystemPromptLabel: "系统提示词",
   compareJudgeUserPromptLabel: "用户提示词（论文 + 评审在运行时注入）",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "覆盖度",
   compareMetricSpecificity: "针对性",
   compareMetricDepth: "深度",
@@ -579,4 +579,6 @@ export const zhHans: Messages = {
   compareVisitPrefix: "访问 ",
   comparePdfReviewSuffix: " 评审",
   comparePdfFallback: "如果 iframe 未渲染，请下载 PDF ↓",
+  compareHistoricalBadge: "历史示意示例——并非当前排行榜证据",
+  compareEvidenceUnavailable: "证据不可用",
 };

--- a/web/src/lib/i18n/zh-Hant.ts
+++ b/web/src/lib/i18n/zh-Hant.ts
@@ -38,7 +38,7 @@ export const zhHant: Messages = {
     "學術同儕審查仰賴未支薪的學術勞動。有些人決定把這當成生意來經營。我們並不認同。",
 
   // hero — score preview
-  scoreVsOthers: "對比其他 AI 審查工具",
+  scoreVsOthers: "開放評估",
   statCostNum: "< $2*",
   statCostLabel: "每次審查",
   statCostFootnote: "*通常如此 :)",
@@ -48,13 +48,13 @@ export const zhHant: Messages = {
   statOpenSourceLabel: "開放原始碼",
 
   // hero — competitive comparison
-  comparePrefix: "盲測評比對象",
+  comparePrefix: "與以下對象的歷史並排對照材料：",
   compareRefine: "refine.ink",
   compareStanford: "Stanford Agentic Reviewer",
   compareReviewer3: "reviewer3.com",
   compareSuffix:
-    "在涵蓋度、具體性與深度上得分更高——而成本只是其中的一小部分。",
-  compareLink: "查看並列比較 →",
+    "僅供示意——並非同模型決策級證據，也不是目前排行榜。",
+  compareLink: "瀏覽歷史對照 →",
 
   // submit form — section heading + paper field
   formSubmitHeading: "提交論文",
@@ -556,7 +556,7 @@ export const zhHant: Messages = {
   compareScoresColSonnet: "Sonnet 4.6",
   compareScoresColKimi: "Kimi K2.5",
   compareScoresFootnote:
-    "由 Gemini 3.1 Pro 以 PDF 多模態輸入進行評估。5.0/5 = 達到參考標準的品質。5.5+/5 = 超越它。",
+    "歷史性 LLM 評判分數（Gemini 3.1 Pro，PDF 多模態）。原生 1–6 分制：5.0 = 達到參考標準品質；5.5–6.0 = 超越它。並非同模型最大推理的排行榜證據。",
   compareJudgeShow: "顯示",
   compareJudgeHide: "隱藏",
   compareJudgeToggleSuffix: " 送往 Gemini 3.1 Pro 的評審提示 ",
@@ -565,7 +565,7 @@ export const zhHant: Messages = {
   compareJudgeSystemPromptLabel: "系統提示",
   compareJudgeUserPromptLabel: "使用者提示（論文與審查於執行時注入）",
   compareVsMid: " vs ",
-  compareScoreOutOf: "/5",
+  compareScoreOutOf: "/6",
   compareMetricCoverage: "涵蓋度",
   compareMetricSpecificity: "具體性",
   compareMetricDepth: "深度",
@@ -575,4 +575,6 @@ export const zhHant: Messages = {
   compareVisitPrefix: "造訪 ",
   comparePdfReviewSuffix: " 審查",
   comparePdfFallback: "若 iframe 未能呈現，請下載 PDF ↓",
+  compareHistoricalBadge: "歷史示意示例——並非目前排行榜證據",
+  compareEvidenceUnavailable: "證據不可用",
 };

--- a/web/tests/compareScores.test.ts
+++ b/web/tests/compareScores.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NA_SCORES,
+  QUALITY_JUDGE_SCALE_MAX,
+  classifyScoreEvidence,
+  formatScoreForDisplay,
+  isHistoricalIllustrative,
+  parseQualityScores,
+  parseScoreFraction,
+  resolveCompareEvidence,
+  scoreDenominatorSuffix,
+  scoreExceedsDenominator,
+  scoreNumeratorLabel,
+} from "@/lib/compareScores";
+
+const SAMPLE_REPORT = `# Quality Evaluation
+
+## Overall Score: 5.83/6.0
+
+## Dimensions
+
+| Dimension | Score | Reasoning |
+|-----------|-------|-----------|
+| coverage | 6.0/6 | Finds real issues. |
+| specificity | 5.5/6 | Precise quotes. |
+| depth | 6.0/6 | Deep engagement. |
+`;
+
+describe("parseQualityScores", () => {
+  it("keeps the native /6 denominator (no /5 substitution)", () => {
+    const scores = parseQualityScores(SAMPLE_REPORT);
+    expect(scores.overall).toBe("5.83/6.0");
+    expect(scores.coverage).toBe("6.0/6");
+    expect(scores.specificity).toBe("5.5/6");
+    expect(scores.depth).toBe("6.0/6");
+    for (const value of Object.values(scores)) {
+      expect(scoreExceedsDenominator(value)).toBe(false);
+      expect(value.endsWith("/5")).toBe(false);
+    }
+  });
+
+  it("returns N/A dimensions when the report has no scores", () => {
+    expect(parseQualityScores("# empty")).toEqual(NA_SCORES);
+  });
+});
+
+describe("score scale display", () => {
+  it("parses fractions and formats numerator/denominator separately", () => {
+    const frac = parseScoreFraction("5.83/6.0");
+    expect(frac).toEqual({ numerator: 5.83, denominator: 6, display: "5.83/6" });
+    expect(scoreNumeratorLabel("5.83/6.0")).toBe("5.83");
+    expect(scoreDenominatorSuffix("5.83/6.0")).toBe("/6");
+    expect(scoreDenominatorSuffix("N/A")).toBe(`/${QUALITY_JUDGE_SCALE_MAX}`);
+  });
+
+  it("flags impossible displays created by denominator substitution", () => {
+    expect(scoreExceedsDenominator("5.83/5")).toBe(true);
+    expect(formatScoreForDisplay("5.83/5").exceedsDenominator).toBe(true);
+    expect(formatScoreForDisplay("5.0/6").exceedsDenominator).toBe(false);
+  });
+
+  it("surfaces unavailable evidence without inventing a score", () => {
+    const missing = formatScoreForDisplay("N/A", "Evidence unavailable");
+    expect(missing).toEqual({
+      text: "Evidence unavailable",
+      available: false,
+      exceedsDenominator: false,
+    });
+    expect(formatScoreForDisplay("not-a-score").available).toBe(false);
+  });
+});
+
+describe("historical artifact labelling", () => {
+  it("labels file-backed LLM-judge scores as historical illustrative", () => {
+    const scores = parseQualityScores(SAMPLE_REPORT);
+    const kind = classifyScoreEvidence(scores);
+    expect(kind).toBe("historical_llm_judge");
+    expect(isHistoricalIllustrative(kind)).toBe(true);
+  });
+
+  it("labels missing scores as unavailable evidence", () => {
+    expect(classifyScoreEvidence(NA_SCORES)).toBe("unavailable");
+    expect(isHistoricalIllustrative("unavailable")).toBe(false);
+  });
+
+  it("prefers run_manifest when a manifest path is present", () => {
+    const scores = parseQualityScores(SAMPLE_REPORT);
+    expect(
+      classifyScoreEvidence(scores, {
+        model: "openai/gpt-5",
+        effort: "max",
+        sampleSize: 30,
+        date: "2026-08-01",
+        benchmarkVersion: "spot-v1",
+        confidenceInterval: "95%",
+        manifestPath: "output/runs/example.json",
+      }),
+    ).toBe("run_manifest");
+  });
+
+  it("resolveCompareEvidence bundles display + provenance for the UI", () => {
+    const resolved = resolveCompareEvidence({
+      scores: parseQualityScores(SAMPLE_REPORT),
+    });
+    expect(resolved.historical).toBe(true);
+    expect(resolved.overall.text).toBe("5.83/6");
+    expect(resolved.overall.exceedsDenominator).toBe(false);
+    expect(resolved.manifest).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Public comparison UI no longer claims Coarse beats named systems without decision-grade evidence, and scores keep their native judge scale.

- Homepage: remove unsupported `5+ / 5` winner framing; point to open/historical evaluation posture
- Compare loader: stop rewriting `/6` → `/5` (which could display numerators above the denominator)
- Compare page: show native scale denominators; label artifacts as historical/illustrative; surface unavailable evidence clearly
- Types/helpers ready to consume run manifests (model/effort/config/sample size/date/benchmark version/CIs) once #273 lands
- Vitest coverage for score parsing, scale display, unavailable evidence, and historical labelling
- English + all 11 translated catalogs updated consistently (438 keys)

## Why

Fixes #271 (Phase 0 public-trust). Live marketing must not outrun reproducible evidence.

## Checklist

- [x] Tests pass (`cd web && npx vitest run` — 23 tests)
- [x] Typecheck passes (`cd web && npx tsc --noEmit`)
- [ ] Lint passes (`uv run ruff check src/ tests/`) — N/A for this web-only PR (no `src/` Python changes)
- [x] CHANGELOG.md updated
- [x] Version bumped in `pyproject.toml` and `src/coarse/__init__.py` (if releasing) — N/A web-only
- [ ] Vercel preview visually checked before merge (AC-5 — maintainer/preview)

## Acceptance criteria mapping

- **AC-1**: Homepage + compare copy no longer claim beats named systems without linked reproducible evidence
- **AC-2**: Native `/6` scale retained; no denominator substitution that can exceed the scale
- **AC-3**: `web/tests/compareScores.test.ts` covers parsing, scale display, unavailable evidence, historical labelling
- **AC-4**: All 12 locale catalogs stay key-complete (438 keys; Python guard updated)
- **AC-5**: Preview check noted for merge

Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>