### PR TITLE
feat(llm): support openai/gpt-5.6-sol-pro on the direct OpenAI route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **`--model openai/gpt-5.6-sol-pro` now works with a direct `OPENAI_API_KEY`.** The `-pro` suffix is an OpenRouter-only variant ID that OpenAI's own API rejects with 404. On the direct OpenAI route, the client now translates it to the real model `gpt-5.6-sol` plus a `reasoning: {"mode": "pro"}` request body (and suppresses the conflicting default `reasoning_effort`); the OpenRouter route keeps sending the variant ID untouched. The variant's pricing and 272k long-context tier are registered (identical to base Sol per OpenRouter), so the pre-flight cost gate no longer quotes $0 for it. The new `DIRECT_REQUEST_MODEL_ALIASES` table in `models.py` makes further OpenRouter-only variants one-line additions.
+- **`--model openai/gpt-5.6-sol-pro` now works with a direct `OPENAI_API_KEY`.** The `-pro` suffix is an OpenRouter-only variant ID that OpenAI's own API rejects with 404. On the direct OpenAI route, the client now translates it to `gpt-5.6-sol` and uses the stateless Responses API (`store: false`) with `reasoning: {"mode": "pro", "effort": "medium"}`; callers can still override effort independently. The OpenRouter route keeps sending the variant ID through Chat Completions unchanged. The variant's pricing and 272k long-context tier are registered (identical to base Sol per OpenRouter), so the pre-flight cost gate no longer quotes $0 for it.
 
 ## v1.9.2 — 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **`--model openai/gpt-5.6-sol-pro` now works with a direct `OPENAI_API_KEY`.** The `-pro` suffix is an OpenRouter-only variant ID that OpenAI's own API rejects with 404. On the direct OpenAI route, the client now translates it to the real model `gpt-5.6-sol` plus a `reasoning: {"mode": "pro"}` request body (and suppresses the conflicting default `reasoning_effort`); the OpenRouter route keeps sending the variant ID untouched. The variant's pricing and 272k long-context tier are registered (identical to base Sol per OpenRouter), so the pre-flight cost gate no longer quotes $0 for it. The new `DIRECT_REQUEST_MODEL_ALIASES` table in `models.py` makes further OpenRouter-only variants one-line additions.
+
 ## v1.9.2 — 2026-08-27
 
 ### Added

--- a/src/coarse/llm.py
+++ b/src/coarse/llm.py
@@ -26,6 +26,7 @@ from coarse.config import (
 )
 from coarse.model_registry import register_model_costs
 from coarse.models import (
+    DIRECT_REQUEST_MODEL_ALIASES,
     JSON_MODE_PREFIXES,
     MARKDOWN_JSON_PREFIXES,
     OPENROUTER_NAMESPACE_MODELS,
@@ -376,6 +377,16 @@ class LLMClient:
             config = load_config()
         self._model = model or config.default_model
         self._model = _normalize_model(self._model, config)
+        # Some OpenRouter variant IDs don't exist on the provider's own API
+        # (e.g. openai/gpt-5.6-sol-pro → OpenAI 404s). On the direct route,
+        # rewrite to the provider's real model ID and carry the variant's
+        # extra request body (merged into extra_body at call time). The
+        # lookup is keyed on bare IDs, so OpenRouter-proxied models — already
+        # `openrouter/`-prefixed by _normalize_model — never match.
+        self._extra_request_body: dict[str, object] | None = None
+        alias = DIRECT_REQUEST_MODEL_ALIASES.get(self._model)
+        if alias is not None:
+            self._model, self._extra_request_body = alias[0], dict(alias[1])
         self._mode = _select_instructor_mode(self._model)
         self._client = instructor.from_litellm(_sanitized_completion, mode=self._mode)
         self._structured_fallback_mode = _select_fallback_instructor_mode(self._model, self._mode)
@@ -398,6 +409,21 @@ class LLMClient:
         # it through call_kwargs removes every call-time read from the
         # dependency chain and closes the race.
         self._api_key: str | None = resolve_api_key(self._model, config)
+
+    def _merge_extra_request_body(self, call_kwargs: dict) -> dict:
+        """Merge the direct-request alias body into ``extra_body``.
+
+        Caller-supplied ``extra_body`` keys win over the alias defaults.
+        No-op (returns ``call_kwargs`` unchanged) when no alias applies.
+        """
+        if not self._extra_request_body:
+            return call_kwargs
+        merged = dict(call_kwargs)
+        merged["extra_body"] = {
+            **self._extra_request_body,
+            **(call_kwargs.get("extra_body") or {}),
+        }
+        return merged
 
     def _complete_with_client(
         self,
@@ -485,8 +511,20 @@ class LLMClient:
         # as "already set"). A caller can still disable by passing a
         # real string like "low" or by passing a non-None sentinel.
         call_kwargs = dict(kwargs)
-        if self._is_reasoning and call_kwargs.get("reasoning_effort") is None:
+        # When a direct-request alias already sets a `reasoning` body (e.g.
+        # {"mode": "pro"}), the default reasoning_effort would conflict with
+        # it — pro mode IS the reasoning setting. An explicit caller-passed
+        # reasoning_effort still goes through untouched, as before.
+        alias_sets_reasoning = bool(self._extra_request_body) and (
+            "reasoning" in self._extra_request_body
+        )
+        if (
+            self._is_reasoning
+            and call_kwargs.get("reasoning_effort") is None
+            and not alias_sets_reasoning
+        ):
             call_kwargs["reasoning_effort"] = REASONING_EFFORT_DEFAULT
+        call_kwargs = self._merge_extra_request_body(call_kwargs)
         if _is_openrouter_kimi_model(self._model):
             call_kwargs = _prepare_openrouter_kimi_structured_kwargs(call_kwargs)
         # Forward the eagerly-resolved API key on every call so the litellm
@@ -558,7 +596,7 @@ class LLMClient:
         stripped via _sanitized_completion.
         """
         clamped = _clamp_max_tokens(self._model, max_tokens)
-        call_kwargs = dict(kwargs)
+        call_kwargs = self._merge_extra_request_body(dict(kwargs))
         # Forward the eagerly-resolved API key on every call (same rationale
         # as complete() — avoids the env-var-at-call-time race that was
         # landing "Missing Authentication header" 401s in prod).

--- a/src/coarse/llm.py
+++ b/src/coarse/llm.py
@@ -26,7 +26,7 @@ from coarse.config import (
 )
 from coarse.model_registry import register_model_costs
 from coarse.models import (
-    DIRECT_REQUEST_MODEL_ALIASES,
+    DIRECT_RESPONSES_MODEL_ALIASES,
     JSON_MODE_PREFIXES,
     MARKDOWN_JSON_PREFIXES,
     OPENROUTER_NAMESPACE_MODELS,
@@ -160,6 +160,19 @@ def _sanitized_completion(*args, **kwargs):
             msg.content = _CTRL_CHAR_RE.sub("", msg.content)
             msg.content = msg.content.replace("\\u0000", "")
     return response
+
+
+def _responses_completion(*, messages: list[dict], **kwargs):
+    """Adapt Instructor's chat-shaped call to LiteLLM's Responses API."""
+    return litellm.responses(input=messages, **kwargs)
+
+
+def _build_responses_create() -> Callable[..., BaseModel]:
+    """Build an Instructor-patched Responses API callable."""
+    return instructor.patch(
+        create=_responses_completion,
+        mode=instructor.Mode.RESPONSES_TOOLS,
+    )
 
 
 def _extract_completion_text(completion: object) -> str | None:
@@ -379,14 +392,14 @@ class LLMClient:
         self._model = _normalize_model(self._model, config)
         # Some OpenRouter variant IDs don't exist on the provider's own API
         # (e.g. openai/gpt-5.6-sol-pro → OpenAI 404s). On the direct route,
-        # rewrite to the provider's real model ID and carry the variant's
-        # extra request body (merged into extra_body at call time). The
-        # lookup is keyed on bare IDs, so OpenRouter-proxied models — already
-        # `openrouter/`-prefixed by _normalize_model — never match.
-        self._extra_request_body: dict[str, object] | None = None
-        alias = DIRECT_REQUEST_MODEL_ALIASES.get(self._model)
+        # rewrite to the provider's real model ID and use the Responses API
+        # with the variant's request defaults. The lookup is keyed on bare
+        # IDs, so OpenRouter-proxied models — already `openrouter/`-prefixed by
+        # _normalize_model — never match.
+        self._responses_request_body: dict[str, object] | None = None
+        alias = DIRECT_RESPONSES_MODEL_ALIASES.get(self._model)
         if alias is not None:
-            self._model, self._extra_request_body = alias[0], dict(alias[1])
+            self._model, self._responses_request_body = alias[0], dict(alias[1])
         self._mode = _select_instructor_mode(self._model)
         self._client = instructor.from_litellm(_sanitized_completion, mode=self._mode)
         self._structured_fallback_mode = _select_fallback_instructor_mode(self._model, self._mode)
@@ -394,6 +407,9 @@ class LLMClient:
             instructor.from_litellm(_sanitized_completion, mode=self._structured_fallback_mode)
             if self._structured_fallback_mode is not None
             else None
+        )
+        self._responses_create = (
+            _build_responses_create() if self._responses_request_body is not None else None
         )
         self._cost_usd: float = 0.0
         self._lock = threading.Lock()
@@ -410,20 +426,26 @@ class LLMClient:
         # dependency chain and closes the race.
         self._api_key: str | None = resolve_api_key(self._model, config)
 
-    def _merge_extra_request_body(self, call_kwargs: dict) -> dict:
-        """Merge the direct-request alias body into ``extra_body``.
-
-        Caller-supplied ``extra_body`` keys win over the alias defaults.
-        No-op (returns ``call_kwargs`` unchanged) when no alias applies.
-        """
-        if not self._extra_request_body:
+    def _prepare_responses_kwargs(self, call_kwargs: dict) -> dict:
+        """Merge direct-route defaults into Responses API kwargs."""
+        if self._responses_request_body is None:
             return call_kwargs
-        merged = dict(call_kwargs)
-        merged["extra_body"] = {
-            **self._extra_request_body,
-            **(call_kwargs.get("extra_body") or {}),
-        }
-        return merged
+        prepared = dict(call_kwargs)
+        requested_effort = prepared.pop("reasoning_effort", None)
+        caller_reasoning = dict(prepared.pop("reasoning", None) or {})
+        defaults = dict(self._responses_request_body)
+        default_reasoning = dict(defaults.pop("reasoning", {}) or {})
+        for key, value in defaults.items():
+            prepared.setdefault(key, value)
+        # The selected alias owns its mode ("-pro" must remain pro), while
+        # effort stays independently caller-configurable as OpenAI documents.
+        reasoning = {**caller_reasoning, **default_reasoning}
+        if requested_effort is not None:
+            reasoning["effort"] = requested_effort
+        else:
+            reasoning.setdefault("effort", REASONING_EFFORT_DEFAULT)
+        prepared["reasoning"] = reasoning
+        return prepared
 
     def _complete_with_client(
         self,
@@ -447,6 +469,17 @@ class LLMClient:
         just send ``None``.
         """
         try:
+            if self._responses_create is not None:
+                response = self._responses_create(
+                    model=self._model,
+                    messages=messages,
+                    response_model=response_model,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                    max_retries=3,
+                    **call_kwargs,
+                )
+                return response, getattr(response, "_raw_response", None)
             return client.chat.completions.create_with_completion(
                 model=self._model,
                 messages=messages,
@@ -511,20 +544,10 @@ class LLMClient:
         # as "already set"). A caller can still disable by passing a
         # real string like "low" or by passing a non-None sentinel.
         call_kwargs = dict(kwargs)
-        # When a direct-request alias already sets a `reasoning` body (e.g.
-        # {"mode": "pro"}), the default reasoning_effort would conflict with
-        # it — pro mode IS the reasoning setting. An explicit caller-passed
-        # reasoning_effort still goes through untouched, as before.
-        alias_sets_reasoning = bool(self._extra_request_body) and (
-            "reasoning" in self._extra_request_body
-        )
-        if (
-            self._is_reasoning
-            and call_kwargs.get("reasoning_effort") is None
-            and not alias_sets_reasoning
-        ):
+        if self._responses_create is not None:
+            call_kwargs = self._prepare_responses_kwargs(call_kwargs)
+        elif self._is_reasoning and call_kwargs.get("reasoning_effort") is None:
             call_kwargs["reasoning_effort"] = REASONING_EFFORT_DEFAULT
-        call_kwargs = self._merge_extra_request_body(call_kwargs)
         if _is_openrouter_kimi_model(self._model):
             call_kwargs = _prepare_openrouter_kimi_structured_kwargs(call_kwargs)
         # Forward the eagerly-resolved API key on every call so the litellm
@@ -592,11 +615,13 @@ class LLMClient:
 
         Used for models where instructor's structured output makes no sense
         (e.g. Perplexity Sonar Pro, which returns prose with citations).
-        Cost is tracked like complete(); control characters are still
-        stripped via _sanitized_completion.
+        Cost is tracked like complete(); control characters are stripped on
+        both the Chat Completions and Responses API paths.
         """
         clamped = _clamp_max_tokens(self._model, max_tokens)
-        call_kwargs = self._merge_extra_request_body(dict(kwargs))
+        call_kwargs = dict(kwargs)
+        if self._responses_create is not None:
+            call_kwargs = self._prepare_responses_kwargs(call_kwargs)
         # Forward the eagerly-resolved API key on every call (same rationale
         # as complete() — avoids the env-var-at-call-time race that was
         # landing "Missing Authentication header" 401s in prod).
@@ -606,13 +631,22 @@ class LLMClient:
         # ``supports_temperature`` in ``coarse.models``).
         if supports_temperature(self._model):
             call_kwargs.setdefault("temperature", temperature)
-        response = _sanitized_completion(
-            model=self._model,
-            messages=messages,
-            max_tokens=clamped,
-            timeout=timeout,
-            **call_kwargs,
-        )
+        if self._responses_create is not None:
+            response = _responses_completion(
+                model=self._model,
+                messages=messages,
+                max_output_tokens=clamped,
+                timeout=timeout,
+                **call_kwargs,
+            )
+        else:
+            response = _sanitized_completion(
+                model=self._model,
+                messages=messages,
+                max_tokens=clamped,
+                timeout=timeout,
+                **call_kwargs,
+            )
         try:
             cost = _completion_cost_with_long_context_pricing(response, self._model)
             if cost is not None:
@@ -620,10 +654,14 @@ class LLMClient:
         except Exception:
             logger.debug("Cost tracking failed for model %s", self._model, exc_info=True)
 
-        content = response.choices[0].message.content
+        content = (
+            response.output_text
+            if self._responses_create is not None
+            else response.choices[0].message.content
+        )
         if not content or not content.strip():
             raise ValueError(f"Model {self._model} returned empty response")
-        return content.strip()
+        return _CTRL_CHAR_RE.sub("", content).replace("\\u0000", "").strip()
 
     def add_cost(self, cost_usd: float) -> None:
         """Register an external cost (e.g. from a direct litellm.completion call)."""
@@ -876,8 +914,14 @@ def _completion_cost_with_long_context_pricing(response, model: str) -> float | 
     """
     standard_cost = litellm.completion_cost(completion_response=response, model=model)
     usage = getattr(response, "usage", None)
-    prompt_tokens = max(0, int(getattr(usage, "prompt_tokens", 0) or 0))
-    completion_tokens = max(0, int(getattr(usage, "completion_tokens", 0) or 0))
+    prompt_tokens = max(
+        0,
+        int(getattr(usage, "prompt_tokens", getattr(usage, "input_tokens", 0)) or 0),
+    )
+    completion_tokens = max(
+        0,
+        int(getattr(usage, "completion_tokens", getattr(usage, "output_tokens", 0)) or 0),
+    )
     base_rates = model_cost_per_token(model)
     tier_rates = model_cost_per_token(model, prompt_tokens=prompt_tokens)
     if tier_rates == base_rates:

--- a/src/coarse/model_registry.py
+++ b/src/coarse/model_registry.py
@@ -64,7 +64,7 @@ def register_model_costs() -> None:
         # and limits as base Sol (verified 2026-08-30); pro mode just spends
         # more reasoning tokens. Registered under the variant ID so the
         # pre-flight cost gate prices it before llm.py aliases the wire
-        # request to the base model (see DIRECT_REQUEST_MODEL_ALIASES).
+        # request to the base model (see DIRECT_RESPONSES_MODEL_ALIASES).
         GPT_5_6_SOL_PRO_MODEL: {
             "max_tokens": 1_050_000,
             "max_output_tokens": 128_000,

--- a/src/coarse/model_registry.py
+++ b/src/coarse/model_registry.py
@@ -18,6 +18,7 @@ from coarse.models import (
     GEMINI_3_6_FLASH_MODEL,
     GPT_5_6_LUNA_MODEL,
     GPT_5_6_SOL_MODEL,
+    GPT_5_6_SOL_PRO_MODEL,
     GPT_5_6_TERRA_MODEL,
     GROK_4_5_MODEL,
     KIMI_K3_MODEL,
@@ -54,6 +55,17 @@ def register_model_costs() -> None:
             "output_cost_per_token": 50e-6,
         },
         GPT_5_6_SOL_MODEL: {
+            "max_tokens": 1_050_000,
+            "max_output_tokens": 128_000,
+            "input_cost_per_token": 5e-6,
+            "output_cost_per_token": 30e-6,
+        },
+        # OpenRouter's pro-reasoning variant of Sol — same per-token pricing
+        # and limits as base Sol (verified 2026-08-30); pro mode just spends
+        # more reasoning tokens. Registered under the variant ID so the
+        # pre-flight cost gate prices it before llm.py aliases the wire
+        # request to the base model (see DIRECT_REQUEST_MODEL_ALIASES).
+        GPT_5_6_SOL_PRO_MODEL: {
             "max_tokens": 1_050_000,
             "max_output_tokens": 128_000,
             "input_cost_per_token": 5e-6,

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -18,8 +18,8 @@ CLAUDE_FABLE_5_MODEL = "anthropic/claude-fable-5"
 GPT_5_6_SOL_MODEL = "openai/gpt-5.6-sol"
 # OpenRouter-only variant ID for Sol's "pro" reasoning mode. The OpenAI API has
 # no model by this name — direct-OpenAI requests must be rewritten to the base
-# Sol ID plus a `reasoning: {"mode": "pro"}` body (see
-# DIRECT_REQUEST_MODEL_ALIASES below). Pricing is identical to base Sol on
+# Sol ID plus a `reasoning: {"mode": "pro"}` body on the Responses API (see
+# DIRECT_RESPONSES_MODEL_ALIASES below). Pricing is identical to base Sol on
 # OpenRouter (verified 2026-08-30); pro mode just spends more reasoning tokens.
 GPT_5_6_SOL_PRO_MODEL = "openai/gpt-5.6-sol-pro"
 GPT_5_6_TERRA_MODEL = "openai/gpt-5.6-terra"
@@ -132,15 +132,16 @@ LITELLM_OPENROUTER_PREFIX = "openrouter/"
 OPENROUTER_NAMESPACE_MODELS: frozenset[str] = frozenset({FUSION_MODEL})
 
 # OpenRouter defines variant model IDs that the underlying provider's own API
-# does not recognize. When such a model routes DIRECT to its provider (i.e.
-# ``_normalize_model`` in llm.py left it without the ``openrouter/`` prefix),
-# the wire request must use the provider's real model ID plus extra request
-# body fields. Maps variant ID → (direct model ID, extra request body). Keys
+# does not recognize. When such a model routes DIRECT to OpenAI, the wire
+# request must use the provider's real model ID plus Responses API fields.
+# Maps variant ID → (direct model ID, Responses API request defaults). Keys
 # are bare canonical IDs, so an ``openrouter/``-prefixed (proxied) model can
 # never match — the OpenRouter route keeps sending the variant ID untouched.
-# Treat the body dicts as immutable; copy before mutating.
-DIRECT_REQUEST_MODEL_ALIASES: dict[str, tuple[str, dict[str, object]]] = {
-    GPT_5_6_SOL_PRO_MODEL: (GPT_5_6_SOL_MODEL, {"reasoning": {"mode": "pro"}}),
+DIRECT_RESPONSES_MODEL_ALIASES: dict[str, tuple[str, dict[str, object]]] = {
+    GPT_5_6_SOL_PRO_MODEL: (
+        GPT_5_6_SOL_MODEL,
+        {"reasoning": {"mode": "pro"}, "store": False},
+    ),
 }
 
 # Vision model for post-extraction QA (multimodal, spot-checks Docling output)

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -16,6 +16,12 @@ CLAUDE_OPUS_5_MODEL = "anthropic/claude-opus-5"
 CLAUDE_SONNET_5_MODEL = "anthropic/claude-sonnet-5"
 CLAUDE_FABLE_5_MODEL = "anthropic/claude-fable-5"
 GPT_5_6_SOL_MODEL = "openai/gpt-5.6-sol"
+# OpenRouter-only variant ID for Sol's "pro" reasoning mode. The OpenAI API has
+# no model by this name — direct-OpenAI requests must be rewritten to the base
+# Sol ID plus a `reasoning: {"mode": "pro"}` body (see
+# DIRECT_REQUEST_MODEL_ALIASES below). Pricing is identical to base Sol on
+# OpenRouter (verified 2026-08-30); pro mode just spends more reasoning tokens.
+GPT_5_6_SOL_PRO_MODEL = "openai/gpt-5.6-sol-pro"
 GPT_5_6_TERRA_MODEL = "openai/gpt-5.6-terra"
 GPT_5_6_LUNA_MODEL = "openai/gpt-5.6-luna"
 GEMINI_3_6_FLASH_MODEL = "google/gemini-3.6-flash"
@@ -35,6 +41,13 @@ GLM_5_2_MODEL = "z-ai/glm-5.2"
 # OpenRouter ``pricing.overrides`` metadata on 2026-07-30.
 LONG_CONTEXT_PRICING_TIERS: dict[str, dict[str, int | float]] = {
     GPT_5_6_SOL_MODEL: {
+        "min_prompt_tokens": 272_000,
+        "input_cost_per_token": 10e-6,
+        "output_cost_per_token": 45e-6,
+    },
+    # Same tier as base Sol — OpenRouter reports identical pricing for the
+    # -pro variant (verified 2026-08-30).
+    GPT_5_6_SOL_PRO_MODEL: {
         "min_prompt_tokens": 272_000,
         "input_cost_per_token": 10e-6,
         "output_cost_per_token": 45e-6,
@@ -117,6 +130,18 @@ WEB_FEATURED_MODEL_IDS: tuple[str, ...] = (
 # must be doubled for litellm provider routing (see FUSION_MODEL note above).
 LITELLM_OPENROUTER_PREFIX = "openrouter/"
 OPENROUTER_NAMESPACE_MODELS: frozenset[str] = frozenset({FUSION_MODEL})
+
+# OpenRouter defines variant model IDs that the underlying provider's own API
+# does not recognize. When such a model routes DIRECT to its provider (i.e.
+# ``_normalize_model`` in llm.py left it without the ``openrouter/`` prefix),
+# the wire request must use the provider's real model ID plus extra request
+# body fields. Maps variant ID → (direct model ID, extra request body). Keys
+# are bare canonical IDs, so an ``openrouter/``-prefixed (proxied) model can
+# never match — the OpenRouter route keeps sending the variant ID untouched.
+# Treat the body dicts as immutable; copy before mutating.
+DIRECT_REQUEST_MODEL_ALIASES: dict[str, tuple[str, dict[str, object]]] = {
+    GPT_5_6_SOL_PRO_MODEL: (GPT_5_6_SOL_MODEL, {"reasoning": {"mode": "pro"}}),
+}
 
 # Vision model for post-extraction QA (multimodal, spot-checks Docling output)
 # litellm uses 'gemini/' prefix for Google AI Studio (not 'google/')

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,3 +1,7 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import instructor
@@ -158,6 +162,22 @@ def test_litellm_actual_cost_registry_has_qwen_long_context_tier():
         response,
         f"openrouter/{QWEN_3_7_PLUS_MODEL}",
     )
+    expected = threshold * float(tier["input_cost_per_token"]) + 100 * float(
+        tier["output_cost_per_token"]
+    )
+    assert actual == pytest.approx(expected)
+
+
+def test_responses_usage_fields_preserve_long_context_cost_floor():
+    tier = LONG_CONTEXT_PRICING_TIERS[GPT_5_6_SOL_MODEL]
+    threshold = int(tier["min_prompt_tokens"])
+    response = SimpleNamespace(
+        usage=SimpleNamespace(input_tokens=threshold, output_tokens=100),
+    )
+
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        actual = _completion_cost_with_long_context_pricing(response, GPT_5_6_SOL_MODEL)
+
     expected = threshold * float(tier["input_cost_per_token"]) + 100 * float(
         tier["output_cost_per_token"]
     )
@@ -1452,7 +1472,7 @@ def test_sanitized_completion_falls_back_to_positional_model():
 
 
 # ---------------------------------------------------------------------------
-# Direct-request model aliases (OpenRouter variant IDs on direct routes)
+# Direct Responses API aliases (OpenRouter variant IDs on direct routes)
 # ---------------------------------------------------------------------------
 
 
@@ -1460,11 +1480,11 @@ def test_sol_pro_direct_route_aliases_model_and_injects_reasoning_body(
     mock_instructor_client, monkeypatch
 ):
     """openai/gpt-5.6-sol-pro is an OpenRouter-only ID. With a direct OpenAI
-    key, the wire request must use the real OpenAI model (gpt-5.6-sol) plus
-    extra_body reasoning mode "pro" — and must NOT also send the default
-    reasoning_effort, which would conflict with the explicit reasoning body."""
+    key, the Responses request must use the real OpenAI model plus pro mode
+    and the independently configured default reasoning effort."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+    client._responses_create.return_value = _SimpleModel(value="ok")
     assert client.model == GPT_5_6_SOL_MODEL
 
     with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
@@ -1473,10 +1493,15 @@ def test_sol_pro_direct_route_aliases_model_and_injects_reasoning_body(
             response_model=_SimpleModel,
         )
 
-    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    call = client._responses_create.call_args
     assert call.kwargs["model"] == GPT_5_6_SOL_MODEL
-    assert call.kwargs["extra_body"] == {"reasoning": {"mode": "pro"}}
+    assert call.kwargs["reasoning"] == {
+        "mode": "pro",
+        "effort": REASONING_EFFORT_DEFAULT,
+    }
+    assert call.kwargs["store"] is False
     assert "reasoning_effort" not in call.kwargs
+    mock_instructor_client.chat.completions.create_with_completion.assert_not_called()
 
 
 def test_sol_pro_direct_route_keeps_explicit_caller_reasoning_effort(
@@ -1484,6 +1509,7 @@ def test_sol_pro_direct_route_keeps_explicit_caller_reasoning_effort(
 ):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+    client._responses_create.return_value = _SimpleModel(value="ok")
 
     with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
         client.complete(
@@ -1492,24 +1518,29 @@ def test_sol_pro_direct_route_keeps_explicit_caller_reasoning_effort(
             reasoning_effort="high",
         )
 
-    call = mock_instructor_client.chat.completions.create_with_completion.call_args
-    assert call.kwargs["reasoning_effort"] == "high"
-    assert call.kwargs["extra_body"] == {"reasoning": {"mode": "pro"}}
+    call = client._responses_create.call_args
+    assert call.kwargs["reasoning"] == {"mode": "pro", "effort": "high"}
+    assert "reasoning_effort" not in call.kwargs
 
 
-def test_sol_pro_direct_route_caller_extra_body_keys_win(mock_instructor_client, monkeypatch):
+def test_sol_pro_direct_route_owns_mode_and_preserves_caller_body(
+    mock_instructor_client, monkeypatch
+):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+    client._responses_create.return_value = _SimpleModel(value="ok")
 
     with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
         client.complete(
             messages=[{"role": "user", "content": "x"}],
             response_model=_SimpleModel,
-            extra_body={"reasoning": {"mode": "standard"}, "other": 1},
+            reasoning={"mode": "standard", "effort": "xhigh"},
+            extra_body={"other": 1},
         )
 
-    call = mock_instructor_client.chat.completions.create_with_completion.call_args
-    assert call.kwargs["extra_body"] == {"reasoning": {"mode": "standard"}, "other": 1}
+    call = client._responses_create.call_args
+    assert call.kwargs["reasoning"] == {"mode": "pro", "effort": "xhigh"}
+    assert call.kwargs["extra_body"] == {"other": 1}
 
 
 def test_sol_pro_complete_text_forwards_reasoning_body(mock_instructor_client, monkeypatch):
@@ -1518,18 +1549,99 @@ def test_sol_pro_complete_text_forwards_reasoning_body(mock_instructor_client, m
 
     def fake_completion(**kwargs):
         captured.update(kwargs)
-        return _completion_with_content("hello")
+        return SimpleNamespace(
+            output_text="hello",
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        )
 
     client = LLMClient(model=GPT_5_6_SOL_PRO_MODEL, config=CoarseConfig())
     with (
-        patch("coarse.llm.litellm.completion", side_effect=fake_completion),
+        patch("coarse.llm._responses_completion", side_effect=fake_completion),
         patch("coarse.llm.litellm.completion_cost", return_value=0.0),
     ):
         out = client.complete_text(messages=[{"role": "user", "content": "x"}])
 
     assert out == "hello"
     assert captured["model"] == GPT_5_6_SOL_MODEL
-    assert captured["extra_body"] == {"reasoning": {"mode": "pro"}}
+    assert captured["reasoning"] == {
+        "mode": "pro",
+        "effort": REASONING_EFFORT_DEFAULT,
+    }
+    assert captured["store"] is False
+    assert captured["max_output_tokens"] == 4096
+
+
+def test_sol_pro_direct_route_posts_responses_endpoint(monkeypatch):
+    """Exercise the pinned LiteLLM + Instructor stack through HTTP.
+
+    Mock-only kwargs tests cannot detect a regression back to /chat/completions.
+    """
+    captured: dict = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            captured["path"] = self.path
+            captured["body"] = json.loads(body)
+            tool_name = captured["body"]["tools"][0]["name"]
+            payload = {
+                "id": "resp_test",
+                "object": "response",
+                "created_at": 0,
+                "status": "completed",
+                "model": "gpt-5.6-sol",
+                "output": [
+                    {
+                        "id": "fc_test",
+                        "call_id": "call_test",
+                        "type": "function_call",
+                        "name": tool_name,
+                        "arguments": '{"value":"ok"}',
+                        "status": "completed",
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 1,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 1,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 2,
+                },
+            }
+            data = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    try:
+        client = LLMClient(model=GPT_5_6_SOL_PRO_MODEL, config=CoarseConfig())
+        with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+            result = client.complete(
+                messages=[{"role": "user", "content": "x"}],
+                response_model=_SimpleModel,
+                reasoning_effort="high",
+                api_base=f"http://127.0.0.1:{server.server_port}/v1",
+            )
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+    assert result.value == "ok"
+    assert captured["path"] == "/v1/responses"
+    assert captured["body"]["model"] == "gpt-5.6-sol"
+    assert captured["body"]["reasoning"] == {"mode": "pro", "effort": "high"}
+    assert captured["body"]["store"] is False
+    assert "reasoning_effort" not in captured["body"]
 
 
 def test_sol_pro_openrouter_route_keeps_variant_id_untouched(mock_instructor_client, monkeypatch):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -25,6 +25,8 @@ from coarse.models import (
     CLAUDE_OPUS_5_MODEL,
     FUSION_MODEL,
     GPT_5_6_LUNA_MODEL,
+    GPT_5_6_SOL_MODEL,
+    GPT_5_6_SOL_PRO_MODEL,
     GPT_5_6_TERRA_MODEL,
     GROK_4_5_MODEL,
     KIMI_K3_MODEL,
@@ -1447,3 +1449,113 @@ def test_sanitized_completion_falls_back_to_positional_model():
 
     # api_key must be injected even though model arrived as args[0].
     assert captured["kwargs"].get("api_key") == "sk-or-v1-fallback-positional"
+
+
+# ---------------------------------------------------------------------------
+# Direct-request model aliases (OpenRouter variant IDs on direct routes)
+# ---------------------------------------------------------------------------
+
+
+def test_sol_pro_direct_route_aliases_model_and_injects_reasoning_body(
+    mock_instructor_client, monkeypatch
+):
+    """openai/gpt-5.6-sol-pro is an OpenRouter-only ID. With a direct OpenAI
+    key, the wire request must use the real OpenAI model (gpt-5.6-sol) plus
+    extra_body reasoning mode "pro" — and must NOT also send the default
+    reasoning_effort, which would conflict with the explicit reasoning body."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+    assert client.model == GPT_5_6_SOL_MODEL
+
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        client.complete(
+            messages=[{"role": "user", "content": "x"}],
+            response_model=_SimpleModel,
+        )
+
+    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    assert call.kwargs["model"] == GPT_5_6_SOL_MODEL
+    assert call.kwargs["extra_body"] == {"reasoning": {"mode": "pro"}}
+    assert "reasoning_effort" not in call.kwargs
+
+
+def test_sol_pro_direct_route_keeps_explicit_caller_reasoning_effort(
+    mock_instructor_client, monkeypatch
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        client.complete(
+            messages=[{"role": "user", "content": "x"}],
+            response_model=_SimpleModel,
+            reasoning_effort="high",
+        )
+
+    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    assert call.kwargs["reasoning_effort"] == "high"
+    assert call.kwargs["extra_body"] == {"reasoning": {"mode": "pro"}}
+
+
+def test_sol_pro_direct_route_caller_extra_body_keys_win(mock_instructor_client, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        client.complete(
+            messages=[{"role": "user", "content": "x"}],
+            response_model=_SimpleModel,
+            extra_body={"reasoning": {"mode": "standard"}, "other": 1},
+        )
+
+    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    assert call.kwargs["extra_body"] == {"reasoning": {"mode": "standard"}, "other": 1}
+
+
+def test_sol_pro_complete_text_forwards_reasoning_body(mock_instructor_client, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    captured: dict = {}
+
+    def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return _completion_with_content("hello")
+
+    client = LLMClient(model=GPT_5_6_SOL_PRO_MODEL, config=CoarseConfig())
+    with (
+        patch("coarse.llm.litellm.completion", side_effect=fake_completion),
+        patch("coarse.llm.litellm.completion_cost", return_value=0.0),
+    ):
+        out = client.complete_text(messages=[{"role": "user", "content": "x"}])
+
+    assert out == "hello"
+    assert captured["model"] == GPT_5_6_SOL_MODEL
+    assert captured["extra_body"] == {"reasoning": {"mode": "pro"}}
+
+
+def test_sol_pro_openrouter_route_keeps_variant_id_untouched(mock_instructor_client, monkeypatch):
+    """With only an OpenRouter key, the variant ID is valid as-is on the
+    proxied route — no alias rewrite, no reasoning extra_body, and the
+    default reasoning_effort still applies."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    client = _reasoning_client(GPT_5_6_SOL_PRO_MODEL, mock_instructor_client)
+    assert client.model == f"openrouter/{GPT_5_6_SOL_PRO_MODEL}"
+
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        client.complete(
+            messages=[{"role": "user", "content": "x"}],
+            response_model=_SimpleModel,
+        )
+
+    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    assert call.kwargs["model"] == f"openrouter/{GPT_5_6_SOL_PRO_MODEL}"
+    assert "extra_body" not in call.kwargs
+    assert call.kwargs.get("reasoning_effort") == REASONING_EFFORT_DEFAULT
+
+
+def test_sol_pro_variant_has_registered_pricing():
+    # The pre-flight cost gate prices the PRE-alias ID the user typed; an
+    # unregistered ID silently quotes $0 and skips the confirmation prompt.
+    in_cost, out_cost = model_cost_per_token(GPT_5_6_SOL_PRO_MODEL)
+    assert in_cost > 0
+    assert out_cost > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,7 @@ from coarse.models import (
     CLAUDE_OPUS_5_MODEL,
     CLAUDE_SONNET_5_MODEL,
     DEFAULT_MODEL,
-    DIRECT_REQUEST_MODEL_ALIASES,
+    DIRECT_RESPONSES_MODEL_ALIASES,
     FUSION_INPUT_COST_PER_TOKEN,
     FUSION_MODEL,
     FUSION_OUTPUT_COST_PER_TOKEN,
@@ -413,14 +413,15 @@ def test_temperature_unsupported_prefixes_are_lowercase():
         assert p == p.lower(), f"unsupported-temperature prefix not lowercase: {p}"
 
 
-def test_direct_request_aliases_map_bare_variant_ids_to_canonical_targets():
-    """The direct-request alias trick in llm.py depends on two invariants:
+def test_direct_responses_aliases_map_bare_variant_ids_to_canonical_targets():
+    """The direct Responses alias in llm.py depends on three invariants:
     keys are bare (un-proxied) IDs so an openrouter/-prefixed model can never
     match, and each target is a canonical featured ID whose pricing/limits
-    are registered."""
-    for variant, (target, extra_body) in DIRECT_REQUEST_MODEL_ALIASES.items():
+    are registered, with an explicit reasoning mode."""
+    for variant, (target, request_body) in DIRECT_RESPONSES_MODEL_ALIASES.items():
         assert not variant.startswith("openrouter/"), variant
         assert not target.startswith("openrouter/"), target
         assert variant != target, variant
         assert target in WEB_FEATURED_MODEL_IDS, target
-        assert isinstance(extra_body, dict) and extra_body, variant
+        assert request_body.get("reasoning", {}).get("mode"), variant
+        assert request_body.get("store") is False, variant

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@ from coarse.models import (
     CLAUDE_OPUS_5_MODEL,
     CLAUDE_SONNET_5_MODEL,
     DEFAULT_MODEL,
+    DIRECT_REQUEST_MODEL_ALIASES,
     FUSION_INPUT_COST_PER_TOKEN,
     FUSION_MODEL,
     FUSION_OUTPUT_COST_PER_TOKEN,
@@ -410,3 +411,16 @@ def test_supports_temperature_true_for_common_models(model_id):
 def test_temperature_unsupported_prefixes_are_lowercase():
     for p in TEMPERATURE_UNSUPPORTED_PREFIXES:
         assert p == p.lower(), f"unsupported-temperature prefix not lowercase: {p}"
+
+
+def test_direct_request_aliases_map_bare_variant_ids_to_canonical_targets():
+    """The direct-request alias trick in llm.py depends on two invariants:
+    keys are bare (un-proxied) IDs so an openrouter/-prefixed model can never
+    match, and each target is a canonical featured ID whose pricing/limits
+    are registered."""
+    for variant, (target, extra_body) in DIRECT_REQUEST_MODEL_ALIASES.items():
+        assert not variant.startswith("openrouter/"), variant
+        assert not target.startswith("openrouter/"), target
+        assert variant != target, variant
+        assert target in WEB_FEATURED_MODEL_IDS, target
+        assert isinstance(extra_body, dict) and extra_body, variant


### PR DESCRIPTION
## Summary

`coarse-ink review --model openai/gpt-5.6-sol-pro paper.pdf` fails with a direct `OPENAI_API_KEY`: the `-pro` suffix is an OpenRouter-only variant ID that OpenAI's API does not recognize. OpenAI exposes Sol pro mode as model `gpt-5.6-sol` with `reasoning.mode = "pro"` on the Responses API.

This PR translates that variant only on the direct OpenAI route. The OpenRouter route remains unchanged.

## Changes

- **`models.py`**: adds `GPT_5_6_SOL_PRO_MODEL` and a `DIRECT_RESPONSES_MODEL_ALIASES` entry mapping the variant to `gpt-5.6-sol`, pro reasoning mode, and `store: false`. Registers the variant's long-context tier.
- **`llm.py`**: routes direct alias hits through LiteLLM's Responses API with Instructor's Responses tool mode. `reasoning.mode` stays `pro`; `reasoning.effort` remains independently configurable and defaults to `medium`. Responses usage fields participate in runtime cost tracking. OpenRouter-proxied aliases continue through Chat Completions untouched.
- **`model_registry.py`**: registers pricing and limits under the variant ID so the pre-flight cost gate no longer quotes $0.
- **`CHANGELOG.md`**: documents the direct Responses route and stateless storage setting.

## Testing

- `make check`: Ruff clean, security scanner clean, 1,366 passed / 1 deselected.
- Endpoint-level regression test runs the pinned LiteLLM + Instructor stack against a local HTTP server and asserts `POST /v1/responses`, wire model `gpt-5.6-sol`, `reasoning: {"mode": "pro", "effort": "high"}`, and `store: false`.
- Unit coverage verifies default and explicit effort, caller kwargs, unstructured Responses calls, OpenRouter passthrough, pricing registration, and Responses usage-based long-context costing.
