### PR TITLE
fix(release): compact packaging and GLM Flash reasoning support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Build distribution
         run: uv build
 
+      - name: Verify distribution contents and size
+        run: python scripts/check_distribution.py dist
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Recognize GLM 5.3 Flash reasoning tokens and reserve output headroom, fixing truncated structured responses observed during the preview smoke test.
+
 - Limit source distributions to package code and release metadata, retain bundled subscription skills, and reject archives above 5 MB before publishing (#293).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Limit source distributions to package code and release metadata, retain bundled subscription skills, and reject archives above 5 MB before publishing (#293).
+
 ### Fixed
 
 - **Security hardening now covers the full review boundary and blocks unreviewed vulnerable dependency locks.** Subscription-backed Claude, Codex, and Gemini stages retain the review-only subprocess isolation described below. The web submit route rejects overlong email input before its backtracking regex; Supabase `SECURITY DEFINER` helpers use an empty search path, schema-qualified relations, service-role-only execution, and bounded rate-limit inputs; and the Python security workflow exports and audits the exact all-extras `uv.lock` instead of auditing the GitHub runner environment and ignoring failures. Direct and Modal dependency floors move past the LiteLLM, Docling, lxml, Pillow, aiohttp, Soup Sieve, and urllib3 advisories, while the web lock advances Sharp to `0.35.4` and Vitest to `4.1.11`; both locks have regression coverage. A single documented waiver remains for medium-severity `CVE-2026-69112`: Accelerate has no fixed release as of 2026-09-08, and neither Coarse nor the resolved Docling packages call its affected sharded-checkpoint loaders; a regression test fails if that version or reachability assumption changes, and #292 tracks removal when upstream publishes a fix. Apply `deploy/migrate_security_definer_hardening.sql` to preview through the normal `dev` migration workflow, validate preview Vercel + Supabase + Modal, then apply it to production Supabase before the production web/worker rollout. This touches `src/coarse/`, web, deploy, and package metadata, so the package portion ships only with the next version bump and `v*` tag.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project structure,
 
 ## Version
 
-1.9.3
+1.9.4
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coarse-ink"
-version = "1.9.3"
+version = "1.9.4"
 description = "Free, open-source AI academic paper reviewer. BYOK — bring your own key."
 readme = "README.md"
 license = "MIT"
@@ -59,6 +59,9 @@ coarse-review = "coarse.cli_review:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coarse"]
+
+[tool.hatch.build.targets.sdist]
+include = ["/src/coarse", "/pyproject.toml", "/README.md", "/LICENSE", "/CHANGELOG.md"]
 
 [tool.ruff]
 target-version = "py312"

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -1,0 +1,38 @@
+"""Reject oversized distributions and accidental repository/credential payloads."""
+
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def check(directory: Path) -> None:
+    archives = list(directory.glob('*.tar.gz')) + list(directory.glob('*.whl'))
+    if len(archives) != 2:
+        raise ValueError('Expected exactly one sdist and one wheel')
+    for archive in archives:
+        if archive.stat().st_size > 5_000_000:
+            raise ValueError(f'{archive.name} exceeds the 5 MB release limit')
+        if archive.name.endswith('.tar.gz'):
+            with tarfile.open(archive) as source:
+                entries = source.getmembers()
+                if any(e.issym() or e.islnk() for e in entries):
+                    raise ValueError('Unexpected archive links')
+                names = ['/'.join(e.name.split('/')[1:]) for e in entries if e.isfile()]
+            allowed = ('src/coarse/', 'pyproject.toml', 'README.md', 'LICENSE',
+                       'CHANGELOG.md', 'PKG-INFO', '.gitignore')
+            if any(not n.startswith(allowed) for n in names):
+                raise ValueError('Unexpected source distribution payload')
+        else:
+            with zipfile.ZipFile(archive) as source:
+                names = source.namelist()
+        for host in ('claude_code', 'codex', 'gemini_cli'):
+            if not any(n.endswith(f'coarse/_skills/{host}/SKILL.md') for n in names):
+                raise ValueError(f'Missing bundled {host} skill')
+        if any('/.env' in n or '..' in Path(n).parts for n in names):
+            raise ValueError('Unsafe archive path')
+        print(f'{archive.name}: {archive.stat().st_size} bytes; contents verified')
+
+
+if __name__ == '__main__':
+    check(Path(sys.argv[1] if len(sys.argv) > 1 else 'dist'))

--- a/src/coarse/__init__.py
+++ b/src/coarse/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.9.3"
+__version__ = "1.9.4"
 
 from coarse.pipeline import extract_and_structure, review_paper  # noqa: F401

--- a/src/coarse/_skills/claude_code/SKILL.md
+++ b/src/coarse/_skills/claude_code/SKILL.md
@@ -31,7 +31,7 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -45,13 +45,13 @@ This is the **same pipeline** that powers coarse.ink — only the LLM backend is
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup`. Note the key passes through the LLM provider (Anthropic / OpenAI / Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `claude` CLI logged in.
 
 ## How to run
@@ -69,12 +69,12 @@ Use a **per-review unique log file** so parallel runs in the same shell don't cl
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns within 2 seconds with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host claude [--model claude-opus-5] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --attach "$LOG"
 ```
 
@@ -100,12 +100,12 @@ If the user came from the coarse web form, they'll paste a handoff URL instead o
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host claude [--model ...] [--effort ...]
 
 # STEP 2b — wait (same long-timeout discipline as local mode)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/codex/SKILL.md
+++ b/src/coarse/_skills/codex/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `codex exec`
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup`. Note the key passes through the LLM provider (OpenAI) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `codex` CLI logged in: `codex login`.
 
 ## How to run
@@ -61,12 +61,12 @@ Step 1 detaches the worker (~2 seconds) and writes `<log>.pid`. Step 2 uses `--a
 LOG=/tmp/coarse-review-$(basename <paper_path> .pdf).log
 
 # STEP 2a — launch (returns in ~2s)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path> --host codex [--model gpt-5.6-sol] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --attach "$LOG"
 ```
 
@@ -96,12 +96,12 @@ These map to Codex's internal reasoning effort:
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host codex
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/_skills/gemini_cli/SKILL.md
+++ b/src/coarse/_skills/gemini_cli/SKILL.md
@@ -28,7 +28,7 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
   - If `uv` exists but `uvx` does not, replace `uvx --python 3.12 --from ...` below with
     `uv tool run --python 3.12 --from ...`.
 - Refresh the bundled `coarse-review` skill with an ephemeral install:
-  `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse install-skills --all --force`
+  `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse install-skills --all --force`
   (If that fails with `No such command 'install-skills'`, you're on a
   PyPI release that predates the command — upgrade or ignore; the skill
   bundle is also loadable directly via `uvx --from` without install.)
@@ -42,13 +42,13 @@ Runs the **full coarse review pipeline** on a paper using the local `gemini -p` 
 
   > I need an OpenRouter API key for PDF OCR (~$0.10) and/or the requested deep literature search (~$0.30). A few options:
   >
-  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
+  > 1. Paste the key here and I'll save it to `~/.coarse/config.toml` via `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup`. Note the key passes through the LLM provider (Google) on its way to me, so treat it as slightly less private than one you typed into a local terminal — rotate at https://openrouter.ai/settings/keys if that worries you.
   > 2. Set it yourself in a separate terminal: `export OPENROUTER_API_KEY=sk-or-v1-...` or add it to `.env` in your current directory, then re-ask me.
-  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
+  > 3. Run `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup` in a separate terminal yourself and paste the key into its interactive prompt — the key never touches this chat.
   >
   > Which do you want?
 
-  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.2' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
+  If the user pastes a key here, save it via `uvx --python 3.12 --from 'coarse-ink==1.9.4' coarse setup` with the pasted value and confirm it's stored. Their chat, their choice.
 - `gemini` CLI signed in (first run prompts for OAuth).
 
 ## How to run
@@ -63,12 +63,12 @@ Use a **per-review unique log file** so parallel runs don't clobber each other's
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch (returns in ~2s with Review PID + Log file)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --detach --log-file "$LOG" \
   <paper_path_or_handoff_url> --host gemini [--model gemini-3.6-flash] [--effort high] [--deep-literature-search]
 
 # STEP 2b — wait (one blocking call, ~10-25 min, emits heartbeats)
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --attach "$LOG"
 ```
 
@@ -92,12 +92,12 @@ Available effort levels: `low`, `medium`, `high` (default), `max`.
 LOG=/tmp/coarse-review-$(date +%s).log
 
 # STEP 2a — launch
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --detach --log-file "$LOG" \
   --handoff https://coarse.ink/h/<token> --host gemini
 
 # STEP 2b — wait
-uvx --python 3.12 --from 'coarse-ink==1.9.2' \
+uvx --python 3.12 --from 'coarse-ink==1.9.4' \
   coarse-review --attach "$LOG"
 ```
 

--- a/src/coarse/models.py
+++ b/src/coarse/models.py
@@ -32,6 +32,7 @@ DEEPSEEK_V4_PRO_MODEL = "deepseek/deepseek-v4-pro"
 GROK_4_5_MODEL = "x-ai/grok-4.5"
 LLAMA_4_MAVERICK_MODEL = "meta-llama/llama-4-maverick"
 GLM_5_2_MODEL = "z-ai/glm-5.2"
+GLM_5_3_FLASH_MODEL = "z-ai/glm-5.3-flash"
 
 # Website replacements verified against OpenRouter on 2026-09-08.
 GPT_6_ASTRA_MODEL = "openai/gpt-6-astra"
@@ -258,6 +259,8 @@ REASONING_MODEL_PREFIXES: tuple[str, ...] = (
     "gpt-6-astra",
     GEMINI_3_8_FLASH_MODEL,
     QWEN_3_8_MAX_MODEL,
+    # GLM Flash spends hidden reasoning from max_tokens before emitting JSON.
+    GLM_5_3_FLASH_MODEL,
     # Current adaptive/default-reasoning frontier models. OpenRouter reports
     # reasoning support for Claude 5 (including Fable), Qwen 3.7 Plus, and
     # Kimi K3, and mandatory reasoning for Gemini 3.6 Flash (verified

--- a/tests/test_headless_instructions.py
+++ b/tests/test_headless_instructions.py
@@ -30,11 +30,11 @@ def test_bundled_skill_assets_use_ephemeral_uvx_flow() -> None:
         # that lands this branch on main. See CHANGELOG.md ## Unreleased
         # "RELEASE BLOCKER" note — DEFAULT_MCP_UVX_FROM and these SKILL.md
         # files must all flip from the temporary git-ref pin to
-        # ``coarse-ink==1.9.2`` as part of the release cut. The `[mcp]`
+        # ``coarse-ink==1.9.4`` as part of the release cut. The `[mcp]`
         # extra was dropped to cut the uvx install from ~114 to ~60
         # packages — the handoff flow does not need fastmcp or
         # pymupdf4llm.
-        assert "uvx --python 3.12 --from 'coarse-ink==1.9.2'" in text
+        assert "uvx --python 3.12 --from 'coarse-ink==1.9.4'" in text
         assert "coarse install-skills --all --force" in text
         # Per-review unique log file: every skill uses a LOG env var
         # derived from a per-paper suffix so parallel runs in the same

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -414,6 +414,20 @@ def test_is_reasoning_property_false_for_gpt5_chat(mock_instructor_client):
     assert client.is_reasoning is False
 
 
+def test_glm_flash_reserves_reasoning_headroom(mock_instructor_client):
+    client = _reasoning_client("z-ai/glm-5.3-flash", mock_instructor_client)
+    assert client.is_reasoning
+    with patch("coarse.llm.litellm.completion_cost", return_value=0.0):
+        client.complete(
+            messages=[{"role": "user", "content": "x"}],
+            response_model=_SimpleModel,
+            max_tokens=4096,
+        )
+    call = mock_instructor_client.chat.completions.create_with_completion.call_args
+    assert call.kwargs["max_tokens"] >= 32768
+    assert call.kwargs["reasoning_effort"] == "medium"
+
+
 def test_complete_bumps_max_tokens_for_reasoning_model(mock_instructor_client):
     """Regression for review 3ee351e6: GPT-5.4 Pro burned 15k reasoning tokens
     on the overview stage (max_tokens=8192) before emitting any output.

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "coarse-ink"
-version = "1.9.3"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/web/src/data/pipelineSpec.json
+++ b/web/src/data/pipelineSpec.json
@@ -41,6 +41,7 @@
     "gpt-6-astra",
     "google/gemini-3.8-flash",
     "qwen/qwen3.8-max-0902",
+    "z-ai/glm-5.3-flash",
     "anthropic/claude-fable-5",
     "anthropic/claude-opus-5",
     "anthropic/claude-sonnet-5",

--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -91,13 +91,13 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 // The variable is still called `DEFAULT_MCP_UVX_FROM` for backward
 // compatibility with the `test_release_blocker_pin_is_coupled_to_unreleased_version`
 // drift test that enforces the pin matches `__version__`.
-const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.9.3";
+const DEFAULT_MCP_UVX_FROM = "coarse-ink==1.9.4";
 
 export function resolvePinnedUvFrom(): string {
   const raw = (process.env.NEXT_PUBLIC_COARSE_UVX_FROM ?? "").trim();
   if (!raw) return DEFAULT_MCP_UVX_FROM;
   // Allowlist for `NEXT_PUBLIC_COARSE_UVX_FROM` overrides. Accepts:
-  //   1. Plain semver pin: `coarse-ink==1.9.3` (production default).
+  //   1. Plain semver pin: `coarse-ink==1.9.4` (production default).
   //   2. `[mcp]` extra form for operators who want the MCP path.
   //   3. Commit-sha git ref for pinned dev testing.
   //   4. `@dev` or `@main` branch ref — self-updating Preview default,


### PR DESCRIPTION
The source distribution currently includes 150 MB of evaluation output. Restrict it to package source and release metadata, keeping all bundled review skills, and validate contents and a 5 MB size ceiling before publishing.

Prepare version 1.9.4 and synchronize the browser and bundled CLI install pins so subscription reviews actually use the hardened implementation. This PR targets dev for preview validation before the main release.

The live GLM 5.3 Flash smoke test also exposed hidden reasoning consuming its visible output budget. Register that model as reasoning so structured requests reserve headroom and carry the existing medium effort default; a regression test checks the outgoing token budget.

Validation: 1,388 Python tests passed (3 skipped, 1 deselected), 15 web tests passed, web production build passed. Two independent distribution builds have identical hashes; the sdist is approximately 267 KB and the wheel 222 KB. Both wheel and sdist install and CLI help smoke checks pass. npm audit is clean; pip-audit retains the existing single Accelerate waiver tracked in #292.

Closes #293.
