### PR TITLE
fix: retry OpenRouter parser rate limits reported as HTTP 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Retry OpenRouter's specific HTTP 400 document-parser rate-limit response with bounded backoff, without retrying billed responses or ordinary invalid requests (#296). Retain sanitized provider diagnostics for OCR HTTP failures such as #296, and redact signed document URLs, inline PDF data, and API keys from extraction error logs. The existing fallback and retry policy are preserved.
+
 ## v1.9.4 — 2026-09-09
 
 ### Changed

--- a/docs/validation/issues-296-292-2026-09-10.md
+++ b/docs/validation/issues-296-292-2026-09-10.md
@@ -1,0 +1,68 @@
+# OCR rate-limit fix and Accelerate reassessment — 2026-09-10
+
+## Issue #296
+
+Reproduced against the unmodified `google/gemini-3-flash-preview` request with
+`file-parser` / `mistral-ocr`, using a three-page synthetic PDF. The same primary
+request succeeded earlier in the session, including on the original release
+smoke's `synthetic-paper.pdf` (3,272 extracted characters). This is intermittent,
+not a consistently invalid model or PDF configuration.
+
+The failing provider response was HTTP **400**, with no usage reported:
+
+> Failed to parse the file: The document parsing engine is currently rate limited. Please retry shortly.
+
+The `pdf-text` fallback then returned HTTP 200 and retained all three unique
+page markers. Its reported OpenRouter cost was $0.000397. OpenRouter's
+[PDF documentation](https://openrouter.ai/docs/guides/overview/multimodal/pdfs)
+still supports `mistral-ocr`; it documents `pdf-text` as an alias redirected to
+`cloudflare-ai`. No model or engine substitution is needed to address the
+observed failure.
+
+The patch recognizes only this specific HTTP 400 parser rate-limit message and
+uses the existing bounded exponential backoff and `COARSE_OCR_MAX_RETRIES`
+setting. Responses reporting nonzero usage are not retried. Other HTTP 400s
+still fall back immediately; exhausted parser retries preserve the fallback.
+Generic HTTP failures now retain bounded, sanitized provider details. Error
+logs redact API keys, signed document URLs and inline base64 file data before
+truncation.
+
+Validation:
+
+- Full Python suite: **1,396 passed, 3 skipped, 1 deselected**.
+- Ruff and `git diff --check` passed.
+- Regressions cover primary recovery, billed-response no-retry, retry exhaustion,
+  ordinary HTTP 400 fallback, page preservation and diagnostic redaction.
+- Temporary Modal **preview** app using the worker's exact image definition and
+  changed local source: primary `mistral-ocr` HTTP 200 / 369 characters, fallback
+  `pdf-text` HTTP 200 / 765 characters; both preserved all three page markers.
+  [Successful run](https://modal.com/apps/davidvandijcke/preview/ap-rPJHuiDPec8ov8TuRH7fSq).
+- An earlier preview run with only three retries observed four parser-rate-limit
+  HTTP 400s and then a successful fallback. The successful final run used the
+  normal nine-retry budget but succeeded on its first attempt. Thus live checks
+  establish primary success and correct retry/exhaustion behavior separately;
+  recovery within one retry loop is covered by the regression test.
+- The temporary app stopped after the smoke. The deployed review app and
+  Supabase were not modified.
+
+This is not a production deployment or an integrated Vercel/Supabase signoff.
+The normal feature -> dev -> preview signoff -> main release discipline still
+applies. Sustained upstream rate limiting can still exhaust retries.
+
+## Issue #292
+
+The latest published Accelerate release is now **1.15.0**, but it does **not**
+remove the unchecked shard-path construction:
+
+- [v1.15.0 source](https://github.com/huggingface/accelerate/blob/v1.15.0/src/accelerate/utils/modeling.py#L1937):
+  `load_checkpoint_in_model` takes `weight_map` values and joins them directly
+  to `checkpoint_folder` (lines 1941–1944), then loads those paths. There is no
+  traversal containment check before the load.
+- [GitHub advisory GHSA-4j2p-28q2-5m79](https://github.com/advisories/GHSA-4j2p-28q2-5m79)
+  still reports `first_patched_version: null`; its affected range stops at
+  `<=1.14.0`. That range alone must not be treated as proof that 1.15.0 is safe.
+
+Retained the existing 1.14.0 lock and narrowly scoped waiver. The frozen
+all-extras audit passed with exactly one ignored advisory, CVE-2026-69112, and
+the waiver/reachability regression passed. This issue remains blocked on a
+verified upstream fix. No dependency upgrade or waiver removal is claimed.

--- a/src/coarse/extraction.py
+++ b/src/coarse/extraction.py
@@ -196,7 +196,9 @@ def extract_text(pdf_path: str | Path, use_cache: bool = True) -> PaperText:
                 if summary:
                     logger.warning("%s failed with API error: %s", name, summary)
                 raise ExtractionError(api_msg) from exc
-            scrubbed = _scrub_secrets(str(exc))
+            # HTTPError.__str__ omits the provider body (including the cause
+            # of HTTP 400). Keep a bounded, scrubbed summary for diagnosis.
+            scrubbed = _describe_api_error(exc) or _scrub_secrets(str(exc))
             errors.append(f"{name}: {scrubbed}")
             logger.warning("%s failed: %s", name, scrubbed)
 

--- a/src/coarse/extraction_openrouter.py
+++ b/src/coarse/extraction_openrouter.py
@@ -37,6 +37,10 @@ signed_url_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 )
 
 _SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # Providers may echo the PDF request in validation errors. Scrub before
+    # truncation so neither signed URLs nor inline documents reach logs.
+    (re.compile(r"https?://[^\s\"'<>]*\?[^\s\"'<>]*"), "[signed URL]"),
+    (re.compile(r"data:[^\s,;]+;base64,[a-zA-Z0-9+/=_-]+"), "[inline file]"),
     (re.compile(r"Bearer\s+\S+", re.IGNORECASE), "Bearer [key]"),
     (re.compile(r"sk-or-v1-[a-zA-Z0-9]{20,}"), "[key]"),
     (re.compile(r"sk-ant-[a-zA-Z0-9_-]{20,}"), "[key]"),
@@ -80,7 +84,7 @@ def _get_ocr_max_retries() -> int:
 
 
 def _scrub_secrets(msg: str) -> str:
-    """Strip API keys and bearer tokens from an error string."""
+    """Strip API keys, bearer tokens, signed URLs, and inline files."""
     for pattern, replacement in _SECRET_PATTERNS:
         msg = pattern.sub(replacement, msg)
     return msg
@@ -275,6 +279,25 @@ def _body_retry_code(resp) -> int | None:
     return None
 
 
+def _is_parser_rate_limit(resp) -> bool:
+    """OpenRouter wraps a transient parser rate limit in HTTP 400 (#296).
+
+    Match only the observed parser error, not arbitrary invalid requests or
+    downstream model errors. They must retain the normal fallback policy.
+    """
+    if resp.status_code != 400:
+        return False
+    try:
+        body = resp.json()
+    except ValueError:
+        return False
+    error = body.get("error") if isinstance(body, dict) else None
+    message = error.get("message") if isinstance(error, dict) else None
+    return isinstance(message, str) and message.lower().startswith(
+        "failed to parse the file: the document parsing engine is currently rate limited."
+    )
+
+
 def _post_openrouter_ocr(
     *,
     url: str,
@@ -309,15 +332,24 @@ def _post_openrouter_ocr(
                     attempt + 1,
                     max_retries + 1,
                     wait,
-                    exc,
+                    _scrub_secrets(str(exc)),
                 )
                 time.sleep(wait)
                 continue
             raise ExtractionError(
-                f"OpenRouter OCR network error after {max_retries + 1} attempts: {exc}"
+                f"OpenRouter OCR network error after {max_retries + 1} attempts: "
+                f"{_scrub_secrets(str(exc))}"
             ) from exc
 
-        if resp.status_code in _OCR_RETRY_STATUSES and attempt < max_retries:
+        parser_rate_limit = _is_parser_rate_limit(resp)
+        if parser_rate_limit and _response_was_billed(resp):
+            logger.warning(
+                "OpenRouter OCR parser rate limit has non-zero usage — "
+                "not retrying to avoid double-billing the user"
+            )
+            return resp
+
+        if (resp.status_code in _OCR_RETRY_STATUSES or parser_rate_limit) and attempt < max_retries:
             wait = _wait_for(attempt)
             logger.warning(
                 "OpenRouter OCR returned %d (attempt %d/%d), retrying in %.1fs",
@@ -374,15 +406,19 @@ def _parse_openrouter_ocr_response(resp: "requests.Response") -> str:  # noqa: F
     if "error" in data and not data.get("choices"):
         err = data["error"]
         msg = err.get("message") if isinstance(err, dict) else None
-        logger.warning("OpenRouter OCR returned error body: %s", str(err)[:_OCR_LOG_TRUNCATE])
-        raise ExtractionError(f"OpenRouter OCR error: {msg or err}")
+        logger.warning(
+            "OpenRouter OCR returned error body: %s", _scrub_secrets(str(err))[:_OCR_LOG_TRUNCATE]
+        )
+        raise ExtractionError(
+            f"OpenRouter OCR error: {_scrub_secrets(str(msg or err))[:_OCR_LOG_TRUNCATE]}"
+        )
 
     choices = data.get("choices")
     if not choices:
         logger.warning(
             "OpenRouter OCR unexpected response (no choices): keys=%s body=%s",
             sorted(data.keys()),
-            str(data)[:_OCR_LOG_TRUNCATE],
+            _scrub_secrets(str(data))[:_OCR_LOG_TRUNCATE],
         )
         raise ExtractionError(
             f"OpenRouter OCR returned no choices (response keys: {sorted(data.keys())})"

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1269,3 +1269,90 @@ def test_extraction_error_message_is_scrubbed(tmp_path: Path, caplog) -> None:
     assert "sk-or-v1-abcdef" not in log_text
     assert secret_bearer not in log_text
     assert "[key]" in log_text
+
+
+def test_ocr_400_logs_safe_provider_detail_and_preserves_fallback(minimal_pdf, caplog):
+    secret = "sk-or-v1-" + "s" * 40
+    signed_url = "https://example.test/paper.pdf?token=private-download-token"
+    inline_file = "data:application/pdf;base64,cHJpdmF0ZS1wYXBlcg=="
+    failed = _mock_error_response(
+        400,
+        {
+            "error": {
+                "message": "Mistral document validation failed",
+                "metadata": {"raw": f"Bearer {secret} {signed_url} {inline_file}"},
+            }
+        },
+    )
+    success = _mock_ocr_response(["# First page\nText.", "# Last page\nEnd."])
+    with (
+        patch("requests.post", side_effect=[failed, success]) as post,
+        patch.dict(os.environ, {"OPENROUTER_API_KEY": secret}),
+        caplog.at_level(logging.WARNING),
+    ):
+        result = extract_text(minimal_pdf, use_cache=False)
+    assert "First page" in result.full_markdown and "Last page" in result.full_markdown
+    assert post.call_count == 2  # An ordinary 400 falls back without retrying the same engine.
+    engines = [c.kwargs["json"]["plugins"][0]["pdf"]["engine"] for c in post.call_args_list]
+    assert engines == ["mistral-ocr", "pdf-text"]
+    assert "status=400" in caplog.text
+    assert "Mistral document validation failed" in caplog.text
+    for private in (secret, "private-download-token", "cHJpdmF0ZS1wYXBlcg=="):
+        assert private not in caplog.text
+
+
+@pytest.mark.parametrize("billed", [False, True])
+def test_ocr_parser_rate_limit_retries_only_unbilled_response(minimal_pdf, monkeypatch, billed):
+    monkeypatch.setenv("COARSE_OCR_MAX_RETRIES", "1")
+    failed = _mock_error_response(
+        400,
+        {
+            "error": {
+                "message": (
+                    "Failed to parse the file: The document parsing engine is currently "
+                    "rate limited. Please retry shortly."
+                )
+            },
+            "usage": {"cost": 0.01 if billed else 0},
+        },
+    )
+    success = _mock_ocr_response(["# First page\nText.", "# Last page\nEnd."])
+    with (
+        patch("requests.post", side_effect=[failed, success]) as post,
+        patch("time.sleep") as sleep,
+        patch.dict(os.environ, {"OPENROUTER_API_KEY": "fake-key"}),
+    ):
+        result = extract_text(minimal_pdf, use_cache=False)
+    assert "Last page" in result.full_markdown
+    engines = [c.kwargs["json"]["plugins"][0]["pdf"]["engine"] for c in post.call_args_list]
+    assert engines == ["mistral-ocr", "pdf-text" if billed else "mistral-ocr"]
+    if billed:
+        sleep.assert_not_called()
+    else:
+        sleep.assert_called_once_with(1.0)
+
+
+def test_ocr_parser_rate_limit_exhaustion_preserves_fallback(minimal_pdf, monkeypatch):
+    monkeypatch.setenv("COARSE_OCR_MAX_RETRIES", "1")
+    failed = _mock_error_response(
+        400,
+        {
+            "error": {
+                "message": (
+                    "Failed to parse the file: The document parsing engine is currently "
+                    "rate limited. Please retry shortly."
+                )
+            }
+        },
+    )
+    success = _mock_ocr_response(["# Recovered paper\nLast page."])
+    with (
+        patch("requests.post", side_effect=[failed, failed, success]) as post,
+        patch("time.sleep") as sleep,
+        patch.dict(os.environ, {"OPENROUTER_API_KEY": "fake-key"}),
+    ):
+        result = extract_text(minimal_pdf, use_cache=False)
+    assert "Last page" in result.full_markdown
+    engines = [c.kwargs["json"]["plugins"][0]["pdf"]["engine"] for c in post.call_args_list]
+    assert engines == ["mistral-ocr", "mistral-ocr", "pdf-text"]
+    sleep.assert_called_once_with(1.0)

--- a/tests/test_extraction_openrouter.py
+++ b/tests/test_extraction_openrouter.py
@@ -297,3 +297,30 @@ def test_extract_openrouter_file_parser_clears_signed_url_after_reset(
 
     file_data = post.call_args.kwargs["payload"]["messages"][0]["content"][1]["file"]["file_data"]
     assert file_data.startswith("data:application/pdf;base64,")
+
+
+@pytest.mark.parametrize("body_kind", ["error", "no_choices", "http_error"])
+def test_provider_diagnostics_scrub_before_truncating(body_kind, caplog):
+    from coarse.extraction_openrouter import _describe_api_error, _parse_openrouter_ocr_response
+
+    secret = "sk-or-v1-" + "x" * 40
+    private = "https://example.test/paper.pdf?token=private-token"
+    # Inline files can dwarf the useful diagnostic; redact before applying the limit.
+    echoed = "data:application/pdf;base64," + "a" * 1000
+    message = f"Invalid document {private} {echoed} {secret} diagnostic-tail"
+    response = MagicMock()
+    response.status_code = 400 if body_kind == "http_error" else 200
+    response.json.return_value = (
+        {"unexpected": message} if body_kind == "no_choices" else {"error": {"message": message}}
+    )
+    if body_kind == "http_error":
+        import requests
+
+        output = _describe_api_error(requests.HTTPError(response=response))
+    else:
+        with pytest.raises(ExtractionError) as exc:
+            _parse_openrouter_ocr_response(response)
+        output = str(exc.value) + caplog.text
+    assert "diagnostic-tail" in output
+    for value in (secret, "private-token", "a" * 100):
+        assert value not in output


### PR DESCRIPTION
OpenRouter intermittently returns HTTP 400 with “The document parsing engine is currently rate limited,” causing primary Mistral OCR to skip transient-error retries. Recognize only that parser response and apply the existing bounded backoff, avoiding retries when usage indicates billing. Preserve ordinary-400 and exhausted-retry fallbacks, and retain sanitized provider diagnostics without exposing keys, signed URLs or inline files. Fixes #296.

Validation: 1,396 Python tests passed; Ruff, static security scan and diff checks passed. An ephemeral Modal preview app using the worker image and changed source returned HTTP 200 from both OCR engines and retained all three synthetic page markers. A separate preview run verified bounded rate-limit retries and successful fallback after exhaustion. Full integrated dev/Vercel/Supabase signoff and production deployment have not occurred.

Also reassessed #292: Accelerate 1.15.0 is available, but its source still joins unchecked shard paths and GitHub lists no patched version. Retained the 1.14.0 lock and waiver; the frozen all-extras audit passed with that one ignored advisory. #292 remains open. Details and preview run evidence are in `docs/validation/issues-296-292-2026-09-10.md`.
