### PR TITLE
chore(release): prepare v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.9.2 — 2026-08-27
+
 ### Added
 
 - **New comprehensive architecture guide and component documentation.** Reorganized planning documentation into `docs/plans/`. Added `docs/architecture.md` featuring Mermaid subsystem component trees, review pipeline workflow diagram, Table of Contents sitemap, and quality/recall benchmark suite documentation. Added `docs/cli_reference.md` for CLI command and configuration details. Docs-only — no package change.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure,
 
 ## Version
 
-1.9.1
+1.9.2
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coarse-ink"
-version = "1.9.1"
+version = "1.9.2"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
 license = "MIT"

--- a/src/coarse/__init__.py
+++ b/src/coarse/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 
 from coarse.pipeline import extract_and_structure, review_paper  # noqa: F401

--- a/src/coarse/_skills/claude_code/SKILL.md
+++ b/src/coarse/_skills/claude_code/SKILL.md
@@ -31,7 +31,7 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -45,13 +45,13 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `claude` CLI logged in.
 
 ## How to run
@@ -69,12 +69,12 @@ Use a **per-review unique log file** so parallel runs in the same shell don't cl
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns within 2 seconds with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host claude [--model claude-opus-5] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --attach "$LOG"
 ```
 
@@ -100,12 +100,12 @@ If the user came from the coarse web form, they'll paste a handoff URL instead o
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host claude [--model ...] [--effort ...]
 
 # STEP 2b — wait (same long-timeout discipline as local mode)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/codex/SKILL.md
+++ b/src/coarse/_skills/codex/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `codex` CLI logged in: `codex login`.
 
 ## How to run
@@ -61,12 +61,12 @@ Step 1 detaches the worker (~2 seconds) and writes `<log>.pid`. Step 2 uses `--a
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns in ~2s)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host codex [--model gpt-5.6-sol] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --attach "$LOG"
 ```
 
@@ -96,12 +96,12 @@ These map to Codex's internal reasoning effort:
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host codex
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/gemini_cli/SKILL.md
+++ b/src/coarse/_skills/gemini_cli/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.1' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `gemini` CLI signed in (first run prompts for OAuth).
 
 ## How to run
@@ -63,12 +63,12 @@ Use a **per-review unique log file** so parallel runs don't clobber each other's
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch (returns in ~2s with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path_or_handoff_url> --host gemini [--model gemini-3.6-flash] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --attach "$LOG"
 ```
 
@@ -92,12 +92,12 @@ Available effort levels: `low`, `medium`, `high` (default), `max`.
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host gemini
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.9.1' \
+uvx --python 3.12 --from 'coarse-ink==1.9.2' \
   coarse-review --attach "$LOG"
 ```
 

--- a/tests/test_headless_instructions.py
+++ b/tests/test_headless_instructions.py
@@ -30,11 +30,11 @@ def test_bundled_skill_assets_use_ephemeral_uvx_flow() -> None:
         # that lands this branch on main. See CHANGELOG.md ## Unreleased
         # "RELEASE BLOCKER" note — DEFAULT_MCP_UVX_FROM and these SKILL.md
         # files must all flip from the temporary git-ref pin to
-        # ``coarse-ink==1.9.1`` as part of the release cut. The `[mcp]`
+        # ``coarse-ink==1.9.2`` as part of the release cut. The `[mcp]`
         # extra was dropped to cut the uvx install from ~114 to ~60
         # packages — the handoff flow does not need fastmcp or
         # pymupdf4llm.
-        assert "uvx --python 3.12 --from 'coarse-ink==1.9.1'" in text
+        assert "uvx --python 3.12 --from 'coarse-ink==1.9.2'" in text
         assert "coarse install-skills --all --force" in text
         # Per-review unique log file: every skill uses a LOG env var
         # derived from a per-paper suffix so parallel runs in the same
@@ -140,7 +140,7 @@ def test_web_handoff_assets_use_shared_uvx_prompt_flow() -> None:
     # as part of the release cut. The release-blocker coupling test
     # in `test_release_blocker_pin_is_coupled_to_unreleased_version`
     # enforces that this pin matches `__version__`.
-    assert '"coarse-ink==1.9.1"' in handoff_lib
+    assert '"coarse-ink==1.9.2"' in handoff_lib
     assert "@feat/mcp-server" not in handoff_lib
     assert "@feat/mcp-server" not in handoff_route
 

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "coarse-ink"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },

--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -91,13 +91,13 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 // The variable is still called `DEFAULT_MCP_UVX_FROM` for backward
 // compatibility with the `test_release_blocker_pin_is_coupled_to_unreleased_version`
 // drift test that enforces the pin matches `__version__`.
-const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.9.1";
+const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.9.2";
 
 export function resolvePinnedUvFrom(): string {
   const raw = (process.env.NEXT_PUBLIC_COARSE_UVX_FROM ?? "").trim();
   if (!raw) return DEFAULT_MCP_UVX_FROM;
   // Allowlist for `NEXT_PUBLIC_COARSE_UVX_FROM` overrides. Accepts:
-  //   1. Plain semver pin: `coarse-ink==1.9.1` (production default).
+  //   1. Plain semver pin: `coarse-ink==1.9.2` (production default).
   //   2. `[mcp]` extra form for operators who want the MCP path.
   //   3. Commit-sha git ref for pinned dev testing.
   //   4. `@dev` or `@main` branch ref — self-updating Preview default,


### PR DESCRIPTION
## What

Prepare patch release v1.9.2 after the exact-head preview signoff:

- bump `pyproject.toml`, `src/coarse/__init__.py`, and `uv.lock` to 1.9.2
- move the current Unreleased entries under `v1.9.2 — 2026-08-27`
- update the README version and every bundled/web `coarse-ink==1.9.2` handoff pin
- update version-coupling regression assertions

## Release contents

- fix blind extraction QA in subscription-backed PDF reviews
- force vision QA through OpenRouter while review reasoning remains on the selected headless host
- fail closed on unsupported multimodal headless content
- rebuild legacy unversioned PDF caches once
- restore a clean npm production dependency audit
- include the new architecture/CLI documentation

## Preview signoff

Exact `dev` code before this metadata-only bump passed:

- Vercel Preview and Modal preview deployments
- subscription PDF handoff: real rendered images reached QA, `provider = openrouter`, QA completed, callback finalized in preview Supabase, no Modal invocation, exact row absent from production
- hosted OpenRouter flow: preview Modal invocation completed in 289 seconds, finalized in preview Supabase, exact row absent from production

## Verification

- `make check` — 1,356 passed, 1 deselected; Ruff and security scanner clean
- `bash scripts/doc-sync-check.sh` — passed
- `make release-audit` repo-local guard — passed
- `npm audit --omit=dev` — zero vulnerabilities
- `npm test` — 14 passed
- `npm run build` — passed
- `uv build` — produced `coarse_ink-1.9.2` sdist and wheel

This PR targets `dev`; after it merges and checks pass, the final release PR will be `dev` → `main`, followed by tag `v1.9.2`.