### PR TITLE
Release subscription review model selection fix

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -18,7 +18,7 @@ import {
   HOST_LABELS,
   HOST_GLYPHS,
   HOST_CLI_NAME,
-  HOST_DEFAULT_MODELS,
+  getHostModels,
   HOST_INSTALL_URL,
   HOST_LAUNCH_LABEL,
   HOST_LAUNCH_HINT,
@@ -887,7 +887,7 @@ function PageBody() {
       const bundle = await mintCliHandoff(id, host, handoffSecret);
 
       // Step 3: defaults for the modal dropdowns.
-      setSelectedModel(HOST_DEFAULT_MODELS[host][0]);
+      setSelectedModel(getHostModels(host, model)[0]);
       setSelectedEffort("high");
 
       setHandoffBundle(bundle);
@@ -1852,7 +1852,7 @@ function PageBody() {
                           onChange={(e) => setSelectedModel(e.target.value)}
                           style={{ marginLeft: "0.25rem", padding: "0.25rem 0.5rem", background: "var(--board)", color: "var(--chalk)", border: "1px solid var(--tray)", borderRadius: "2px", fontFamily: "monospace", fontSize: "0.92rem" }}
                         >
-                          {HOST_DEFAULT_MODELS[host].map((m) => (<option key={m} value={m}>{m}</option>))}
+                          {getHostModels(host, model).map((m) => (<option key={m} value={m}>{m}</option>))}
                         </select>
                       </label>
                       <label style={{ fontFamily: "var(--font-chalk)", fontSize: "0.95rem", color: "var(--dust)" }}>

--- a/web/src/lib/mcpHandoff.ts
+++ b/web/src/lib/mcpHandoff.ts
@@ -65,15 +65,31 @@ export const HOST_CLI_NAME: Record<ChatHost, "claude" | "codex" | "gemini"> = {
 // pre-selected default (see page.tsx setSelectedModel). Latest generation
 // leads; the prior generation stays available as a fallback option.
 export const HOST_DEFAULT_MODELS: Record<ChatHost, string[]> = {
-  "claude-code": ["claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5"],
-  "codex": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4"],
+  "claude-code": ["claude-fable-5-1", "claude-fable-5", "claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5"],
+  "codex": ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4"],
   "gemini-cli": [
+    "gemini-3.8-flash",
+    "gemini-3.7-flash",
     "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
     "gemini-3.1-pro-preview",
     "gemini-3-flash-preview",
     "gemini-3.1-flash-lite-preview",
   ],
 };
+
+// Carry matching catalog selections into the native CLI, including models
+// released after this suggested list. Never send another provider's model.
+export function getHostModels(host: ChatHost, selectedModel: string): string[] {
+  const prefix = { "claude-code": "anthropic/", codex: "openai/", "gemini-cli": "google/" }[host];
+  if (!selectedModel.startsWith(prefix)) return HOST_DEFAULT_MODELS[host];
+  let nativeModel = selectedModel.slice(prefix.length).replace(/:[^:]+$/, "");
+  // Anthropic CLI version separators differ from the OpenRouter catalog.
+  if (host === "claude-code") nativeModel = nativeModel.replace(/(\d)\.(?=\d)/g, "$1-");
+  if (!nativeModel) return HOST_DEFAULT_MODELS[host];
+  return Array.from(new Set([nativeModel, ...HOST_DEFAULT_MODELS[host]]));
+}
 
 export const EFFORT_LEVELS = ["low", "medium", "high", "max"] as const;
 export type EffortLevel = (typeof EFFORT_LEVELS)[number];

--- a/web/tests/mcpHandoff.test.ts
+++ b/web/tests/mcpHandoff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildAgentPrompt, buildCliCommands } from "@/lib/mcpHandoff";
+import { buildAgentPrompt, buildCliCommands, getHostModels, type ChatHost } from "@/lib/mcpHandoff";
 
 const baseCommands = {
   setupCmd: "uvx --from coarse-ink coarse install-skills --all --force",
@@ -56,4 +56,30 @@ describe("deep-literature subscription handoff", () => {
     expect(prompt).toContain("triggered vision QA");
     expect(prompt).not.toContain("No OpenRouter API key is needed for this review");
   });
+});
+
+
+describe("subscription model selection", () => {
+  it.each([
+    ["claude-code", "anthropic/claude-fable-5.1", "claude-fable-5-1"],
+    ["codex", "openai/gpt-6-astra", "gpt-6-astra"],
+    ["gemini-cli", "google/gemini-3.8-flash", "gemini-3.8-flash"],
+    ["gemini-cli", "google/gemini-99-flash:free", "gemini-99-flash"],
+  ] as const)("carries %s selection into the native command", (host, selected, expected) => {
+    const models = getHostModels(host, selected);
+    expect(models[0]).toBe(expected);
+    expect(new Set(models).size).toBe(models.length);
+    const { runCmd } = buildCliCommands({
+      handoffUrl: "https://example.test/h/token", host, model: models[0],
+      effort: "high", paperId: "00000000-0000-4000-8000-000000000000",
+    });
+    expect(runCmd).toContain(expected);
+    expect(runCmd).not.toContain(selected);
+  });
+
+  it.each(["claude-code", "codex", "gemini-cli"] as ChatHost[])(
+    "does not carry a different provider into %s", (host) => {
+      expect(getHostModels(host, "other/model")).toEqual(getHostModels(host, ""));
+    },
+  );
 });


### PR DESCRIPTION
Preserve the main-form model selection in subscription reviews, normalize native CLI IDs, and refresh Fable, GPT, and Gemini choices. Web-only release. All 22 web tests, TypeScript, CI, and feature preview checks passed; verify latest dev preview before merging.